### PR TITLE
Adding newrelic module to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ requests==2.9.1
 unittest-xml-reporting==2.1.0
 python-json-logger==0.1.5
 pyflakes==1.3.0
+newrelic==2.70.0.51


### PR DESCRIPTION
This module needs to be used inside the virtualenv to run a wrapper around the WSGI command, in order to instrument the application and gather data.

We could in theory install it when the virtualenv is created and only in selected EC2 instances, but the presence of the code doesn't seem invasive (this will not be run in dev, for example.)