### PR TITLE
Bugfix dateformat

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e # everything must succeed.
+
+. download-api-raml.sh
+
 if [ ! -d venv ]; then
     virtualenv --python=`which python2` venv
 fi
@@ -10,5 +13,3 @@ if [ ! -e app.cfg ]; then
 fi
 pip install -r requirements.txt
 python src/manage.py migrate --no-input
-
-. download-api-raml.sh

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -91,10 +91,9 @@ def todt(val):
     if val is None:
         return None
 
-    if not isinstance(val, datetime):
+    dt = val
+    if not isinstance(dt, datetime):
         dt = parser.parse(val, fuzzy=False)
-    else:
-        dt = val # don't attempt to parse, work with what we have
 
     if not dt.tzinfo:
         # no timezone (naive), assume UTC and make it explicit
@@ -104,7 +103,7 @@ def todt(val):
     else:
         # ensure tz is UTC
         if dt.tzinfo != pytz.utc:
-            LOG.debug("got an aware dt that isn't in utc: %r", dt)
+            LOG.debug("converting an aware dt that isn't in utc TO utc: %r", dt)
             return dt.astimezone(pytz.utc)
     return dt
 


### PR DESCRIPTION
the v1 pubdate has no time component or timezone component but during scraping in the bot-lax-adaptor it *is* given a time component but no timezone. 

when an article is INGESTED into lax, a datetime isn't set. when an article is PUBLISHED and it is a v1, the published value from the json is used, which lacks the timezone. the statusdate and versiondates however are not pulled from the xml and are managed by lax, so they do have timezones.

this fix replaces the version pubdate from lax when merging article fragments and storing the result. it also has the sideeffect of correctly enforcing the rule of: 'published' is null if article hasn't been published yet (which fails validation, PR on api-raml is still open).

