### PR TITLE
Feature ajson cli

### DIFF
--- a/.test.sh
+++ b/.test.sh
@@ -21,9 +21,9 @@ if [ $print_coverage -eq 1 ]; then
     coverage report
     # is only run if tests pass
     covered=$(coverage report | grep TOTAL | awk '{print $4}' | sed 's/%//')
-    if [ $covered -lt 75 ]; then
+    if [ $covered -lt 78 ]; then
         echo
-        echo "FAILED this project requires at least 75% coverage, got $covered"
+        echo "FAILED this project requires at least 78% coverage, got $covered"
         echo
         exit 1
     fi

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -191,6 +191,9 @@ LOGGING = {
             '()': jsonlogger.JsonFormatter,
             'format': FORMAT_STR,
         },
+        'brief': {
+            'format': '%(levelname)s - %(message)s'
+        },
     },
     
     'handlers': {
@@ -209,6 +212,7 @@ LOGGING = {
         'debug-console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
+            'formatter': 'brief',
         },
     },
     

--- a/src/publisher/ajson_ingestor.py
+++ b/src/publisher/ajson_ingestor.py
@@ -168,12 +168,16 @@ def publish(msid, version, datetime_published=None, force=False):
     else:
         # ensure given datetime is in utc
         datetime_published = utils.todt(datetime_published)
-    av = models.ArticleVersion.objects.get(article__manuscript_id=msid, version=version)
-    if av.published() and not force:
-        raise StateError("refusing to publish an already published article")
-    av.datetime_published = datetime_published
-    av.save()
-    return av
+    try:
+        av = models.ArticleVersion.objects.get(article__manuscript_id=msid, version=version)
+        if av.published() and not force:
+            raise StateError("refusing to publish an already published article")
+        av.datetime_published = datetime_published
+        av.save()
+        return av
+    except models.ArticleVersion.DoesNotExist:
+        # attempted to publish an article that doesn't exist ...
+        raise StateError("refusing to publish an article '%sv%s' that doesn't exist" % (msid, version))
 
 #
 # INGEST+PUBLISH requests

--- a/src/publisher/ajson_ingestor.py
+++ b/src/publisher/ajson_ingestor.py
@@ -5,6 +5,7 @@ import logging
 from django.db import transaction
 from et3 import render
 from et3.extract import path as p, val
+from django.db import IntegrityError
 
 LOG = logging.getLogger(__name__)
 
@@ -32,6 +33,26 @@ ARTICLE_VERSION = {
     'article_json_v1_raw': [val],
 }
 
+def atomic(fn):
+    def wrapper(*args, **kwargs):
+        result, rollback_key = None, 'dry run rollback'
+        # NOTE: dry_run must always be passed as keyword parameter (dry_run=True)
+        dry_run = kwargs.pop('dry_run', False)
+        try:
+            with transaction.atomic():
+                result = fn(*args, **kwargs)
+                if dry_run:
+                    # `transaction.rollback()` doesn't work here because the `transaction.atomic()`
+                    # block is expecting to do all the work and only rollback on exceptions
+                    raise IntegrityError(rollback_key)
+                return result
+        except IntegrityError as err:
+            if dry_run and err.message == rollback_key:
+                return result
+            # this was some other IntegrityError
+            raise
+    return wrapper
+    
 #
 #
 #
@@ -61,19 +82,16 @@ def create_or_update(Model, orig_data, key_list, create=True, update=True, commi
     # in this case if the model cannot be found then None is returned: (None, False, False)
     return (inst, created, updated)
 
-@transaction.atomic
-def ingest(data, force=False):
+def _ingest(data, force=False):
     """ingests article-json. returns a triple of (journal obj, article obj, article version obj)
-
     unpublished article-version data can be ingested multiple times UNLESS that article version has been published.
-
     published article-version data can be ingested only if force=True"""
 
     data = copy.deepcopy(data) # we don't want to modify the given data
     
     create = update = True
     log_context = {}
-    
+
     try:
         journal_struct = render.render_item(JOURNAL, data['journal'])
         journal, created, updated = \
@@ -89,12 +107,11 @@ def ingest(data, force=False):
         assert isinstance(article, models.Article)
         log_context['article'] = article
 
-
         previous_article_versions = None
         if updated:
             previous_article_versions = list(article.articleversion_set.all().order_by('version')) # earliest -> latest
 
-        # this is an INGEST event, not a PUBLISH event. we don't touch the date published. see `publish()`
+        # this is an INGEST event and *not* a PUBLISH event. we don't touch the date published.
         av_ingest_description = exsubdict(ARTICLE_VERSION, ['datetime_published'])
         av_struct = render.render_item(av_ingest_description, data['article'])
         av, created, update = \
@@ -103,6 +120,8 @@ def ingest(data, force=False):
 
         assert isinstance(av, models.ArticleVersion)
         log_context['article-version'] = av
+
+        # enforce business rules
         
         if created:
             if previous_article_versions:
@@ -123,20 +142,22 @@ def ingest(data, force=False):
                         'expected-version': last_version.version +1})
                     LOG.error(msg, extra=log_context)
                     raise StateError(msg)
+
+            # no other versions of article exist
             else:
                 if not av.version == 1:
                     # uhoh. we're attempting to create our first article version and it isn't a version 1
-                    msg = "refusing to ingest new article version our of sequence. no other article versions exist, I'm expecting a v1"
+                    msg = "refusing to ingest new article version out of sequence. no other article versions exist so I expect a v1"
                     log_context.update({
                         'given-version': av.version,
                         'expected-version': 1})
                     LOG.error(msg, extra=log_context)
                     raise StateError(msg)
-        
+
         elif updated:
             # this version of the article already exists
             # this is only a problem if the article version has already been published
-            if av.datetime_published:
+            if av.published():
                 # uhoh. we've received an INGEST event for a previously published article version
                 if not force:
                     # unless our arm is being twisted, die.
@@ -146,6 +167,7 @@ def ingest(data, force=False):
 
         # passed all checks, save
         av.save()
+
         return journal, article, av
 
     except StateError:
@@ -155,11 +177,16 @@ def ingest(data, force=False):
         LOG.exception("unhandled exception attempting to ingest article-json", extra=log_context)
         raise
 
+@atomic
+def ingest(*args, **kwargs):
+    return _ingest(*args, **kwargs)
+    
+
 #
 # PUBLISH requests
 #
 
-def publish(msid, version, datetime_published=None, force=False):
+def _publish(msid, version, datetime_published=None, force=False):
     """attach a `datetime_published` value to an article version. if none provided, use RIGHT NOW.
     you cannot publish an already published article version unless force==True"""
     # ensure we have a utc datetime
@@ -179,15 +206,19 @@ def publish(msid, version, datetime_published=None, force=False):
         # attempted to publish an article that doesn't exist ...
         raise StateError("refusing to publish an article '%sv%s' that doesn't exist" % (msid, version))
 
+@atomic
+def publish(*args, **kwargs):
+    return _publish(*args, **kwargs)
+    
 #
 # INGEST+PUBLISH requests
 #
 
-@transaction.atomic
-def ingest_publish(data, force=False):
+@atomic
+def ingest_publish(data, force=False, dry_run=False):
     "convenience. publish an article if it were successfully ingested"
-    j, a, av = ingest(data, force)
-    return j, a, publish(a.manuscript_id, av.version, force=force)
+    j, a, av = _ingest(data, force=force)
+    return j, a, _publish(a.manuscript_id, av.version, force=force)
 
 #
 # article json wrangling

--- a/src/publisher/ajson_ingestor.py
+++ b/src/publisher/ajson_ingestor.py
@@ -147,6 +147,9 @@ def ingest(data, force=False):
         # passed all checks, save
         av.save()
         return journal, article, av
+
+    except StateError:
+        raise
     
     except Exception:
         LOG.exception("unhandled exception attempting to ingest article-json", extra=log_context)

--- a/src/publisher/management/commands/ingest.py
+++ b/src/publisher/management/commands/ingest.py
@@ -58,7 +58,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         force = options['force']
-        dry_run = options['dry_run']
         action = options['action']
         data = options['infile']
 
@@ -79,7 +78,7 @@ class Command(BaseCommand):
         }
 
         try:
-            jaav = choices[action](data, dry_run, force)
+            jaav = choices[action](data, force)
             self.success(action, jaav)
 
         except StateError as err:

--- a/src/publisher/management/commands/ingest.py
+++ b/src/publisher/management/commands/ingest.py
@@ -108,7 +108,7 @@ class Command(ModCommand):
             sys.exit(1)
         
         try:
-            if action == INGEST:
+            if action in [INGEST, BOTH]:
                 data = json.load(options['infile'])
                 # vagary of the CLI interface: article id and version are required
                 # these may not match the data given

--- a/src/publisher/management/commands/ingest.py
+++ b/src/publisher/management/commands/ingest.py
@@ -10,13 +10,15 @@ The ingest script DOES obey business rules and will not publish things twice,
 import sys, json, argparse
 from django.core.management.base import BaseCommand
 from publisher import ajson_ingestor
+from publisher.ajson_ingestor import StateError
 import logging
 
 LOG = logging.getLogger(__name__)
 
+INVALID = 'invalid'
 IMPORT_TYPES = ['ingest', 'publish', 'ingest-publish']
 INGEST, PUBLISH, BOTH = IMPORT_TYPES
-
+INGESTED, PUBLISHED = 'ingested', 'published'
 
 class Command(BaseCommand):
     help = ''    
@@ -33,24 +35,43 @@ class Command(BaseCommand):
         # version
         # msid
 
-    def prn(self, *bits):
-        self.stderr.write(''.join(map(str, bits)))
-        self.stderr.write("\n")
-        self.stderr.flush()
-        
+    def write(self, out=None):
+        if not isinstance(out, basestring):
+            out = json.dumps(out)
+        self.stdout.write(out)
+        self.stdout.flush()
+
+    def error(self, errtype, message):
+        return self.write({
+            'status': errtype,
+            'message': message
+        })
+
+    def success(self, action, jaav):
+        status = INGESTED if action == INGEST else PUBLISHED
+        j, a, av = jaav
+        return self.write({
+            'status': status,
+            'id': a.manuscript_id,
+            'datetime': av.datetime_published
+        })
+
     def handle(self, *args, **options):
         force = options['force']
+        dry_run = options['dry_run']
         action = options['action']
         data = options['infile']
-        data = json.load(data)
-        
+
         if not action:
-            self.prn("no action specified!")
-            exit(1)
-        
-        #self.prn('force?',force)
-        #self.prn('data?',data)
-        
+            self.error(INVALID, "no action specified. I need either a 'ingest', 'publish' or 'ingest+publish' action")
+            sys.exit(1)
+
+        try:
+            data = json.load(data)
+        except ValueError as err:
+            self.error(INVALID, "could decode the json you gave me: %s" % err.message)
+            sys.exit(1)
+
         choices = {
             INGEST: ajson_ingestor.ingest,
             PUBLISH: ajson_ingestor.publish,
@@ -58,7 +79,12 @@ class Command(BaseCommand):
         }
 
         try:
-            choices[action](data, force)
-        except ajson_ingestor.StateError as err:
-            print err.message
-            exit(1)
+            jaav = choices[action](data, dry_run, force)
+            self.success(action, jaav)
+
+        except StateError as err:
+            msg = "failed to call action %r: %s" % (action, err.message)
+            self.error(INVALID, msg)
+            sys.exit(1)
+
+        sys.exit(0)

--- a/src/publisher/models.py
+++ b/src/publisher/models.py
@@ -199,10 +199,10 @@ class ArticleVersion(models.Model):
         return self.article.dxdoi_url()
 
     def __unicode__(self):
-        return '%s v%s' % (self.article.doi, self.version)
+        return '%s v%s' % (self.article.manuscript_id, self.version)
     
     def __repr__(self):
-        return u'<Article %s>' % self
+        return u'<ArticleVersion %s>' % self
 
 #
 # as of 2016.04.06, ArticleAttributes are not being used.

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -310,7 +310,18 @@ class IngestPublishCLI(BaseCase):
         self.assertTrue(utils.has_all_keys(result, ['status', 'id', 'datetime']))
         self.assertEqual(result['status'], 'published')
 
-        
-
     def test_ingest_publish_from_cli(self):
-        pass
+        args = [self.nom, '--ingest+publish', '--id', self.msid, '--version', self.version, self.ajson_fixture1]
+        errcode, stdout = self.call_command(*args)
+        self.assertEqual(errcode, 0)
+        # article has been ingested
+        av = models.ArticleVersion.objects.get(article__manuscript_id=self.msid, version=self.version)
+        # article has been published
+        self.assertTrue(av.published())
+        # ensure response is json and well-formed
+        result = json.loads(stdout.getvalue())
+        self.assertTrue(utils.has_all_keys(result, ['status', 'id', 'datetime']))
+        # ensure response data is correct
+        self.assertEqual(result['status'], 'published')
+        self.assertEqual(result['datetime'], av.datetime_published.isoformat())
+

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -1,4 +1,4 @@
-import copy
+import copy, json
 import pytz
 from dateutil import parser
 from django.utils import timezone
@@ -155,3 +155,12 @@ def updatedict(ddict, **kwargs):
     for key, val in kwargs.items():
         newdata[key] = val
     return newdata
+
+def json_dumps(obj):
+    "drop-in for json.dumps that handles datetime objects."
+    def datetime_handler(obj):
+        if hasattr(obj, 'isoformat'):
+            return obj.isoformat()
+        else:
+            raise TypeError, 'Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj))
+    return json.dumps(obj, default=datetime_handler)


### PR DESCRIPTION
This improves the handling of the article-json `ingest` command line interface. It now: 

* returns json on stdout that is similar to the response schema in `bot-lax-adaptor`
* has tests
* has caught a few new cases in the article-json ingestion
* demonstrates how to test management commands (tricksy)