### PR TITLE
fix for api v1 serving unpublished content. 

### DIFF
--- a/src/publisher/api_v1_urls.py
+++ b/src/publisher/api_v1_urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 import api_v1_views as views
 
 urlpatterns = [
-    url(r'corpus/info/$', views.corpus_info, name='api-corpus-info'),
+    #url(r'corpus/info/$', views.corpus_info, name='api-corpus-info'),
 
     url(r'article/create/$', views.create_article, name='api-create-article'),
     url(r'article/update/$', views.update_article, name='api-update-article'),

--- a/src/publisher/api_v1_views.py
+++ b/src/publisher/api_v1_views.py
@@ -20,18 +20,19 @@ def article_or_404(doi, version=None):
 # API, collections of articles
 #
 
+'''
 @api_view(['GET'])
 def corpus_info(rest_request):
     articles = models.Article.objects.all()
     return Response({'article-count': articles.count(),
                      'research-article-count': articles.filter(type='research-article').count()})
+'''
 
 #
 # API, specific articles
 #
 
 class ArticleSerializer(szr.ModelSerializer):
-
     class Meta:
         exclude = ('id', 'journal')
         model = models.Article
@@ -57,10 +58,7 @@ def get_article(rest_request, doi, version=None):
 
 @api_view(['GET'])
 def get_article_versions(rest_request, doi):
-    """
-    Returns all versions of the requested article, grouped by version number.
-
-    """
+    "Returns all versions of the requested article, grouped by version number."
     article_list = logic.article_versions(doi)
     if not article_list:
         raise Http404()

--- a/src/publisher/logic.py
+++ b/src/publisher/logic.py
@@ -29,14 +29,14 @@ def article(doi, version=None):
     try:
         article = models.Article.objects.get(doi__iexact=doi)
         if version:
-            return article, article.articleversion_set.get(version=version)
-        return article, article.articleversion_set.latest('version')
+            return article, article.articleversion_set.exclude(datetime_published=None).get(version=version)
+        return article, article.articleversion_set.exclude(datetime_published=None).latest('version')
     except ObjectDoesNotExist:
         raise models.Article.DoesNotExist()
 
 def article_versions(doi):
     "returns all versions of the given article"
-    return models.ArticleVersion.objects.filter(article__doi__iexact=doi)
+    return models.ArticleVersion.objects.filter(article__doi__iexact=doi).exclude(datetime_published=None)
 
 
 # TODO: move this into `tests/`

--- a/src/publisher/tests/fixtures/ajson/dummyelife-20105-v1.xml.json
+++ b/src/publisher/tests/fixtures/ajson/dummyelife-20105-v1.xml.json
@@ -1,1 +1,354 @@
-{"snippet": {"status": "poa", "doi": "10.7554/eLife.20105", "versionDate": "2016-10-04T00:00:00", "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", "authorLine": "Neel H Shah et al", "elocationId": "e20105", "volume": 5, "version": 1, "published": "2016-10-04T00:00:00", "pdf": "elife-20105-v1.pdf", "subjects": [{"id": "biophysics-structural-biology", "name": "Biophysics and Structural Biology"}, {"id": "immunology", "name": "Immunology"}], "researchOrganisms": ["E. coli"], "type": "research-article", "id": "20105"}, "article": {"status": "poa", "doi": "10.7554/eLife.20105", "versionDate": "2016-10-04T00:00:00", "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", "copyright": {"holder": "Shah et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", "authorLine": "Neel H Shah et al", "authors": [{"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Shah, Neel H", "preferred": "Neel H Shah"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["D. E. Shaw Research"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "type": "person", "name": {"index": "Wang, Qi", "preferred": "Qi Wang"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Janssen Pharmaceutical Companies of Johnson and Johnson"], "address": {"formatted": ["Malvern", "United States"], "components": {"country": "United States", "locality": ["Malvern"]}}}], "type": "person", "name": {"index": "Yan, Qingrong", "preferred": "Qingrong Yan"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Karandur, Deepti", "preferred": "Deepti Karandur"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", "Howard Hughes Medical Institute, University of California, San Francisco"], "address": {"formatted": ["San Francisco", "United States"], "components": {"country": "United States", "locality": ["San Francisco"]}}}], "type": "person", "name": {"index": "Kadlacek, Theresa A", "preferred": "Theresa A Kadlacek"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Fallahee, Ian R", "preferred": "Ian R Fallahee"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Green Center for Systems Biology", "University of Texas Southwestern Medical Center"], "address": {"formatted": ["Dallas", "United States"], "components": {"country": "United States", "locality": ["Dallas"]}}}], "type": "person", "name": {"index": "Russ, William P", "preferred": "William P Russ"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Green Center for Systems Biology", "University of Texas Southwestern Medical Center"], "address": {"formatted": ["Dallas", "United States"], "components": {"country": "United States", "locality": ["Dallas"]}}}], "type": "person", "name": {"index": "Ranganathan, Rama", "preferred": "Rama Ranganathan"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"orcid": "0000-0002-2414-9024", "affiliations": [{"name": ["Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", "Howard Hughes Medical Institute, University of California, San Francisco"], "address": {"formatted": ["San Francisco", "United States"], "components": {"country": "United States", "locality": ["San Francisco"]}}}], "type": "person", "name": {"index": "Weiss, Arthur", "preferred": "Arthur Weiss"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"name": {"index": "Kuriyan, John", "preferred": "John Kuriyan"}, "competingInterests": "John Kuriyan, Senior editor, eLife.", "affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "orcid": "0000-0002-4414-5477", "emailAddresses": ["jkuriyan@mac.com"], "type": "person"}], "elocationId": "e20105", "volume": 5, "version": 1, "published": "2016-10-04T00:00:00", "statusDate": "2016-01-01T00:00:00Z", "pdf": "elife-20105-v1.pdf", "subjects": [{"id": "biophysics-structural-biology", "name": "Biophysics and Structural Biology"}, {"id": "immunology", "name": "Immunology"}], "researchOrganisms": ["E. coli"], "type": "research-article", "id": "20105"}, "journal": {"issn": "2050-084X", "id": "eLife", "title": "eLife"}}
+{
+    "snippet": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20105", 
+        "versionDate": "2016-10-04T00:00:00", 
+        "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", 
+        "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", 
+        "authorLine": "Neel H Shah et al", 
+        "elocationId": "e20105", 
+        "volume": 5, 
+        "version": 1, 
+        "published": "2016-10-04T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20105/pdf/elife-20105.pdf", 
+        "subjects": [
+            {
+                "id": "biophysics-structural-biology", 
+                "name": "Biophysics and Structural Biology"
+            }, 
+            {
+                "id": "immunology", 
+                "name": "Immunology"
+            }
+        ], 
+        "researchOrganisms": [
+            "E. coli"
+        ], 
+        "type": "research-article", 
+        "id": "20105"
+    }, 
+    "article": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20105", 
+        "versionDate": "2016-10-04T00:00:00", 
+        "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", 
+        "copyright": {
+            "holder": "Shah et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", 
+        "authorLine": "Neel H Shah et al", 
+        "authors": [
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Shah, Neel H", 
+                    "preferred": "Neel H Shah"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "D. E. Shaw Research"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Wang, Qi", 
+                    "preferred": "Qi Wang"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Janssen Pharmaceutical Companies of Johnson and Johnson"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Malvern", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Malvern"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Yan, Qingrong", 
+                    "preferred": "Qingrong Yan"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Karandur, Deepti", 
+                    "preferred": "Deepti Karandur"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", 
+                            "Howard Hughes Medical Institute, University of California, San Francisco"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "San Francisco", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "San Francisco"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Kadlacek, Theresa A", 
+                    "preferred": "Theresa A Kadlacek"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Fallahee, Ian R", 
+                    "preferred": "Ian R Fallahee"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Green Center for Systems Biology", 
+                            "University of Texas Southwestern Medical Center"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Dallas", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Dallas"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Russ, William P", 
+                    "preferred": "William P Russ"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Green Center for Systems Biology", 
+                            "University of Texas Southwestern Medical Center"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Dallas", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Dallas"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Ranganathan, Rama", 
+                    "preferred": "Rama Ranganathan"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "orcid": "0000-0002-2414-9024", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", 
+                            "Howard Hughes Medical Institute, University of California, San Francisco"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "San Francisco", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "San Francisco"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Weiss, Arthur", 
+                    "preferred": "Arthur Weiss"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "name": {
+                    "index": "Kuriyan, John", 
+                    "preferred": "John Kuriyan"
+                }, 
+                "competingInterests": "John Kuriyan, Senior editor, eLife.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "orcid": "0000-0002-4414-5477", 
+                "emailAddresses": [
+                    "jkuriyan@mac.com"
+                ], 
+                "type": "person"
+            }
+        ], 
+        "elocationId": "e20105", 
+        "volume": 5, 
+        "version": 1, 
+        "published": "2016-10-04T00:00:00", 
+        "statusDate": "2016-01-01T00:00:00Z", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20105/pdf/elife-20105.pdf", 
+        "subjects": [
+            {
+                "id": "biophysics-structural-biology", 
+                "name": "Biophysics and Structural Biology"
+            }, 
+            {
+                "id": "immunology", 
+                "name": "Immunology"
+            }
+        ], 
+        "researchOrganisms": [
+            "E. coli"
+        ], 
+        "type": "research-article", 
+        "id": "20105"
+    }, 
+    "journal": {
+        "issn": "2050-084X", 
+        "id": "eLife", 
+        "title": "eLife"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/dummyelife-20105-v2.xml.json
+++ b/src/publisher/tests/fixtures/ajson/dummyelife-20105-v2.xml.json
@@ -1,1 +1,353 @@
-{"snippet": {"status": "poa", "doi": "10.7554/eLife.20105", "elocationId": "e20105", "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", "authorLine": "Neel H Shah et al", "volume": 5, "version": 2, "published": "2016-10-04T00:00:00", "pdf": "elife-20105-v2.pdf", "subjects": [{"id": "biophysics-structural-biology", "name": "Biophysics and Structural Biology"}, {"id": "immunology", "name": "Immunology"}], "researchOrganisms": ["E. coli"], "type": "research-article", "id": "20105"}, "article": {"status": "poa", "versionDate": "2016-01-01T00:00:00Z", "doi": "10.7554/eLife.20105", "elocationId": "e20105", "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", "copyright": {"holder": "Shah et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", "authorLine": "Neel H Shah et al", "authors": [{"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Shah, Neel H", "preferred": "Neel H Shah"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["D. E. Shaw Research"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "type": "person", "name": {"index": "Wang, Qi", "preferred": "Qi Wang"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Janssen Pharmaceutical Companies of Johnson and Johnson"], "address": {"formatted": ["Malvern", "United States"], "components": {"country": "United States", "locality": ["Malvern"]}}}], "type": "person", "name": {"index": "Yan, Qingrong", "preferred": "Qingrong Yan"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Karandur, Deepti", "preferred": "Deepti Karandur"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", "Howard Hughes Medical Institute, University of California, San Francisco"], "address": {"formatted": ["San Francisco", "United States"], "components": {"country": "United States", "locality": ["San Francisco"]}}}], "type": "person", "name": {"index": "Kadlecek, Theresa A", "preferred": "Theresa A Kadlecek"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Fallahee, Ian R", "preferred": "Ian R Fallahee"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Green Center for Systems Biology", "University of Texas Southwestern Medical Center"], "address": {"formatted": ["Dallas", "United States"], "components": {"country": "United States", "locality": ["Dallas"]}}}], "type": "person", "name": {"index": "Russ, William P", "preferred": "William P Russ"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Green Center for Systems Biology", "University of Texas Southwestern Medical Center"], "address": {"formatted": ["Dallas", "United States"], "components": {"country": "United States", "locality": ["Dallas"]}}}], "type": "person", "name": {"index": "Ranganathan, Rama", "preferred": "Rama Ranganathan"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"orcid": "0000-0002-2414-9024", "affiliations": [{"name": ["Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", "Howard Hughes Medical Institute, University of California, San Francisco"], "address": {"formatted": ["San Francisco", "United States"], "components": {"country": "United States", "locality": ["San Francisco"]}}}], "type": "person", "name": {"index": "Weiss, Arthur", "preferred": "Arthur Weiss"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"name": {"index": "Kuriyan, John", "preferred": "John Kuriyan"}, "competingInterests": "John Kuriyan, Senior editor, eLife.", "affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "orcid": "0000-0002-4414-5477", "emailAddresses": ["jkuriyan@mac.com"], "type": "person"}], "volume": 5, "version": 2, "published": "2016-10-04T00:00:00", "statusDate": "2016-01-01T00:00:00Z", "pdf": "elife-20105-v2.pdf", "subjects": [{"id": "biophysics-structural-biology", "name": "Biophysics and Structural Biology"}, {"id": "immunology", "name": "Immunology"}], "researchOrganisms": ["E. coli"], "type": "research-article", "id": "20105"}, "journal": {"issn": "2050-084X", "id": "eLife", "title": "eLife"}}
+{
+    "snippet": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20105", 
+        "elocationId": "e20105", 
+        "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", 
+        "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", 
+        "authorLine": "Neel H Shah et al", 
+        "volume": 5, 
+        "version": 2, 
+        "published": "2016-10-04T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20105/pdf/elife-20105.pdf", 
+        "subjects": [
+            {
+                "id": "biophysics-structural-biology", 
+                "name": "Biophysics and Structural Biology"
+            }, 
+            {
+                "id": "immunology", 
+                "name": "Immunology"
+            }
+        ], 
+        "researchOrganisms": [
+            "E. coli"
+        ], 
+        "type": "research-article", 
+        "id": "20105"
+    }, 
+    "article": {
+        "status": "poa", 
+        "versionDate": "2016-01-01T00:00:00Z", 
+        "doi": "10.7554/eLife.20105", 
+        "elocationId": "e20105", 
+        "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", 
+        "copyright": {
+            "holder": "Shah et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", 
+        "authorLine": "Neel H Shah et al", 
+        "authors": [
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Shah, Neel H", 
+                    "preferred": "Neel H Shah"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "D. E. Shaw Research"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Wang, Qi", 
+                    "preferred": "Qi Wang"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Janssen Pharmaceutical Companies of Johnson and Johnson"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Malvern", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Malvern"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Yan, Qingrong", 
+                    "preferred": "Qingrong Yan"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Karandur, Deepti", 
+                    "preferred": "Deepti Karandur"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", 
+                            "Howard Hughes Medical Institute, University of California, San Francisco"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "San Francisco", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "San Francisco"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Kadlecek, Theresa A", 
+                    "preferred": "Theresa A Kadlecek"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Fallahee, Ian R", 
+                    "preferred": "Ian R Fallahee"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Green Center for Systems Biology", 
+                            "University of Texas Southwestern Medical Center"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Dallas", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Dallas"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Russ, William P", 
+                    "preferred": "William P Russ"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Green Center for Systems Biology", 
+                            "University of Texas Southwestern Medical Center"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Dallas", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Dallas"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Ranganathan, Rama", 
+                    "preferred": "Rama Ranganathan"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "orcid": "0000-0002-2414-9024", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", 
+                            "Howard Hughes Medical Institute, University of California, San Francisco"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "San Francisco", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "San Francisco"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Weiss, Arthur", 
+                    "preferred": "Arthur Weiss"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "name": {
+                    "index": "Kuriyan, John", 
+                    "preferred": "John Kuriyan"
+                }, 
+                "competingInterests": "John Kuriyan, Senior editor, eLife.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "orcid": "0000-0002-4414-5477", 
+                "emailAddresses": [
+                    "jkuriyan@mac.com"
+                ], 
+                "type": "person"
+            }
+        ], 
+        "volume": 5, 
+        "version": 2, 
+        "published": "2016-10-04T00:00:00", 
+        "statusDate": "2016-01-01T00:00:00Z", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20105/pdf/elife-20105.pdf", 
+        "subjects": [
+            {
+                "id": "biophysics-structural-biology", 
+                "name": "Biophysics and Structural Biology"
+            }, 
+            {
+                "id": "immunology", 
+                "name": "Immunology"
+            }
+        ], 
+        "researchOrganisms": [
+            "E. coli"
+        ], 
+        "type": "research-article", 
+        "id": "20105"
+    }, 
+    "journal": {
+        "issn": "2050-084X", 
+        "id": "eLife", 
+        "title": "eLife"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/dummyelife-20105-v3.xml.json
+++ b/src/publisher/tests/fixtures/ajson/dummyelife-20105-v3.xml.json
@@ -1,1 +1,355 @@
-{"snippet": {"status": "poa", "doi": "10.7554/eLife.20105", "elocationId": "e20105", "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", "authorLine": "Neel H Shah et al", "volume": 5, "version": 3, "published": "2016-10-04T00:00:00", "pdf": "elife-20105-v3.pdf", "subjects": [{"id": "biophysics-structural-biology", "name": "Biophysics and Structural Biology"}, {"id": "immunology", "name": "Immunology"}], "researchOrganisms": ["E. coli"], "type": "research-article", "id": "20105"}, "article": {"status": "poa", "versionDate": "2016-01-01T00:00:00Z", "doi": "10.7554/eLife.20105", "elocationId": "e20105", "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", "copyright": {"holder": "Shah et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", "authorLine": "Neel H Shah et al", "authors": [{"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Shah, Neel H", "preferred": "Neel H Shah"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Wang, Qi", "preferred": "Qi Wang"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Yan, Qingrong", "preferred": "Qingrong Yan"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Karandur, Deepti", "preferred": "Deepti Karandur"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", "Howard Hughes Medical Institute, University of California, San Francisco"], "address": {"formatted": ["San Francisco", "United States"], "components": {"country": "United States", "locality": ["San Francisco"]}}}], "type": "person", "name": {"index": "Kadlecek, Theresa A", "preferred": "Theresa A Kadlecek"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "type": "person", "name": {"index": "Fallahee, Ian R", "preferred": "Ian R Fallahee"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Green Center for Systems Biology", "University of Texas Southwestern Medical Center"], "address": {"formatted": ["Dallas", "United States"], "components": {"country": "United States", "locality": ["Dallas"]}}}], "type": "person", "name": {"index": "Russ, William P", "preferred": "William P Russ"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Green Center for Systems Biology", "University of Texas Southwestern Medical Center"], "address": {"formatted": ["Dallas", "United States"], "components": {"country": "United States", "locality": ["Dallas"]}}}], "type": "person", "name": {"index": "Ranganathan, Rama", "preferred": "Rama Ranganathan"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"orcid": "0000-0002-2414-9024", "affiliations": [{"name": ["Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", "Howard Hughes Medical Institute, University of California, San Francisco"], "address": {"formatted": ["San Francisco", "United States"], "components": {"country": "United States", "locality": ["San Francisco"]}}}], "type": "person", "name": {"index": "Weiss, Arthur", "preferred": "Arthur Weiss"}, "competingInterests": "The other authors declare that no competing interests exist."}, {"name": {"index": "Kuriyan, John", "preferred": "John Kuriyan"}, "competingInterests": "John Kuriyan, Senior editor, eLife.", "affiliations": [{"name": ["Department of Molecular and Cell Biology", "Howard Hughes Medical Institute, University of California, Berkeley"], "address": {"formatted": ["Berkeley", "United States"], "components": {"country": "United States", "locality": ["Berkeley"]}}}], "orcid": "0000-0002-4414-5477", "emailAddresses": ["jkuriyan@mac.com"], "type": "person"}], "volume": 5, "version": 3, "published": "2016-10-04T00:00:00", "statusDate": "2016-01-01T00:00:00Z", "pdf": "elife-20105-v3.pdf", "subjects": [{"id": "biophysics-structural-biology", "name": "Biophysics and Structural Biology"}, {"id": "immunology", "name": "Immunology"}], "researchOrganisms": ["E. coli"], "type": "research-article", "id": "20105"}, "journal": {"issn": "2050-084X", "id": "eLife", "title": "eLife"}}
+{
+    "snippet": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20105", 
+        "elocationId": "e20105", 
+        "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", 
+        "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", 
+        "authorLine": "Neel H Shah et al", 
+        "volume": 5, 
+        "version": 3, 
+        "published": "2016-10-04T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20105/pdf/elife-20105.pdf", 
+        "subjects": [
+            {
+                "id": "biophysics-structural-biology", 
+                "name": "Biophysics and Structural Biology"
+            }, 
+            {
+                "id": "immunology", 
+                "name": "Immunology"
+            }
+        ], 
+        "researchOrganisms": [
+            "E. coli"
+        ], 
+        "type": "research-article", 
+        "id": "20105"
+    }, 
+    "article": {
+        "status": "poa", 
+        "versionDate": "2016-01-01T00:00:00Z", 
+        "doi": "10.7554/eLife.20105", 
+        "elocationId": "e20105", 
+        "impactStatement": "The sequence of events that initiates T cell signaling is dictated by the specificities and order of activation of the tyrosine kinases that signal downstream of the T cell receptor. Using a platform that combines exhaustive point-mutagenesis of peptide substrates, bacterial surface-display, cell sorting, and deep sequencing, we have defined the specificities of the first two kinases in this pathway, Lck and ZAP-70, for the T cell receptor \u03b6 chain and the scaffold proteins LAT and SLP-76. We find that ZAP-70 selects its substrates by utilizing an electrostatic mechanism that excludes substrates with positively-charged residues and favors LAT and SLP-76 phosphosites that are surrounded by negatively-charged residues. This mechanism prevents ZAP-70 from phosphorylating its own activation loop, thereby enforcing its strict dependence on Lck for activation. The sequence features in ZAP-70, LAT, and SLP-76 that underlie electrostatic selectivity likely contribute to the specific response of T cells to foreign antigens.", 
+        "copyright": {
+            "holder": "Shah et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "An electrostatic selection mechanism controls sequential kinase signaling downstream of the T cell receptor", 
+        "authorLine": "Neel H Shah et al", 
+        "authors": [
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Shah, Neel H", 
+                    "preferred": "Neel H Shah"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Wang, Qi", 
+                    "preferred": "Qi Wang"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Yan, Qingrong", 
+                    "preferred": "Qingrong Yan"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Karandur, Deepti", 
+                    "preferred": "Deepti Karandur"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", 
+                            "Howard Hughes Medical Institute, University of California, San Francisco"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "San Francisco", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "San Francisco"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Kadlecek, Theresa A", 
+                    "preferred": "Theresa A Kadlecek"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Fallahee, Ian R", 
+                    "preferred": "Ian R Fallahee"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Green Center for Systems Biology", 
+                            "University of Texas Southwestern Medical Center"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Dallas", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Dallas"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Russ, William P", 
+                    "preferred": "William P Russ"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Green Center for Systems Biology", 
+                            "University of Texas Southwestern Medical Center"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Dallas", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Dallas"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Ranganathan, Rama", 
+                    "preferred": "Rama Ranganathan"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "orcid": "0000-0002-2414-9024", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Rosalind Russell/Ephraim P. Engleman Rheumatology Research Center, Department of Medicine", 
+                            "Howard Hughes Medical Institute, University of California, San Francisco"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "San Francisco", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "San Francisco"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Weiss, Arthur", 
+                    "preferred": "Arthur Weiss"
+                }, 
+                "competingInterests": "The other authors declare that no competing interests exist."
+            }, 
+            {
+                "name": {
+                    "index": "Kuriyan, John", 
+                    "preferred": "John Kuriyan"
+                }, 
+                "competingInterests": "John Kuriyan, Senior editor, eLife.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Molecular and Cell Biology", 
+                            "Howard Hughes Medical Institute, University of California, Berkeley"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Berkeley", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "Berkeley"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "orcid": "0000-0002-4414-5477", 
+                "emailAddresses": [
+                    "jkuriyan@mac.com"
+                ], 
+                "type": "person"
+            }
+        ], 
+        "volume": 5, 
+        "version": 3, 
+        "published": "2016-10-04T00:00:00", 
+        "statusDate": "2016-01-01T00:00:00Z", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20105/pdf/elife-20105.pdf", 
+        "subjects": [
+            {
+                "id": "biophysics-structural-biology", 
+                "name": "Biophysics and Structural Biology"
+            }, 
+            {
+                "id": "immunology", 
+                "name": "Immunology"
+            }
+        ], 
+        "researchOrganisms": [
+            "E. coli"
+        ], 
+        "type": "research-article", 
+        "id": "20105"
+    }, 
+    "journal": {
+        "issn": "2050-084X", 
+        "id": "eLife", 
+        "title": "eLife"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/dummyelife-20125-v1.xml.json
+++ b/src/publisher/tests/fixtures/ajson/dummyelife-20125-v1.xml.json
@@ -1,1 +1,746 @@
-{"snippet": {"status": "poa", "doi": "10.7554/eLife.20125", "versionDate": "2016-09-08T00:00:00", "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <italic>de novo</italic> or rare transmitted mutations in <italic>SMAD6</italic>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <italic>SMAD6</italic> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <italic>BMP2</italic> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", "authorLine": "Andrew T Timberlake et al", "elocationId": "e20125", "volume": 5, "version": 1, "published": "2016-09-08T00:00:00", "pdf": "elife-20125-v1.pdf", "subjects": [{"id": "genes-chromosomes", "name": "Genes and Chromosomes"}, {"id": "genomics-evolutionary-biology", "name": "Genomics and Evolutionary Biology"}], "researchOrganisms": ["Human"], "type": "research-article", "id": "20125"}, "article": {"status": "poa", "doi": "10.7554/eLife.20125", "versionDate": "2016-09-08T00:00:00", "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <italic>de novo</italic> or rare transmitted mutations in <italic>SMAD6</italic>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <italic>SMAD6</italic> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <italic>BMP2</italic> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", "copyright": {"holder": "Timberlake et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", "authorLine": "Andrew T Timberlake et al", "authors": [{"orcid": "0000-0002-8926-9692", "affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Timberlake, Andrew T", "preferred": "Andrew T Timberlake"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Choi, Jungmin", "preferred": "Jungmin Choi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Zaidi, Samir", "preferred": "Samir Zaidi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Lu, Qiongshi", "preferred": "Qiongshi Lu"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Nelson-Williams, Carol", "preferred": "Carol Nelson-Williams"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Brooks, Eric D", "preferred": "Eric D Brooks"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Bilguvar, Kaya", "preferred": "Kaya Bilguvar"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Yale Center for Genome Analysis", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Tikhonova, Irina", "preferred": "Irina Tikhonova"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Mane, Shrikant", "preferred": "Shrikant Mane"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Yang, Jenny F", "preferred": "Jenny F Yang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Sawh-Martinez, Rajendra", "preferred": "Rajendra Sawh-Martinez"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Persing, Sarah", "preferred": "Sarah Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Zellner, Elizabeth G", "preferred": "Elizabeth G Zellner"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Loring, Erin", "preferred": "Erin Loring"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Chuang, Carolyn", "preferred": "Carolyn Chuang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Craniosynostosis and Positional Plagiocephaly Support"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "type": "person", "name": {"index": "Galm, Amy", "preferred": "Amy Galm"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Hashim, Peter W", "preferred": "Peter W Hashim"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Steinbacher, Derek M", "preferred": "Derek M Steinbacher"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "DiLuna, Michael L", "preferred": "Michael L DiLuna"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Duncan, Charles C", "preferred": "Charles C Duncan"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Child Study Center", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Pelphrey, Kevin A", "preferred": "Kevin A Pelphrey"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Zhao, Hongyu", "preferred": "Hongyu Zhao"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Persing, John A", "preferred": "John A Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "emailAddresses": ["richard.lifton@yale.edu"], "type": "person", "name": {"index": "Lifton, Richard P", "preferred": "Richard P Lifton"}, "competingInterests": "The authors declare that no competing interests exist."}], "elocationId": "e20125", "volume": 5, "version": 1, "published": "2016-09-08T00:00:00", "statusDate": "2016-01-01T00:00:00Z", "pdf": "elife-20125-v1.pdf", "subjects": [{"id": "genes-chromosomes", "name": "Genes and Chromosomes"}, {"id": "genomics-evolutionary-biology", "name": "Genomics and Evolutionary Biology"}], "researchOrganisms": ["Human"], "type": "research-article", "id": "20125"}, "journal": {"issn": "2050-084X", "id": "eLife", "title": "eLife"}}
+{
+    "snippet": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20125", 
+        "versionDate": "2016-09-08T00:00:00", 
+        "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <i>de novo</i> or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", 
+        "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", 
+        "authorLine": "Andrew T Timberlake et al", 
+        "elocationId": "e20125", 
+        "volume": 5, 
+        "version": 1, 
+        "published": "2016-09-08T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20125/pdf/elife-20125.pdf", 
+        "subjects": [
+            {
+                "id": "genes-chromosomes", 
+                "name": "Genes and Chromosomes"
+            }, 
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "researchOrganisms": [
+            "Human"
+        ], 
+        "type": "research-article", 
+        "id": "20125"
+    }, 
+    "article": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20125", 
+        "versionDate": "2016-09-08T00:00:00", 
+        "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <i>de novo</i> or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", 
+        "copyright": {
+            "holder": "Timberlake et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", 
+        "authorLine": "Andrew T Timberlake et al", 
+        "authors": [
+            {
+                "orcid": "0000-0002-8926-9692", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Timberlake, Andrew T", 
+                    "preferred": "Andrew T Timberlake"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Choi, Jungmin", 
+                    "preferred": "Jungmin Choi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Zaidi, Samir", 
+                    "preferred": "Samir Zaidi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Lu, Qiongshi", 
+                    "preferred": "Qiongshi Lu"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Nelson-Williams, Carol", 
+                    "preferred": "Carol Nelson-Williams"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Brooks, Eric D", 
+                    "preferred": "Eric D Brooks"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Bilguvar, Kaya", 
+                    "preferred": "Kaya Bilguvar"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Tikhonova, Irina", 
+                    "preferred": "Irina Tikhonova"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Mane, Shrikant", 
+                    "preferred": "Shrikant Mane"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Yang, Jenny F", 
+                    "preferred": "Jenny F Yang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Sawh-Martinez, Rajendra", 
+                    "preferred": "Rajendra Sawh-Martinez"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, Sarah", 
+                    "preferred": "Sarah Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Zellner, Elizabeth G", 
+                    "preferred": "Elizabeth G Zellner"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Loring, Erin", 
+                    "preferred": "Erin Loring"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Chuang, Carolyn", 
+                    "preferred": "Carolyn Chuang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Craniosynostosis and Positional Plagiocephaly Support"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Galm, Amy", 
+                    "preferred": "Amy Galm"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Hashim, Peter W", 
+                    "preferred": "Peter W Hashim"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Steinbacher, Derek M", 
+                    "preferred": "Derek M Steinbacher"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "DiLuna, Michael L", 
+                    "preferred": "Michael L DiLuna"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Duncan, Charles C", 
+                    "preferred": "Charles C Duncan"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Child Study Center", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Pelphrey, Kevin A", 
+                    "preferred": "Kevin A Pelphrey"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Zhao, Hongyu", 
+                    "preferred": "Hongyu Zhao"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, John A", 
+                    "preferred": "John A Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "richard.lifton@yale.edu"
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Lifton, Richard P", 
+                    "preferred": "Richard P Lifton"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }
+        ], 
+        "elocationId": "e20125", 
+        "volume": 5, 
+        "version": 1, 
+        "published": "2016-09-08T00:00:00", 
+        "statusDate": "2016-01-01T00:00:00Z", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20125/pdf/elife-20125.pdf", 
+        "subjects": [
+            {
+                "id": "genes-chromosomes", 
+                "name": "Genes and Chromosomes"
+            }, 
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "researchOrganisms": [
+            "Human"
+        ], 
+        "type": "research-article", 
+        "id": "20125"
+    }, 
+    "journal": {
+        "issn": "2050-084X", 
+        "id": "eLife", 
+        "title": "eLife"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/dummyelife-20125-v2.xml.json
+++ b/src/publisher/tests/fixtures/ajson/dummyelife-20125-v2.xml.json
@@ -1,1 +1,745 @@
-{"snippet": {"status": "poa", "doi": "10.7554/eLife.20125", "elocationId": "e20125", "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <italic>de novo</italic> or rare transmitted mutations in <italic>SMAD6</italic>, an inhibitor of BMP - induced osteoblast differentiation (P < 10-20). <italic>SMAD6</italic> mutations nonetheless showed striking incomplete penetrance (<60%). Genotypes of a common variant near <italic>BMP2</italic> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", "authorLine": "Andrew T Timberlake et al", "volume": 5, "version": 2, "published": "2016-09-08T00:00:00", "pdf": "elife-20125-v2.pdf", "subjects": [{"id": "genes-chromosomes", "name": "Genes and Chromosomes"}, {"id": "genomics-evolutionary-biology", "name": "Genomics and Evolutionary Biology"}], "researchOrganisms": ["Human"], "type": "research-article", "id": "20125"}, "article": {"status": "poa", "versionDate": "2016-01-01T00:00:00Z", "doi": "10.7554/eLife.20125", "elocationId": "e20125", "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <italic>de novo</italic> or rare transmitted mutations in <italic>SMAD6</italic>, an inhibitor of BMP - induced osteoblast differentiation (P < 10-20). <italic>SMAD6</italic> mutations nonetheless showed striking incomplete penetrance (<60%). Genotypes of a common variant near <italic>BMP2</italic> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", "copyright": {"holder": "Timberlake et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", "authorLine": "Andrew T Timberlake et al", "authors": [{"orcid": "0000-0002-8926-9692", "affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Timberlake, Andrew T", "preferred": "Andrew T Timberlake"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Choi, Jungmin", "preferred": "Jungmin Choi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Zaidi, Samir", "preferred": "Samir Zaidi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Lu, Qiongshi", "preferred": "Qiongshi Lu"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Nelson-Williams, Carol", "preferred": "Carol Nelson-Williams"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Brooks, Eric D", "preferred": "Eric D Brooks"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Bilguvar, Kaya", "preferred": "Kaya Bilguvar"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Yale Center for Genome Analysis", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Tikhonova, Irina", "preferred": "Irina Tikhonova"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Mane, Shrikant", "preferred": "Shrikant Mane"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Yang, Jenny F", "preferred": "Jenny F Yang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Sawh-Martinez, Rajendra", "preferred": "Rajendra Sawh-Martinez"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Persing, Sarah", "preferred": "Sarah Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Zellner, Elizabeth G", "preferred": "Elizabeth G Zellner"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Loring, Erin", "preferred": "Erin Loring"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Chuang, Carolyn", "preferred": "Carolyn Chuang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Craniosynostosis and Positional Plagiocephaly Support"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "type": "person", "name": {"index": "Galm, Amy", "preferred": "Amy Galm"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Hashim, Peter W", "preferred": "Peter W Hashim"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Steinbacher, Derek M", "preferred": "Derek M Steinbacher"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "DiLuna, Michael L", "preferred": "Michael L DiLuna"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Duncan, Charles C", "preferred": "Charles C Duncan"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Child Study Center", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Pelphrey, Kevin A", "preferred": "Kevin A Pelphrey"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Zhao, Hongyu", "preferred": "Hongyu Zhao"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "type": "person", "name": {"index": "Persing, John A", "preferred": "John A Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "emailAddresses": ["richard.lifton@yale.edu"], "type": "person", "name": {"index": "Lifton, Richard P", "preferred": "Richard P Lifton"}, "competingInterests": "The authors declare that no competing interests exist."}], "volume": 5, "version": 2, "published": "2016-09-08T00:00:00", "statusDate": "2016-01-01T00:00:00Z", "pdf": "elife-20125-v2.pdf", "subjects": [{"id": "genes-chromosomes", "name": "Genes and Chromosomes"}, {"id": "genomics-evolutionary-biology", "name": "Genomics and Evolutionary Biology"}], "researchOrganisms": ["Human"], "type": "research-article", "id": "20125"}, "journal": {"issn": "2050-084X", "id": "eLife", "title": "eLife"}}
+{
+    "snippet": {
+        "status": "poa", 
+        "doi": "10.7554/eLife.20125", 
+        "elocationId": "e20125", 
+        "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <i>de novo</i> or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", 
+        "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", 
+        "authorLine": "Andrew T Timberlake et al", 
+        "volume": 5, 
+        "version": 2, 
+        "published": "2016-09-08T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20125/pdf/elife-20125.pdf", 
+        "subjects": [
+            {
+                "id": "genes-chromosomes", 
+                "name": "Genes and Chromosomes"
+            }, 
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "researchOrganisms": [
+            "Human"
+        ], 
+        "type": "research-article", 
+        "id": "20125"
+    }, 
+    "article": {
+        "status": "poa", 
+        "versionDate": "2016-01-01T00:00:00Z", 
+        "doi": "10.7554/eLife.20125", 
+        "elocationId": "e20125", 
+        "impactStatement": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <i>de novo</i> or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", 
+        "copyright": {
+            "holder": "Timberlake et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", 
+        "authorLine": "Andrew T Timberlake et al", 
+        "authors": [
+            {
+                "orcid": "0000-0002-8926-9692", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Timberlake, Andrew T", 
+                    "preferred": "Andrew T Timberlake"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Choi, Jungmin", 
+                    "preferred": "Jungmin Choi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Zaidi, Samir", 
+                    "preferred": "Samir Zaidi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Lu, Qiongshi", 
+                    "preferred": "Qiongshi Lu"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Nelson-Williams, Carol", 
+                    "preferred": "Carol Nelson-Williams"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Brooks, Eric D", 
+                    "preferred": "Eric D Brooks"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Bilguvar, Kaya", 
+                    "preferred": "Kaya Bilguvar"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Tikhonova, Irina", 
+                    "preferred": "Irina Tikhonova"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Mane, Shrikant", 
+                    "preferred": "Shrikant Mane"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Yang, Jenny F", 
+                    "preferred": "Jenny F Yang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Sawh-Martinez, Rajendra", 
+                    "preferred": "Rajendra Sawh-Martinez"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, Sarah", 
+                    "preferred": "Sarah Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Zellner, Elizabeth G", 
+                    "preferred": "Elizabeth G Zellner"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Loring, Erin", 
+                    "preferred": "Erin Loring"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Chuang, Carolyn", 
+                    "preferred": "Carolyn Chuang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Craniosynostosis and Positional Plagiocephaly Support"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Galm, Amy", 
+                    "preferred": "Amy Galm"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Hashim, Peter W", 
+                    "preferred": "Peter W Hashim"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Steinbacher, Derek M", 
+                    "preferred": "Derek M Steinbacher"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "DiLuna, Michael L", 
+                    "preferred": "Michael L DiLuna"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Duncan, Charles C", 
+                    "preferred": "Charles C Duncan"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Child Study Center", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Pelphrey, Kevin A", 
+                    "preferred": "Kevin A Pelphrey"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Zhao, Hongyu", 
+                    "preferred": "Hongyu Zhao"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, John A", 
+                    "preferred": "John A Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "richard.lifton@yale.edu"
+                ], 
+                "type": "person", 
+                "name": {
+                    "index": "Lifton, Richard P", 
+                    "preferred": "Richard P Lifton"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }
+        ], 
+        "volume": 5, 
+        "version": 2, 
+        "published": "2016-09-08T00:00:00", 
+        "statusDate": "2016-01-01T00:00:00Z", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20125/pdf/elife-20125.pdf", 
+        "subjects": [
+            {
+                "id": "genes-chromosomes", 
+                "name": "Genes and Chromosomes"
+            }, 
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "researchOrganisms": [
+            "Human"
+        ], 
+        "type": "research-article", 
+        "id": "20125"
+    }, 
+    "journal": {
+        "issn": "2050-084X", 
+        "id": "eLife", 
+        "title": "eLife"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/dummyelife-20125-v3.xml.json
+++ b/src/publisher/tests/fixtures/ajson/dummyelife-20125-v3.xml.json
@@ -1,1 +1,9691 @@
-{"snippet": {"status": "vor", "doi": "10.7554/eLife.20125", "elocationId": "e20125", "impactStatement": "Epistatic interactions of rare loss of function mutations in <italic>SMAD6</italic> and a common variant modifier near <italic>BMP2</italic> are the most common cause of midline craniosynostosis in humans.", "copyright": {"holder": "Timberlake et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", "authorLine": "Andrew T Timberlake et al", "abstract": {"content": [{"text": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging de novo or rare transmitted mutations in <italic>SMAD6</italic>, an inhibitor of BMP \u2013 induced osteoblast differentiation (p<10<sup>\u221220</sup>). <italic>SMAD6</italic> mutations nonetheless showed striking incomplete penetrance (<60%). Genotypes of a common variant near <italic>BMP2</italic> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" href=\"10.7554/eLife.20125.001\">http://dx.doi.org/10.7554/eLife.20125.001</ext-link>", "type": "paragraph"}], "doi": "10.7554/eLife.20125.001"}, "authors": [{"name": {"index": "Timberlake, Andrew T", "preferred": "Andrew T Timberlake"}, "competingInterests": "The authors declare that no competing interests exist.", "affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "orcid": "0000-0002-8926-9692", "contribution": "ATT, Recruited and enrolled patients, collected genetic specimens, performed SNP genotyping and Sanger sequencing, performed genetic analyses, wrote the manuscript", "type": "person"}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "JC, Performed genetic analyses", "type": "person", "name": {"index": "Choi, Jungmin", "preferred": "Jungmin Choi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "SZ, Performed genetic analyses", "type": "person", "name": {"index": "Zaidi, Samir", "preferred": "Samir Zaidi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "QL, Performed genetic analyses", "type": "person", "name": {"index": "Lu, Qiongshi", "preferred": "Qiongshi Lu"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "CN-W, Performed SNP genotyping and Sanger sequencing, performed genetic analyses", "type": "person", "name": {"index": "Nelson-Williams, Carol", "preferred": "Carol Nelson-Williams"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "EDB, Recruited and enrolled patients, collected genetic specimens", "type": "person", "name": {"index": "Brooks, Eric D", "preferred": "Eric D Brooks"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "KB, Directed exome sequence production", "type": "person", "name": {"index": "Bilguvar, Kaya", "preferred": "Kaya Bilguvar"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "IT, Directed exome sequence production", "type": "person", "name": {"index": "Tikhonova, Irina", "preferred": "Irina Tikhonova"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "SM, Directed exome sequence production", "type": "person", "name": {"index": "Mane, Shrikant", "preferred": "Shrikant Mane"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "JFY, Recruited and enrolled patients, collected genetic specimens", "type": "person", "name": {"index": "Yang, Jenny F", "preferred": "Jenny F Yang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "RS-M, Contributed clinical evaluations", "type": "person", "name": {"index": "Sawh-Martinez, Rajendra", "preferred": "Rajendra Sawh-Martinez"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "SP, Contributed clinical evaluations", "type": "person", "name": {"index": "Persing, Sarah", "preferred": "Sarah Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "EGZ, Contributed clinical evaluations", "type": "person", "name": {"index": "Zellner, Elizabeth G", "preferred": "Elizabeth G Zellner"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "EL, Recruited and enrolled patients", "type": "person", "name": {"index": "Loring, Erin", "preferred": "Erin Loring"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "CC, Collected genetic specimens", "type": "person", "name": {"index": "Chuang, Carolyn", "preferred": "Carolyn Chuang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Craniosynostosis and Positional Plagiocephaly Support"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "contribution": "AG, Recruited and enrolled patients", "type": "person", "name": {"index": "Galm, Amy", "preferred": "Amy Galm"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "PWH, Collected genetic specimens", "type": "person", "name": {"index": "Hashim, Peter W", "preferred": "Peter W Hashim"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "DMS, Contributed clinical evaluations", "type": "person", "name": {"index": "Steinbacher, Derek M", "preferred": "Derek M Steinbacher"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "MLD, Contributed clinical evaluations", "type": "person", "name": {"index": "DiLuna, Michael L", "preferred": "Michael L DiLuna"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "CCD, Contributed clinical evaluations", "type": "person", "name": {"index": "Duncan, Charles C", "preferred": "Charles C Duncan"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Child Study Center", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "KAP, Recruited and enrolled patients", "type": "person", "name": {"index": "Pelphrey, Kevin A", "preferred": "Kevin A Pelphrey"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "HZ, Performed genetic analyses", "type": "person", "name": {"index": "Zhao, Hongyu", "preferred": "Hongyu Zhao"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "JAP, Conceived, designed, and directed study, contributed clinical evaluations", "type": "person", "name": {"index": "Persing, John A", "preferred": "John A Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"name": {"index": "Lifton, Richard P", "preferred": "Richard P Lifton"}, "competingInterests": "The authors declare that no competing interests exist.", "affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["The Rockefeller University"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "emailAddresses": ["richard.lifton@yale.edu"], "type": "person", "contribution": "RPL, Conceived, designed, and directed the study, performed genetic analyses, wrote the manuscript"}], "volume": 5, "version": 3, "published": "2016-09-08T00:00:00", "pdf": "elife-20125-v3.pdf", "subjects": [{"id": "genes-chromosomes", "name": "Genes and Chromosomes"}, {"id": "genomics-evolutionary-biology", "name": "Genomics and Evolutionary Biology"}], "researchOrganisms": ["Human"], "type": "research-article", "id": "20125"}, "article": {"body": [{"content": [{"text": "The cranial sutures are not fused at birth, allowing for doubling of brain volume in the first year of life and continued growth through adolescence (<xref ref-type=\"bibr\" rid=\"bib29\">Persing et al., 1989</xref>). The metopic suture normally closes between 6 and 12 months, while the sagittal, coronal, and lambdoid sutures typically fuse in adulthood (<xref ref-type=\"bibr\" rid=\"bib29\">Persing et al., 1989</xref>; <xref ref-type=\"bibr\" rid=\"bib44\">Weinzweig et al., 2003</xref>). Premature fusion of any of these sutures can result in brain compression and suture-specific craniofacial dysmorphism (<xref ref-type=\"fig\" rid=\"fig1\">Figure 1</xref>). Studies of syndromic forms of craniosynostosis, each with prevalence of ~1/60,000 to 1/1,000,000 live births and collectively accounting for 15\u201320% of all cases, have implicated mutations in more than 50 genes (<xref ref-type=\"bibr\" rid=\"bib40\">Twigg and Wilkie, 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib10\">Flaherty et al., 2016</xref>). For example, mutations that increase MAPK/ERK signaling (e.g. <italic>FGFR1-3</italic> (<xref ref-type=\"bibr\" rid=\"bib40\">Twigg and Wilkie, 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib10\">Flaherty et al., 2016</xref>), <italic>ERF</italic> [<xref ref-type=\"bibr\" rid=\"bib39\">Twigg et al., 2013</xref>]) cause rare syndromic coronal or multisuture craniosynostosis, while mutations that perturb SMAD signaling (e.g. <italic>TGFBR1/2</italic> [<xref ref-type=\"bibr\" rid=\"bib21\">Loeys et al., 2005</xref>], <italic>SKI</italic> [<xref ref-type=\"bibr\" rid=\"bib7\">Doyle et al., 2012</xref>], <italic>RUNX2</italic> [<xref ref-type=\"bibr\" rid=\"bib24\">Mefford et al., 2010</xref>; <xref ref-type=\"bibr\" rid=\"bib17\">Javed et al., 2008</xref>]) cause rare syndromes involving the midline (sagittal and metopic) sutures. While the detailed pathophysiology of premature suture fusion has not been elucidated, aberrant signaling in cranial neural crest cells during craniofacial development has been suggested as a common mechanism (<xref ref-type=\"bibr\" rid=\"bib25\">Mishina and Snider, 2014</xref>; <xref ref-type=\"bibr\" rid=\"bib19\">Komatsu et al., 2013</xref>).", "type": "paragraph"}, {"doi": "10.7554/eLife.20125.003", "title": "Phenotypes of midline craniosynostosis.", "uri": "https://example.org/elife-20125-fig1-v3", "label": "Figure 1.", "caption": [{"text": "(<bold>a</bold>) Normal infant skull with patent sagittal (S) and metopic (M) sutures. (<bold>b</bold>) Three-dimensional reconstruction of computed tomography (3D CT) demonstrating premature fusion of both the sagittal and metopic sutures. (<bold>c</bold>) A three-month-old boy with sagittal craniosynostosis featuring scaphocephaly (narrow and elongated cranial vault), and frontal bossing. (<bold>d</bold>) 3D CT reconstruction of a one-month-old boy found to have sagittal craniosynostosis. (<bold>e</bold>) A six-month-old boy presenting with trigonocephaly (triangulation of the cranial vault, with prominent forehead ridge resulting from premature fusion of the metopic suture) and hypotelorism (abnormally decreased intercanthal distance, also a result of premature fusion of the metopic suture). 3D CT reconstruction demonstrated metopic craniosynostosis. (<bold>f</bold>) 3D CT reconstruction demonstrating premature fusion of the metopic suture with characteristic trigonocephaly and hypotelorism.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.003\">http://dx.doi.org/10.7554/eLife.20125.003</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig1"}, {"text": "Despite success in identifying the genes underlying rare syndromic craniosynostosis, mutations in these genes are very rarely found in their non-syndromic counterparts (<xref ref-type=\"bibr\" rid=\"bib2\">Boyadjiev and International Craniosynostosis Consortium, 2007</xref>). Non-syndromic craniosynostosis of the midline sutures account for 50% of all craniosynostosis (<xref ref-type=\"bibr\" rid=\"bib38\">Slater et al., 2008</xref>; <xref ref-type=\"bibr\" rid=\"bib12\">Greenwood et al., 2014</xref>). A GWAS of non-syndromic sagittal craniosynostosis has implicated common variants in a segment of a gene desert ~345 kb downstream of <italic>BMP2</italic>, and within an intron of <italic>BBS9</italic>; these risk alleles have unusually large effect (odds ratios > 4 at each locus) (<xref ref-type=\"bibr\" rid=\"bib18\">Justice et al., 2012</xref>). Nonetheless, rare alleles with large effect have not been identified to date in non-syndromic sagittal or metopic craniosynostosis. We considered that the often sporadic occurrence of non-syndromic craniosynostosis might frequently be attributable to de novo mutation or incomplete penetrance of rare transmitted variants.", "type": "paragraph"}], "type": "section", "id": "s1", "title": "Introduction"}, {"content": [{"content": [{"text": "We recruited a cohort of 191 probands with non-syndromic midline craniosynostosis, including 132 parent-offspring trios and 59 probands with one parent, along with selected extended family members (see Materials\u00a0and\u00a0methods). All probands had undergone reconstructive surgery for either isolated sagittal (n\u00a0=\u00a0113), metopic (n\u00a0=\u00a070) or combined sagittal and metopic (n\u00a0=\u00a08) craniosynostosis. Seventeen kindreds had 1 to 3 additional affected family members, including 7 parents, 12 siblings, 3 aunts/uncles and 4 more distant relatives of probands. DNA was prepared from buccal swab samples. Exome sequencing was performed as described in Materials and methods; summary data are shown in <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1A</xref>. Variants were called using the GATK pipeline (see Materials and methods) and de novo mutations in parent-offspring trios were called using TrioDeNovo (<xref ref-type=\"bibr\" rid=\"bib43\">Wei et al., 2015</xref>). The impact of identified missense variants on protein function was inferred using MetaSVM (<xref ref-type=\"bibr\" rid=\"bib6\">Dong et al., 2015</xref>). All de novo calls were verified by in silico visualization of aligned reads (<xref ref-type=\"fig\" rid=\"fig2s1\">Figure 2\u2014figure supplement 1</xref>), and all calls contributing to significant results for individual genes were verified by direct Sanger sequencing.", "type": "paragraph"}, {"text": "We identified a total of 144 de novo mutations, providing a de novo mutation rate of 1.64 \u00d7 10<sup>\u20138</sup> per base pair, and 1.09 de novo mutations in the coding region per offspring, consistent with prior experimental results and expectation (<xref ref-type=\"bibr\" rid=\"bib42\">Ware et al., 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib14\">Homsy et al., 2015</xref>) (<xref ref-type=\"table\" rid=\"tbl1\">Table 1</xref>). Comparison of the observed distribution of mutation types to the expected from the Poisson distribution demonstrated significant enrichment of protein-altering mutations, predominantly accounted for by an excess of damaging missense mutations (MetaSVM D-mis; 28 observed D-mis compared to 14.5 expected, p=1.0 \u00d7 10<sup>\u20133</sup>, 1.93-fold enrichment), with a corresponding paucity of silent mutations (21 compared to 40.4 expected, p=3.0 \u00d7 10<sup>\u20134</sup>). From the difference in the observed vs. expected number of de novo protein-altering mutations per subject, we infer that these de novo mutations contribute to ~15% of non-syndromic midline craniosynostosis.", "type": "paragraph"}, {"tables": ["<table><thead><tr><th/><th colspan=\"2\">Observed</th><th colspan=\"2\">Expected</th><th>Enrichment</th><th>p-value</th></tr><tr><th>Class</th><th>#</th><th>#/subject</th><th>#</th><th>#/subject</th><th/><th/></tr></thead><tbody><tr><td>All mutations</td><td>144</td><td>1.09</td><td>142.8</td><td>1.08</td><td>1.01</td><td>0.47</td></tr><tr><td>Synonymous</td><td>21</td><td>0.16</td><td>40.4</td><td>0.31</td><td>0.52</td><td>3.0 \u00d7 10<sup>\u22124</sup></td></tr><tr><td>Protein altering</td><td>123</td><td>0.93</td><td>102.4</td><td>0.78</td><td>1.17</td><td>0.03</td></tr><tr><td>Total missense</td><td>110</td><td>0.83</td><td>89.7</td><td>0.68</td><td>1.23</td><td>0.02</td></tr><tr><td>T-mis</td><td>82</td><td>0.62</td><td>75.2</td><td>0.57</td><td>1.09</td><td>0.23</td></tr><tr><td>D-mis</td><td>28</td><td>0.21</td><td>14.5</td><td>0.11</td><td>1.93</td><td>1.0 \u00d7 10<sup>\u22123</sup></td></tr><tr><td>Loss of function (LOF)</td><td>13</td><td>0.10</td><td>12.7</td><td>0.10</td><td>1.03</td><td>0.50</td></tr><tr><td>LOF + D-mis</td><td>41</td><td>0.31</td><td>27.1</td><td>0.21</td><td>1.51</td><td>7.8 \u00d7 10<sup>\u22123</sup></td></tr></tbody></table>"], "doi": "10.7554/eLife.20125.004", "title": "De novo mutations in 132 trios with sagittal and/or metopic craniosynostosis.", "label": "Table 1.", "caption": [{"text": "Enrichment of protein-altering de novo mutations in 132 subjects with sagittal and/or metopic craniosynostosis.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.004\">http://dx.doi.org/10.7554/eLife.20125.004</ext-link>", "type": "paragraph"}], "sourceData": [{"doi": "10.7554/eLife.20125.005", "title": "De novo mutations in 132 trios with sagittal and/or metopic craniosynostosis.", "mediaType": "application/xlsx", "uri": "https://example.org/elife-20125-table1-data1-v3.xlsx", "label": "Table 1\u2014source data 1.", "id": "SD1-data"}], "footnotes": [{"text": [{"text": "#, number of de novo mutations in 132 subjects; #/subject, number of de novo mutations per subject; Damaging and tolerated missense called by MetaSVM (D-mis, T-mis respectively); Loss of function denotes premature termination, frameshift, or splice site mutation. For mutation classes with enrichment compared to expectation, p-values represent the upper tail of the Poisson probability density function. For mutation classes in which we observed a paucity of mutations compared to expectation, p-values represent the lower tail.", "type": "paragraph"}]}], "type": "table", "id": "tbl1"}], "type": "section", "id": "s2-1", "title": "Exome sequencing of non-syndromic midline craniosynostosis"}, {"content": [{"text": "Analysis of de novo mutation burden revealed that a single gene, <italic>SMAD6</italic>, harbored three de novo mutations, including two inferred loss of function (LOF) mutations (p.Q78fs*41 and p.E374*) and one D-mis mutation (p.G390C). All three were heterozygous and occurred in families in which the proband was the sole affected member. Two de novo mutations occurred in probands and one occurred in an unaffected mother of a proband (<xref ref-type=\"fig\" rid=\"fig2\">Figure 2</xref>). All three de novo mutations were confirmed by Sanger sequencing of PCR amplicons containing the putative mutation (<xref ref-type=\"fig\" rid=\"fig2s2\">Figure 2\u2014figure supplement 2</xref>). <italic>TTN</italic>, which encodes the largest human protein, was the only other gene with more than one protein altering de novo mutation, and both of these were predicted by MetaSVM to encode tolerated variants (p.I3580M, p.T19373S). From the prior probability of de novo mutation of each base in <italic>SMAD6</italic> and the impact on the encoded protein (<xref ref-type=\"bibr\" rid=\"bib32\">Samocha et al., 2014</xref>), the probability of seeing at least two de novo LOFs and one missense mutation by chance in a cohort of this size was 3.6 \u00d7 10<sup>\u20139</sup>\u00a0(<xref ref-type=\"table\" rid=\"tbl2\">Table 2</xref>). Similarly, observing two or more de novo LOF mutations in any gene in this cohort was not expected by chance (p=8.4 \u00d7 10<sup>\u20133</sup>, see Materials and methods). Lastly, <italic>SMAD6</italic> is not unusually mutable, as we found no de novo <italic>SMAD6</italic> mutations in 900 control trios comprising healthy siblings of individuals with autism (<xref ref-type=\"bibr\" rid=\"bib15\">Iossifov et al., 2014</xref>; <xref ref-type=\"bibr\" rid=\"bib27\">O'Roak et al., 2011</xref>; <xref ref-type=\"bibr\" rid=\"bib33\">Sanders et al., 2012</xref>). These findings provide highly significant evidence implicating damaging mutations in <italic>SMAD6</italic> as a cause of midline suture craniosynostosis.", "type": "paragraph"}, {"supplements": [{"doi": "10.7554/eLife.20125.009", "title": "Plots of independent Illumina sequencing reads in a parent-offspring trio showing de novo <italic>SMAD6</italic> mutation.", "uri": "https://example.org/elife-20125-fig2-figsupp1-v3", "label": "Figure 2\u2014figure supplement 1.", "caption": [{"text": "The reference sequence of a segment of <italic>SMAD6</italic> that includes base 15:67073502 (denoted by arrow) is shown in the top row, with red, blue, green and yellow squares representing A, C, G, T, respectively. Below, all independent reads that map to this interval are shown. The results show that the proband has 23 reads of reference \u2018G\u2019, and 10 reads of non-reference \u2018T\u2019. Only the reference \u2018G\u2019 is seen in both parents, providing evidence of a de novo mutation.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.009\">http://dx.doi.org/10.7554/eLife.20125.009</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig2s1"}, {"doi": "10.7554/eLife.20125.010", "title": "Confirmation of <italic>SMAD6</italic> mutations by Sanger sequencing of PCR products.", "uri": "https://example.org/elife-20125-fig2-figsupp2-v3", "label": "Figure 2\u2014figure supplement 2.", "caption": [{"text": "Sanger sequencing traces of PCR amplicons containing <italic>SMAD6</italic> mutations identified by exome sequencing are shown. Above each trace or set of traces, the kindred ID, mutation identified in the DNA sequence and its impact on SMAD6 protein is indicated. Above sequence traces, the inferred DNA sequence is shown, along with the inferred amino acid sequence (shown in single letter code). Heterozygous mutations are indicated beneath the wild-type sequence and non-reference amino acid sequences are shown in red. Deleted and inserted bases are denoted, and result in an overlap of wild-type and mutant sequences.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.010\">http://dx.doi.org/10.7554/eLife.20125.010</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig2s2"}], "doi": "10.7554/eLife.20125.006", "title": "Segregation of <italic>SMAD6</italic> mutations and <italic>BMP2</italic> SNP genotypes in pedigrees with midline craniosynostosis.", "uri": "https://example.org/elife-20125-fig2-v3", "label": "Figure 2.", "caption": [{"text": "(<bold>a</bold>) Domain structure of <italic>SMAD6</italic> showing location of the MH1 and MH2 domains. The MH1 domain mediates DNA binding and negatively regulates the functions of the MH2 domain, while the MH2 domain is responsible for transactivation and mediates phosphorylation-triggered heteromeric assembly with receptor\u00a0SMADs. De novo or rare damaging mutations identified in craniosynostosis probands are indicated. Color of text denotes suture(s) showing premature closure. (<bold>b</bold>) Pedigrees harboring de novo (denoted by stars within pedigree symbols) or rare transmitted variants in <italic>SMAD6</italic>. Filled and unfilled symbols denote individuals with and without craniosynostosis, respectively. The <italic>SMAD6</italic> mutation identified in each kindred is noted above each pedigree. Below each symbol, genotypes are shown first for <italic>SMAD6</italic> (with 'D' denoting the damaging allele) and for rs1884302 risk locus downstream of <italic>BMP2</italic>, (with 'T' conferring protection from and 'C' conferring increased risk of craniosynostosis). All 17 subjects with craniosynostosis have <italic>SMAD6</italic> mutations, and 14/17 have also inherited the risk allele at rs1884302, whereas only 3 of 16 <italic>SMAD6</italic> mutation carriers without the rs1884302 risk allele have craniosynostosis.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.006\">http://dx.doi.org/10.7554/eLife.20125.006</ext-link>", "type": "paragraph"}], "sourceData": [{"doi": "10.7554/eLife.20125.007", "title": "Variants identified in <italic>SMAD6</italic>.", "mediaType": "application/docx", "uri": "https://example.org/elife-20125-fig2-data1-v3.docx", "label": "Figure 2\u2014source data 1.", "id": "SD2-data"}, {"doi": "10.7554/eLife.20125.008", "title": "PCR primer sequences for Sanger sequencing of reported variants.", "mediaType": "application/docx", "uri": "https://example.org/elife-20125-fig2-data2-v3.docx", "label": "Figure 2\u2014source data 2.", "id": "SD3-data"}], "alt": "", "type": "image", "id": "fig2"}, {"tables": ["<table><thead><tr><th valign=\"top\">Gene(s)</th><th valign=\"top\">Mutations</th><th valign=\"top\">Number of observed mutations</th><th valign=\"top\">Number of expected mutations</th><th valign=\"top\">p value</th></tr></thead><tbody><tr><td valign=\"top\"><italic>SMAD6</italic></td><td valign=\"top\">Loss of function</td><td valign=\"top\">2</td><td valign=\"top\">0.00026</td><td valign=\"top\">3.31 \u00d7 10<sup>\u22128</sup></td></tr><tr><td valign=\"top\"><italic>SMAD6</italic></td><td valign=\"top\">Missense</td><td valign=\"top\">1</td><td valign=\"top\">0.0046</td><td valign=\"top\">4.67 \u00d7 10<sup>\u22123</sup></td></tr><tr><td valign=\"top\"><italic>SPRY1, SPRY2, SPRY3, SPRY4</italic></td><td valign=\"top\">Nonsense, splice site, frameshift</td><td valign=\"top\">2</td><td valign=\"top\">0.001193</td><td valign=\"top\">7.11 \u00d7 10<sup>\u22127</sup></td></tr></tbody></table>"], "doi": "10.7554/eLife.20125.011", "title": "Probability of observed de novo mutations in <italic>SMAD6</italic> and Sprouty genes occurring by chance in 132 subjects using gene-specific mutation probabilities.", "label": "Table 2.", "caption": [{"text": "Probability of observed de novo mutations in <italic>SMAD6</italic> and Sprouty genes occurring by chance in 132 subjects using gene-specific mutation probabilities.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.011\">http://dx.doi.org/10.7554/eLife.20125.011</ext-link>", "type": "paragraph"}], "footnotes": [{"text": [{"text": "Probabilities calculated from the Poisson distribution using DenovolyzeR. The probability of observing at least 2 LOF and 1 missense mutation in <italic>SMAD6</italic> was 3.6 10<sup>\u22129</sup> via Fisher\u2019s method.", "type": "paragraph"}]}], "type": "table", "id": "tbl2"}, {"text": "We next considered the total burden of rare (prospectively specified allele frequency in ExAC database <2 \u00d7 10<sup>\u20135</sup>) LOF and D-mis mutations in each gene in probands. Among 191 probands, we found 1135 rare LOF and 3156 rare damaging (LOF + D-mis) alleles. The probability of the observed number of rare variants in each gene occurring by chance was calculated from the binomial distribution after adjusting for the length of each gene; Q-Q plots comparing the observed and expected P-value distributions are shown in <xref ref-type=\"fig\" rid=\"fig3\">Figure 3</xref>. The observed distribution conforms closely to expected with the exception of <italic>SMAD6</italic>. The expected number of rare LOF alleles in <italic>SMAD6</italic> in probands was 0.05, and the observed number was 8 (p=1.1 \u00d7 10<sup>\u201315</sup>, 156-fold enrichment). Similarly, there were 13 rare damaging variants in <italic>SMAD6</italic> compared to 0.14 expected (p=1.3 \u00d7 10<sup>\u201321</sup>, 91.4-fold enrichment). All of these <italic>SMAD6</italic> variants were confirmed by direct Sanger sequencing (<xref ref-type=\"fig\" rid=\"fig2s2\">Figure 2\u2014figure supplement 2</xref>). All were heterozygous and different from one another (<xref ref-type=\"supplementary-material\" rid=\"SD2-data\">Figure 2\u2014source data 1</xref>); 11 were absent among >10<sup>5</sup> alleles in the ExAC database, while two were previously seen, each once in ExAC (p.E407* and p.R465C, ExAC allele frequencies 9.0\u00a0\u00d7 10<sup>\u20136</sup> and 9.4 \u00d7 10<sup>\u20136</sup> respectively). The results for <italic>SMAD6</italic> remain highly significant after excluding de novo mutations and only analyzing transmitted variants (<xref ref-type=\"fig\" rid=\"fig3s1\">Figure 3\u2014figure supplement 1</xref>), demonstrating a\u00a0significant contribution of both de novo and transmitted variants (<xref ref-type=\"table\" rid=\"tbl3\">Table 3</xref>). The fact that eight of the 13 rare heterozygous damaging variants in <italic>SMAD6</italic> seen in our cohort are frameshift (n = 5) or premature termination (n = 3) mutations, which are distributed throughout the encoded protein (<xref ref-type=\"fig\" rid=\"fig2\">Figure 2a</xref>), strongly supports haploinsufficiency as the mechanism of the genetic contribution of <italic>SMAD6</italic> to craniosynostosis.", "type": "paragraph"}, {"supplements": [{"doi": "10.7554/eLife.20125.014", "title": "Quantile-quantile plots comparing all transmitted, damaging variants in protein-coding genes in 191 probands with midline craniosynostosis to the expected binomial distribution.", "uri": "https://example.org/elife-20125-fig3-figsupp1-v3", "label": "Figure 3\u2014figure supplement 1.", "caption": [{"text": "De novo variants were excluded from this analysis, leaving 1122 rare (ExAC allele frequency < 2 x10<sup>\u22125</sup>), transmitted LOF variants and 3115 transmitted damaging (LOF + D-mis) variants. All genes closely matched expectation, with the exception of <italic>SMAD6</italic>. (<bold>a</bold>) There were 6 transmitted <italic>SMAD6</italic> LOF mutations, a 118-fold enrichment compared to the expected 0.05 (p=2.2 \u00d7 10<sup>\u201311</sup>). (<bold>b</bold>) Similarly, there were 10 transmitted damaging <italic>SMAD6</italic> variants, a 71-fold enrichment compared to the expected 0.14 (p=7.0 \u00d7 10<sup>\u201316</sup>). The results demonstrate genome-wide significance of rare transmitted variants in <italic>SMAD6</italic> independent of de novo mutations.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.014\">http://dx.doi.org/10.7554/eLife.20125.014</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig3s1"}, {"doi": "10.7554/eLife.20125.015", "title": "Principal-component analysis of 191 probands and 3337 European autism controls.", "uri": "https://example.org/elife-20125-fig3-figsupp2-v3", "label": "Figure 3\u2014figure supplement 2.", "caption": [{"text": "(<bold>a</bold>) Principal component analysis of exome sequence genotypes from 191 probands with sagittal, metopic, or combined sagittal and metopic craniosynostosis clustered along with HapMap subjects. Results identify 172 craniosynostosis subjects that cluster with HapMap European subjects. (<bold>b</bold>) Principal component analysis of genotypes from exome sequencing data of European autism parent controls (n\u00a0=\u00a03337) showing clustering with HapMap subjects. In both panels, subjects considered to be of European ancestry are circled.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.015\">http://dx.doi.org/10.7554/eLife.20125.015</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig3s2"}, {"doi": "10.7554/eLife.20125.016", "title": "Quantile-quantile plot of observed versus expected p-values comparing the burden of damaging (LOF + D-mis) variants in protein-coding genes in craniosynostosis cases and controls.", "uri": "https://example.org/elife-20125-fig3-figsupp3-v3", "label": "Figure 3\u2014figure supplement 3.", "caption": [{"text": "The frequency of rare (allele frequency < 2 \u00d7 10<sup>\u20135</sup>\u00a0in the ExAC03 database) loss of function and D-mis variants in each gene was compared in 172 European probands with midline craniosynostosis and 3337 European controls. The distribution of observed p-values conforms to expectation with the exception of <italic>SMAD6</italic>, which deviates significantly from expectation. Because exon 1 of <italic>SMAD6</italic> was poorly captured using the V2 capture reagent (used in control samples), 3 damaging variants in exon 1 in cases were excluded from this analysis.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.016\">http://dx.doi.org/10.7554/eLife.20125.016</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig3s3"}], "doi": "10.7554/eLife.20125.012", "title": "Quantile-quantile plots of observed versus expected p-values comparing the burden of rare LOF and damaging (LOF + D-mis) variants in protein-coding genes in craniosynostosis cases.", "uri": "https://example.org/elife-20125-fig3-v3", "label": "Figure 3.", "caption": [{"text": "Rare (allele frequency <2 \u00d7 10<sup>\u20135</sup>\u00a0in the ExAC03 database) loss of function (LOF) and damaging missense (D-mis) variants were identified in 191 probands. The probability of the observed number of variants in each gene occurring by chance was calculated from the total number of observed variants and the length of the coding region of each gene using the binomial test. The distribution of observed P-values compared to the expected distribution is shown. (<bold>a</bold>) Q-Q plot for rare LOF variants in each gene from a total of 1135 LOF variants identified in probands. The distribution of observed p-values closely conforms to expectation with the exception of <italic>SMAD6</italic>, which shows p=1.1 \u00d7 10<sup>\u201315</sup>\u00a0and 156-fold enrichment in cases. (<bold>b</bold>) Q-Q plot for rare damaging (LOF + D-mis) variants in each gene from a total of 3156 damaging variants in probands. Again, <italic>SMAD6</italic> deviates greatly from the expected distribution, with p<10<sup>\u201320</sup> and 91-fold enrichment.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.012\">http://dx.doi.org/10.7554/eLife.20125.012</ext-link>", "type": "paragraph"}], "sourceData": [{"doi": "10.7554/eLife.20125.013", "title": "Source data for <xref ref-type=\"fig\" rid=\"fig3s3\">Figure 3\u2014figure supplement 3</xref>.", "mediaType": "application/docx", "uri": "https://example.org/elife-20125-fig3-data1-v3.docx", "label": "Figure 3\u2014source data 1.", "id": "SD4-data"}], "alt": "", "type": "image", "id": "fig3"}, {"tables": ["<table><thead><tr><th valign=\"top\"/><th valign=\"top\">Observed</th><th valign=\"top\">Expected</th><th valign=\"top\">Enrichment</th><th valign=\"top\">p-value</th></tr></thead><tbody><tr><td valign=\"top\">De novo LOF and D-mis</td><td valign=\"top\">3</td><td valign=\"top\">0.0049</td><td valign=\"top\">612</td><td valign=\"top\">3.6 \u00d7 10<sup>\u22129</sup></td></tr><tr><td valign=\"top\">Transmitted LOF and D-mis</td><td valign=\"top\">10</td><td valign=\"top\">0.1404</td><td valign=\"top\">71.2</td><td valign=\"top\">7.0 \u00d7 10<sup>\u221216</sup></td></tr><tr><td valign=\"top\">Total</td><td valign=\"top\">13</td><td valign=\"top\">0.1453</td><td valign=\"top\">89.5</td><td valign=\"top\">1.4 \u00d7 10<sup>\u221222</sup></td></tr></tbody></table>"], "doi": "10.7554/eLife.20125.017", "title": "Enrichment of de novo and transmitted damaging variants in <italic>SMAD6</italic> in craniosynostosis.", "label": "Table 3.", "caption": [{"text": "Enrichment of de novo and transmitted damaging variants in <italic>SMAD6</italic> in craniosynostosis.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.017\">http://dx.doi.org/10.7554/eLife.20125.017</ext-link>", "type": "paragraph"}], "footnotes": [{"text": [{"text": "LOF, loss of function; D-mis, damaging missense variants per MetaSVM; The total number of <italic>SMAD6</italic> variants expected in this cohort was calculated by summing the expected number of de novo and transmitted variants. P-value combining probabilities from de novo and transmitted protein damaging <italic>SMAD6</italic> variants was determined by Fisher\u2019s method.", "type": "paragraph"}]}], "type": "table", "id": "tbl3"}, {"text": "Lastly, we compared the frequency of rare (allele frequency <2\u00a0\u00d7 10<sup>\u20135</sup> in the ExAC database) damaging (LOF + D-mis) variants in all genes in 172 European probands and 3337 unrelated European controls, who were parents of autism probands sequenced to a similar depth of coverage and analyzed in a similar fashion (see Materials and methods, <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1A</xref>). European ancestry was determined by principal component analysis of exome sequence data (<xref ref-type=\"fig\" rid=\"fig3s2\">Figure 3\u2014figure supplement 2</xref>). Q-Q plots showed that the observed distribution of Fisher\u2019s exact statistics comparing the frequency of damaging variants in cases and controls closely corresponded to the expected distribution, again with the exception of <italic>SMAD6,</italic> in which cases showed enrichment of damaging variants (p=6.3 \u00d7 10<sup>\u20138</sup>) and LOF variants (p=5.7 \u00d7 10<sup>\u20136</sup>) (<xref ref-type=\"fig\" rid=\"fig3s3\">Figure 3\u2014figure supplement 3</xref>). Significant enrichment was also seen in comparison to European NHLBI and ExAC controls (<xref ref-type=\"supplementary-material\" rid=\"SD4-data\">Figure 3\u2014source data 1</xref>). The odds ratios for association of all damaging variants in <italic>SMAD6</italic> in cases vs. controls was consistent across control cohorts, ranging from 26.9 to 35.1; the odds ratios for LOFs ranged from 102.6 to infinity (owing to zero LOF\u2019s in autism controls).", "type": "paragraph"}, {"text": "Aside from <italic>SMAD6</italic>, no other single gene approached genome-wide significance in these analyses of dominant alleles. Analysis of recessive genotypes, considering alleles with frequency <10<sup>\u20133</sup>, identified no genes with more than one rare recessive genotype.", "type": "paragraph"}, {"text": "Collectively, the significant burden of both de novo and rare transmitted mutations, along with significant association results in case-control analysis provide extremely strong evidence that rare damaging <italic>SMAD6</italic> alleles impart large effects on risk of non-syndromic midline craniosynostosis.", "type": "paragraph"}, {"text": "<italic>SMAD6</italic> mutations were significantly more frequent in kindreds with any metopic craniosynostosis (10 of 78, 12.8%) compared to those with isolated sagittal craniosynostosis (3 of 113, 2.7%; p=8.1 \u00d7 10<sup>\u20133</sup> by Fisher\u2019s exact test, odds ratio 5.3). These results suggest that mutations in <italic>SMAD6</italic> confer greater risk for metopic suture closure. We found no significant correlation between the type of mutation (LOF vs. D-mis) or location within the gene of <italic>SMAD6</italic> mutation and phenotypic class (<xref ref-type=\"table\" rid=\"tbl4\">Table 4</xref>).", "type": "paragraph"}, {"tables": ["<table><thead><tr><th/><th>Total # kindreds</th><th>Total # <italic>SMAD6</italic> mutations (%)</th><th># LOF (%)</th></tr></thead><tbody><tr><td>Sagittal</td><td>113</td><td>3 (2.7)</td><td>2 (1.8)</td></tr><tr><td>Metopic</td><td>70</td><td>7 (10)</td><td>3 (3.9)</td></tr><tr><td>Sagittal and Metopic</td><td>8</td><td>3 (37.5)</td><td>3 (37.5)</td></tr><tr><td>Total</td><td>191</td><td>13 (6.8)</td><td>8 (4.2)</td></tr></tbody></table>"], "doi": "10.7554/eLife.20125.018", "title": "Distribution of suture involvement in kindreds with and without rare (allele frequency < 2\u00a0\u00d7 10<sup>\u22125</sup>) de novo and transmitted damaging (LOF + D-mis) variants in <italic>SMAD6</italic>.", "label": "Table 4.", "caption": [{"text": "Distribution of suture involvement in kindreds with and without rare (allele frequency < 2\u00a0\u00d7 10<sup>\u22125</sup>) de novo and transmitted damaging (LOF + D-mis) variants in <italic>SMAD6</italic>.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.018\">http://dx.doi.org/10.7554/eLife.20125.018</ext-link>", "type": "paragraph"}], "type": "table", "id": "tbl4"}, {"text": "Interestingly, transmitted <italic>SMAD6</italic> mutations were significantly enriched in kindreds with familial craniosynostosis, accounting for 4 of 17 kindreds with more than one affected subject (p=0.02, Fisher\u2019s exact test; odds ratio 5.6). In these kindreds, all four additional affected subjects carried the <italic>SMAD6</italic> mutation found in the proband (<xref ref-type=\"fig\" rid=\"fig2\">Figure 2</xref>).", "type": "paragraph"}, {"text": "SMAD6 is a member of the inhibitory-SMAD family. Activation of BMP receptors leads to phosphorylation of receptor SMADs, which can complex with SMAD4, translocate to the nucleus and partner with RUNX2 to induce transcription of genes that promote osteoblast differentiation (<xref ref-type=\"bibr\" rid=\"bib17\">Javed et al., 2008</xref>; <xref ref-type=\"bibr\" rid=\"bib13\">Hata et al., 1998</xref>) (<xref ref-type=\"fig\" rid=\"fig4\">Figure 4a</xref>). This process is inhibited by SMAD6 binding to phosphorylated receptor SMADs, forming an inactive complex. SMAD6 also inhibits BMP signaling by complexing with the ubiquitin ligase SMURF1, which ubiquitylates BMP receptors, receptor SMADs and RUNX2, leading to their proteasomal degradation (<xref ref-type=\"fig\" rid=\"fig4\">Figure 4b</xref>) (<xref ref-type=\"bibr\" rid=\"bib26\">Murakami et al., 2003</xref>). This pathway plays a well-established role in the\u00a0development of the cranial vault and closure of cranial sutures. In mice, constitutive activity of BMPR1A in cranial neural crest results in SMAD-dependent development of metopic craniosynostosis (<xref ref-type=\"bibr\" rid=\"bib19\">Komatsu et al., 2013</xref>), and genetic deficiency for the SMAD inhibitor <italic>SMURF1</italic> causes midline craniosynostosis (<xref ref-type=\"bibr\" rid=\"bib34\">Shimazu et al., 2016</xref>). Similarly, duplication of <italic>RUNX2</italic> causes syndromic metopic craniosynostosis in humans (<xref ref-type=\"bibr\" rid=\"bib24\">Mefford et al., 2010</xref>). Lastly, <italic>SMAD6</italic> knockout mice are born with domed skulls and show anomalous bone deposition in the metopic suture; they also show an augmented and prolonged response to BMP2 stimulation (<xref ref-type=\"bibr\" rid=\"bib8\">Estrada et al., 2011</xref>; <xref ref-type=\"bibr\" rid=\"bib30\">Retting, 2008</xref>). These findings are consistent with haploinsufficiency as the mechanism of <italic>SMAD6</italic> mutations in craniosynostosis, with loss of the inhibitory effect of SMAD6 promoting increased BMP signaling and premature closure of sutures.", "type": "paragraph"}, {"doi": "10.7554/eLife.20125.019", "title": "SMAD6 inhibits osteoblast differentiation by inhibiting BMP-mediated SMAD signaling (<xref ref-type=\"bibr\" rid=\"bib31\">Salazar et al., 2016</xref>).", "uri": "https://example.org/elife-20125-fig4-v3", "label": "Figure 4.", "caption": [{"text": "(<bold>a</bold>) BMP ligands activate BMP receptors, leading to phosphorylation of receptor-regulated SMADs (R-SMADs), which complex with SMAD4 and enter the nucleus, cooperating with RUNX2 to induce osteoblast differentiation. SMAD6 inhibits this signal by competing with SMAD4 for binding to R-SMADs, preventing nuclear translocation. (<bold>b</bold>) SMAD6 also cooperates with SMURF1, an E3 ubiquitin ligase, to induce ubiquitin-mediated proteasomal degradation of R-SMADs, BMP receptor complexes, and RUNX2.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.019\">http://dx.doi.org/10.7554/eLife.20125.019</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig4"}, {"text": "We explored our kindreds for other mutations in this signaling pathway. Interestingly, we identified one de novo D-mis mutation in <italic>SMURF1</italic> in a proband with sporadic metopic craniosynostosis (<xref ref-type=\"fig\" rid=\"fig5\">Figure 5</xref>).", "type": "paragraph"}, {"doi": "10.7554/eLife.20125.020", "title": "A de novo variant identified in <italic>SMURF1</italic>.", "uri": "https://example.org/elife-20125-fig5-v3", "label": "Figure 5.", "caption": [{"text": "(<bold>a</bold>) Sanger sequence electropherogram of a PCR product amplified from the genomic DNA of a proband with metopic craniosynostosis, confirming a de novo R468W mutation in <italic>SMURF1</italic>, a <italic>SMAD6</italic> binding partner. (<bold>b</bold>) Patient photographs of the proband, who presented with trigonocephaly and mild orbital abnormalities. 3D CT reconstruction demonstrates metopic craniosynostosis, trigonocephaly, and a patent sagittal suture.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.020\">http://dx.doi.org/10.7554/eLife.20125.020</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig5"}], "type": "section", "id": "s2-2", "title": "De novo and transmitted mutations in <italic>SMAD6</italic>"}, {"content": [{"text": "Within the 13 kindreds harboring rare damaging <italic>SMAD6</italic> variants, all 17 affected subjects had the <italic>SMAD6</italic> mutation found in the proband (<xref ref-type=\"fig\" rid=\"fig2\">Figure 2</xref>). Nonetheless, <italic>SMAD6</italic> mutations showed striking incomplete penetrance. In particular, zero of 10 parental <italic>SMAD6</italic> mutation carriers had a diagnosis of, or showed evidence of craniosynostosis. Examination of Illumina read counts and Sanger sequence traces provided no suggestion that the mutations were mosaic in unaffected parents (mean/median of 52.9%/52.4% variant reads in transmitting parents, respectively; range 37.3% to 71.4%). There was no significant effect of gender on penetrance. From the data in these kindreds, the penetrance of <italic>SMAD6</italic> mutations is estimated at 24% following exclusion of probands, who were ascertained for the presence of disease (57% if probands are included). The striking absence of craniosynostosis among transmitting parents suggests the possibility of purifying selection, with subjects having craniosynostosis less likely to have offspring.", "type": "paragraph"}, {"text": "We considered whether inheritance at other genetic loci might account for the striking incomplete penetrance of <italic>SMAD6</italic> mutations in these kindreds. A previous GWAS of non-syndromic sagittal craniosynostosis implicated common variants ~345 kb downstream of the closest gene, <italic>BMP2</italic> (encoding bone morphogenetic protein 2), with unusually large effect size (e.g., rs1884302, with risk allele frequency of 0.34 and odds ratio of 4.6). BMP2 is a ligand for BMP receptors upstream of SMAD signaling (<xref ref-type=\"bibr\" rid=\"bib31\">Salazar et al., 2016</xref>) and is an inducer of osteogenesis. We posited that risk alleles at this locus might increase the penetrance of <italic>SMAD6</italic> mutations by increasing BMP2 levels and further increasing SMAD signaling. Genotypes for rs1884302 are shown in <xref ref-type=\"fig\" rid=\"fig2\">Figure 2</xref> and provide strong evidence of epistatic interaction between <italic>SMAD6</italic> and <italic>BMP2</italic> alleles. Fourteen individuals had both a <italic>SMAD6</italic> mutation and the rs1884302 risk allele; 100% of these had craniosynostosis. In contrast, 16 subjects had a <italic>SMAD6</italic> mutation but no rs1884302 risk allele; only 3 of these individuals (19%) had craniosynostosis. Lastly, 0 of 18 members of these kindreds who had only the rs1884302 risk allele had craniosynostosis. The relationship of these two genotypes to craniosynostosis in these kindreds was highly significant (p=1.4\u00a0\u00d7 10<sup>\u201310</sup> by the Freeman-Halton extension of Fisher\u2019s exact test; <xref ref-type=\"table\" rid=\"tbl5\">Table 5</xref>).", "type": "paragraph"}, {"tables": ["<table><thead><tr><th><italic>SMAD6/BMP2</italic> Genotypes</th><th>Craniosynostosis (+)</th><th>Craniosynostosis (\u2212)</th></tr></thead><tbody><tr><td><italic>SMAD6</italic> (+) <italic>/ BMP2</italic> risk allele (+)</td><td>14</td><td>0</td></tr><tr><td><italic>SMAD6</italic> (+) <italic>/ BMP2</italic> risk allele (\u2212)</td><td>3</td><td>13</td></tr><tr><td><italic>SMAD6</italic> (\u2212) <italic>/ BMP2</italic> risk allele (+)</td><td>0</td><td>18</td></tr></tbody></table>"], "doi": "10.7554/eLife.20125.021", "title": "Risk of craniosynostosis in <italic>SMAD6</italic> mutation carriers in the presence or absence of a <italic>BMP2</italic> risk allele.", "label": "Table 5.", "caption": [{"text": "Risk of craniosynostosis in <italic>SMAD6</italic> mutation carriers in the presence or absence of a <italic>BMP2</italic> risk allele.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.021\">http://dx.doi.org/10.7554/eLife.20125.021</ext-link>", "type": "paragraph"}], "footnotes": [{"text": [{"text": "All members of kindreds found to have a mutation in <italic>SMAD6</italic> were included. <italic>SMAD6</italic>(+) indicates the presence of a heterozygous LOF or D-mis allele. The reported <italic>BMP2</italic> risk allele is \u2018C\u2019 at risk locus rs1884302, found within a gene desert ~345kb downstream of <italic>BMP2</italic>. p=1.4 \u00d7 10<sup>\u221210</sup> by the Freeman-Halton extension of Fisher\u2019s exact test. Odds ratio in favor of disease was incalculable due to the absence of craniosynostosis in <italic>SMAD6</italic> (\u2212) individuals in these kindreds.", "type": "paragraph"}]}], "type": "table", "id": "tbl5"}, {"text": "Confining analysis just to subjects with <italic>SMAD6</italic> mutation, there was dramatically increased occurrence of craniosynostosis among those with the rs1884302 risk allele compared to those without (p=4.8 \u00d7 10<sup>\u20136</sup> by Fisher\u2019s exact test). The presence of the rs1884302 risk allele increased the risk of craniosynostosis >5-fold with a very high odds ratio that includes infinity owing to 100% penetrance among those with risk genotypes at both loci. This two locus contribution is further supported by significant transmission disequilibrium, with rs1884302 risk alleles transmitted from heterozygous parents to affected offspring in 11 of 13 transmissions (p=0.013 by Chi-square, <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1B</xref>). In sum, inheritance at rs1884302 explains nearly all of the variation in phenotype among subjects with <italic>SMAD6</italic> mutations and demonstrates two locus transmission of craniosynostosis.", "type": "paragraph"}, {"text": "In contrast, common variants at the <italic>BBS9</italic> locus that also showed strong association with midline craniosynostosis in case-control analysis (OR > 4) (<xref ref-type=\"bibr\" rid=\"bib18\">Justice et al., 2012</xref>) showed no significant interaction with <italic>SMAD6</italic> (TDT p=0.89; <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1B</xref>), demonstrating specificity of the observed interaction of rare variants in <italic>SMAD6</italic> and a common variant near <italic>BMP2</italic>.", "type": "paragraph"}, {"text": "Lastly, we compared the joint segregation of rare damaging <italic>SMAD6</italic> and common <italic>BMP2</italic> risk alleles to the segregation of craniosynostosis in a parametric two locus linkage model in these kindreds (see Materials and methods, <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1C</xref>). The results provided extremely strong evidence supporting linkage under a two locus model, with a maximum lod score of 7.37 (odds ratio 2.3 \u00d7 10<sup>7</sup>:1 in favor of linkage compared to the null hypothesis; family-specific lod scores are shown in <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1D</xref>). The maximum likelihood model specified 100% penetrance of craniosynostosis when risk alleles at both loci are present, 9% penetrance when only a damaging <italic>SMAD6</italic> allele is present, 0.08% or 0.32% penetrance when only one or two <italic>BMP2</italic> risk alleles are present, and a 0.02% phenocopy rate, with zero recombination between trait and both marker loci. This two locus model was 1410 \u2013 fold more likely than than the best single locus model, in which damaging <italic>SMAD6</italic> variants had penetrance of 20%. These results provide extremely strong statistical support for the two locus model by linkage and extends the genetic evidence beyond simple association to linkage within pedigrees, which is not susceptible to potential confounders such as population stratification, and is insensitive to misspecification of allele frequency.", "type": "paragraph"}], "type": "section", "id": "s2-3", "title": "Incomplete penetrance of <italic>SMAD6</italic> mutations explained by a common variant near <italic>BMP2</italic>"}, {"content": [{"text": "Previous research has implicated increased activity of the MAP kinase/ERK pathway in craniosynostosis (<xref ref-type=\"bibr\" rid=\"bib39\">Twigg et al., 2013</xref>; <xref ref-type=\"bibr\" rid=\"bib36\">Shukla et al., 2007</xref>). We identified one de novo LOF in both <italic>SPRY1</italic> and <italic>SPRY4,</italic> developmental regulators of the MAP kinase/ERK pathway; these variants comprised two of only 11 de novo LOFs other than those in <italic>SMAD6</italic>. The <italic>SPRY4</italic> mutation (p.E160*) arose de novo in a proband with sagittal craniosynostosis and no family history (<xref ref-type=\"fig\" rid=\"fig6\">Figure 6a</xref>). The <italic>SPRY1</italic> mutation (p.Q6fs*8) was de novo in a woman with mild cranial dysmorphism who did not undergo surgery, and was transmitted to both of her children, who both had sagittal craniosynostosis (<xref ref-type=\"fig\" rid=\"fig6\">Figure 6b</xref>). The probability of observing two or more de novo LOF mutations in any of the 4 Sprouty genes by chance in this cohort surpassed genome-wide significance (p=7.1 \u00d7 10<sup>\u20137</sup>, <xref ref-type=\"table\" rid=\"tbl2\">Table 2</xref>). Consistent with a role for <italic>SPRY1</italic> haploinsufficiency, a de novo microdeletion that included <italic>SPRY1</italic> has previously been reported in a child with sagittal craniosynostosis (<xref ref-type=\"bibr\" rid=\"bib9\">Fern\u00e1ndez-Ja\u00e9n et al., 2014</xref>). Moreover, in mice with <italic>TWIST1</italic> haploinsufficiency, a model of syndromic craniosynostosis, overexpression of <italic>SPRY1</italic> prevents suture fusion (<xref ref-type=\"bibr\" rid=\"bib3\">Connerney et al., 2008</xref>). Lastly, protein altering de novo mutations were also identified in other regulators and mediators of MAP kinase signaling, including <italic>RASAL2, DUSP5, MAP3K8, KSR2, RPS6KA4</italic>, and <italic>RGS3</italic>. 5 of 6 occurred in probands with sagittal craniosynostosis (<xref ref-type=\"supplementary-material\" rid=\"SD1-data\">Table 1\u2014source data 1</xref>). Determining the significance of these findings will require further study.", "type": "paragraph"}, {"doi": "10.7554/eLife.20125.022", "title": "De novo loss-of-function mutations in Sprouty genes.", "uri": "https://example.org/elife-20125-fig6-v3", "label": "Figure 6.", "caption": [{"text": "(<bold>a</bold>) Pedigree and Sanger sequencing traces for kindred SAG150, demonstrating a de novo nonsense mutation in <italic>SPRY4</italic> (p.E160*) in the proband. (<bold>b</bold>) Pedigree and Sanger sequencing traces in a kindred with a de novo <italic>SPRY1</italic> frameshift mutation (p.Q6fs*8) that was transmitted to two affected offspring.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" xlink:href=\"10.7554/eLife.20125.022\">http://dx.doi.org/10.7554/eLife.20125.022</ext-link>", "type": "paragraph"}], "alt": "", "type": "image", "id": "fig6"}], "type": "section", "id": "s2-4", "title": "Mutations in MAP kinase regulators"}], "type": "section", "id": "s2", "title": "Results"}, {"content": [{"text": "These findings implicate a two locus model of inheritance in non-syndromic midline craniosynostosis via epistatic interactions of rare heterozygous <italic>SMAD6</italic> mutations and common risk alleles near <italic>BMP2</italic>. There is extremely strong evidence implicating each locus independently, along with highly significant evidence from both analysis of association and linkage that the risk of craniosynostosis is markedly increased in individuals carrying risk alleles at both loci compared to those with only a single risk allele at either locus. Rare damaging variants in <italic>SMAD6</italic> alone impart very large effects on disease risk with low penetrance, with inheritance at <italic>BMP2</italic> explaining nearly all of the variation in occurrence of craniosynostosis seen among <italic>SMAD6</italic> mutation carriers. The results support a threshold effect model, with quantitative increases in SMAD signaling resulting from reduced inhibition of SMAD signaling by SMAD6, owing to haploinsufficiency (strongly supported by a plethora of LOF variants distributed across <italic>SMAD6</italic>), along with a putative increase in SMAD signaling owing to increased BMP2 expression via the risk SNP rs1884302 leading to accelerated closure of midline sutures. Consistent with this model, as articulated previously, substantial prior evidence in mouse and human has implicated BMP signaling via SMADs in closure of the midline sutures, and <italic>SMAD6</italic> in inhibiting this pathway. Moreover, consistent with the common variant near <italic>BMP2</italic> modifying BMP2 expression, duplication of a nearby limb-specific enhancer increased BMP2 expression, leading to a Mendelian limb defect (<xref ref-type=\"bibr\" rid=\"bib4\">Dathe et al., 2009</xref>). While the genetic data provide unequivocal support for the role of these two loci in midline craniosynostosis, and for haploinsufficiency as the mechanism of <italic>SMAD6</italic> contribution, further studies will be necessary to delineate the precise mechanism by which the risk genotypes cause disease.", "type": "paragraph"}, {"text": "<italic>SMAD6</italic> mutations with and without <italic>BMP2</italic> risk alleles account for ~7% of probands in this cohort of non-syndromic midline craniosynostosis. This frequency is much greater than any other genotype causing syndromic midline craniosynostosis (e.g., <italic>TGFBR1/2, SKI, RUNX2</italic>), which are sufficiently rare that their prevalence has not been well-established. Moreover, because non-syndromic sagittal and metopic craniosynostosis comprise half of all craniosynostoses (<xref ref-type=\"bibr\" rid=\"bib38\">Slater et al., 2008</xref>; <xref ref-type=\"bibr\" rid=\"bib12\">Greenwood et al., 2014</xref>), <italic>SMAD6/BMP2</italic> genotypes are inferred to account for ~3.5% of all craniosynostosis, and are likely rivaled in frequency only by mutations in <italic>FGFR2</italic> as the most frequent cause of all craniosynostoses (<xref ref-type=\"bibr\" rid=\"bib40\">Twigg and Wilkie, 2015</xref>).", "type": "paragraph"}, {"text": "These findings will be of immediate utility in clinical diagnosis and genetic counseling. The combination of a rare damaging <italic>SMAD6</italic> mutation plus a common <italic>BMP2</italic> risk allele conferred 100% risk of craniosynostosis in our cohort, while those with a <italic>SMAD6</italic> mutation but no <italic>BMP2</italic> risk allele were at markedly lower risk. Interestingly, these <italic>SMAD6</italic> mutation-only cases thus far have all had isolated metopic craniosynostosis (<xref ref-type=\"fig\" rid=\"fig2\">Figure 2</xref>). Rare damaging SMAD6 mutations were found in nearly 25% of kindreds with recurrent midline craniosynostosis, and 37.5% of patients with combined sagittal and metopic craniosynostosis in our cohort. The precision of penetrance estimates and prevalence in specific disease subsets will improve with larger sample sizes.", "type": "paragraph"}, {"text": "Given the suggestion of a threshold for phenotypic effect, we also considered whether there might be additional <italic>SMAD6</italic> alleles that impart phenotypic effect that have a\u00a0higher frequency than the 2 \u00d7 10<sup>\u20135</sup> threshold that we used. We found only one additional <italic>SMAD6</italic> damaging allele among parents in our cohort with allele frequency <0.001. Interestingly, this allele, p.E287K, (ExAC frequency 3.3 \u00d7 10<sup>\u20135</sup>) was transmitted to a proband with sagittal and metopic craniosynostosis along with two doses of the <italic>BMP2</italic> risk allele, each inherited from a heterozygous parent.", "type": "paragraph"}, {"text": "Considering neurodevelopmental outcomes, 11 of 15 subjects with rare damaging <italic>SMAD6</italic> variants who are more than one year of age (and hence can have neurodevelopmental evaluation) had some form of developmental delay (<xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1E</xref>). While early surgical intervention provides the best neurological outcomes (<xref ref-type=\"bibr\" rid=\"bib28\">Patel et al., 2014</xref>), more than a third of patients with non-syndromic midline craniosynostosis have subtle learning disability (<xref ref-type=\"bibr\" rid=\"bib23\">Magge et al., 2002</xref>; <xref ref-type=\"bibr\" rid=\"bib35\">Shipster et al., 2003</xref>; <xref ref-type=\"bibr\" rid=\"bib37\">Sidoti et al., 1996</xref>). BMP signaling plays an essential role in vertebrate brain development (<xref ref-type=\"bibr\" rid=\"bib1\">Bier and De Robertis, 2015</xref>), raising the possibility that aberrant BMP signaling could contribute to neurodevelopmental outcome independent of its effect on craniosynostosis. The only other clinical finding observed in more than one subject with <italic>SMAD6</italic> mutation was a\u00a0congenital inguinal hernia in 3 patients (16.7%; <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1E</xref>).", "type": "paragraph"}, {"text": "While <italic>SMAD6</italic> was the only single gene showing genome-wide significant burden of de novo mutation, de novo protein-altering mutations are estimated to contribute to ~15% of cases. This estimated fraction is similar to estimates for autism and congenital heart disease, other diseases in which large-scale studies have shown a role for de novo mutations (<xref ref-type=\"bibr\" rid=\"bib14\">Homsy et al., 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib15\">Iossifov et al., 2014</xref>; <xref ref-type=\"bibr\" rid=\"bib33\">Sanders et al., 2012</xref>; <xref ref-type=\"bibr\" rid=\"bib45\">Zaidi et al., 2013</xref>; <xref ref-type=\"bibr\" rid=\"bib5\">De Rubeis et al., 2014</xref>). Also like autism and congenital heart disease, few individual genes were implicated after sequencing modest numbers of trios, implying that de novo mutation in a large number of genes are likely to contribute to sagittal and metopic craniosynostosis. This observation strongly supports sequencing substantially larger numbers of non-syndromic patients, an approach that has proved highly productive for discovery of genes and pathways underlying autism and CHD.", "type": "paragraph"}, {"text": "Lastly, these results provide a clear example of the epistatic (non-additive) interaction of very rare mutations at one locus with a common variant at a second, unlinked locus. This observation adds to the small number of two locus phenotypes that have been defined with robust genetic data (<xref ref-type=\"bibr\" rid=\"bib22\">Lupski, 2012</xref>), and suggest that other common variants, particularly those with relatively large effect, may combine with rare alleles at one or more loci to produce genotypes with high penetrance that together may account for a substantial fraction of disease risk.", "type": "paragraph"}], "type": "section", "id": "s3", "title": "Discussion"}, {"content": [{"content": [{"text": "Participants were ascertained from either the Yale Pediatric Craniofacial Clinic or by responding to an invitation posted on the Cranio Kids- Craniosynostosis Support and Craniosynostosis-Positional Plagiocephaly Support Facebook pages. All participants or their parents provided written informed consent to participate in a study of the\u00a0genetic causes of craniosynostosis in their family. Inclusion criteria included a\u00a0diagnosis of sagittal and/or metopic craniosynostosis in the absence of known syndromic forms of disease by a craniofacial plastic surgeon or pediatric neurosurgeon. All probands had undergone reconstructive surgery. Participating family members provided buccal swab samples (Isohelix SK-2S buccal swabs), craniofacial phenotype data, medical records, operative reports, and imaging studies. Written consent was obtained for publication of patient photographs. The study protocol was approved by the Yale Human Investigation Committee Institutional Review Board (IRB).", "type": "paragraph"}, {"text": "Control cohorts comprised 3337 previously studied healthy European parents of probands with autism, Europeans found in the NHLBI Exome Sequencing Project database (NHLBI), and Non-Finnish Europeans found in the Exome Aggregation Consortium v0.3 database (ExAC).", "type": "paragraph"}], "type": "section", "id": "s4-1", "title": "Subjects and samples"}, {"content": [{"text": "DNA was prepared from buccal swab samples according to the manufacturer\u2019s protocol. Exome sequencing was performed by exon capture using the Roche MedExome or Roche V2 capture reagent followed by 74 base paired-end sequencing on the Illumina HiSeq 2000 instrument as previously described (<xref ref-type=\"bibr\" rid=\"bib45\">Zaidi et al., 2013</xref>). Samples were barcoded then captured and sequenced in multiplex. Quality metrics are shown in <xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1A</xref>.", "type": "paragraph"}, {"text": "Sequence reads were aligned to the GRCh37/hg19 human reference genome using BWA-Mem. Local realignment and quality score recalibration were performed using the GATK pipeline, after which variants were called using the Genome Analysis Toolkit Haplotype Caller. A Bayesian algorithm, TrioDeNovo, was used to call de novo mutations (<xref ref-type=\"bibr\" rid=\"bib43\">Wei et al., 2015</xref>). VQSR \"PASS\" variants with ExAC allele frequency \u22640.001 sequenced to a depth of 8 or greater in the proband and 12 or greater in each parent with Phred-scaled genotype likelihood scores >30 and de novo quality scores (log<sub>10</sub>(Bayes factor)) >6 were considered. Independent aligned reads at variant positions were visualized in silico to remove false calls (<xref ref-type=\"fig\" rid=\"fig2s1\">Figure 2\u2014figure supplement 1</xref>). For de novo calls passing visual inspection, variants receiving the highest de novo genotype quality score (100) were deemed valid. Forty of these de novo mutations were selected at random for validation by bidirectional Sanger sequencing of the proband and both parents; 100% of these tests confirmed de novo mutation in the proband. The observed number of de novo variants identified per trio closely matched the expected Poisson distribution (<xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1F</xref>). All de novo variants named in the main text were confirmed by Sanger sequencing. Transmitted variants were similarly aligned and called as per above. All de novo and transmitted variants were annotated using ANNOVAR (<xref ref-type=\"bibr\" rid=\"bib41\">Wang et al., 2010</xref>). Allele frequencies of identified variants were taken from the ExAC database. The impact of nonsynonymous variants was predicted using the MetaSVM rank score, with scores greater than 0.83357 serving as a threshold for predicting that the mutation was deleterious (MetaSVM 'D', D-mis) (<xref ref-type=\"bibr\" rid=\"bib6\">Dong et al., 2015</xref>). For case control burden analysis of all protein coding genes, all GATK VQSR 'PASS' variants were considered.", "type": "paragraph"}, {"text": "In assessing the association of known risk alleles near <italic>BMP2</italic> and within <italic>BBS9</italic> with craniosynostosis in <italic>SMAD6</italic> mutation carriers, genotypes for rs1884302 and rs10262453 were determined by direct Sanger sequencing.", "type": "paragraph"}, {"text": "All mutations reported in <italic>SMAD6, SMURF1, SPRY1</italic>, and <italic>SPRY4</italic> were confirmed by direct bidirectional Sanger sequencing of the products of PCR amplification of segments containing putative mutations (<xref ref-type=\"fig\" rid=\"fig2s2\">Figure 2\u2014figure supplement 2</xref>, <xref ref-type=\"fig\" rid=\"fig5\">Figure 5</xref>, <xref ref-type=\"fig\" rid=\"fig6\">Figure 6</xref>). PCR primers are listed in <xref ref-type=\"supplementary-material\" rid=\"SD3-data\">Figure 2\u2014source data 2</xref>. Sanger sequencing electropherograms were manually inspected using Geneious after alignment to the reference genome sequence in GRCh37/hg19.", "type": "paragraph"}], "type": "section", "id": "s4-2", "title": "Exome sequencing, risk allele genotyping, and analysis"}, {"content": [{"text": "The observed distribution of mutation type was compared to pre-computed expected values across the exome using Poisson statistics as described (<xref ref-type=\"bibr\" rid=\"bib42\">Ware et al., 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib14\">Homsy et al., 2015</xref>). Pre-calculated gene-specific mutation probabilities were used to determine the probability of the observed number and type of de novo mutations in <italic>SMAD6</italic> occurring by chance using denovolyzeR (<xref ref-type=\"bibr\" rid=\"bib42\">Ware et al., 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib32\">Samocha et al., 2014</xref>).\u00a0To assess the probability of observing 3 protein damaging mutations, P values for observing 2 de novo LOF\u2019s and one de novo missense mutation were combined using the\u00a0Fisher\u2019s combined probability test. To assess the burden of de novo mutation in Sprouty genes, a gene set was curated in denovolyzeR including: <italic>SPRY1, SPRY2, SPRY3, SPRY4</italic>. The probability of observing 2 de novo LOF mutations in this gene set was calculated by comparing this number to expectation in denovolyzeR. The probability of observing more than one de novo LOF mutation in any gene in our cohort was determined using a permutation function- denovolyzeMultiHits() (<xref ref-type=\"bibr\" rid=\"bib42\">Ware et al., 2015</xref>). In total, 13 de novo LOF variants were observed in our cohort. The probability of observing >1 de novo LOF in any gene by chance with a set of 13 mutations was determined by 1 million iterations in which these 13 \u2018hits\u2019 were sampled from all genes given the probability of de novo mutation in each (<xref ref-type=\"bibr\" rid=\"bib14\">Homsy et al., 2015</xref>). The number of times any gene had more than one hit in an iteration was counted, and that number divided by 1 million represented the probability of observing more than one de novo LOF mutation in our cohort.", "type": "paragraph"}], "type": "section", "id": "s4-3", "title": "Burden of de novo mutations"}, {"content": [{"text": "We infer that the number of probands with protein altering de novo mutations (n\u00a0=\u00a0123) in excess of expectation by chance (n\u00a0=\u00a0102.4) represents the number of subjects in whom these mutations confer craniosynostosis risk (n\u00a0=\u00a020.6). Comparing this fraction to the total number of trios (20.6/132) yields the fraction of patients in our cohort in whom we expect these mutations contribute to disease: ~15.6%.", "type": "paragraph"}], "type": "section", "id": "s4-4", "title": "Contribution of de novo mutation to craniosynostosis"}, {"content": [{"text": "The observed distribution of rare (ExAC frequency <2 \u00d7 10<sup>\u20135</sup>) LOF and D-mis alleles was compared to the expected distribution using the binomial test. The total number of LOF and D-mis alleles in 191 probands was tabulated, totaling 1135 LOF alleles and 2021 D-mis alleles (3156 total damaging alleles). The expected number of variants in each gene was calculated from the proportion of the exome comprising the coding region of each gene multiplied by the total number of alleles identified in cases. Enrichment was calculated as the number of observed mutations divided by the expected number.", "type": "paragraph"}], "type": "section", "id": "s4-5", "title": "Binomial test"}, {"content": [{"text": "We used a transmission disequilibrium test to compare the transmission (M<sub>1</sub>) and non-transmission (M<sub>2</sub>) of <italic>BMP2</italic> and <italic>BBS9</italic> risk alleles (rs1884302 and rs10262453 respectively) to affected offspring in kindreds with <italic>SMAD6</italic> mutations. We tested for deviation from the expected transmission value of 50% by the binomial Chi-square test with 1 Df.", "type": "paragraph"}], "type": "section", "id": "s4-6", "title": "Transmission disequilibrium test"}, {"content": [{"text": "A fisher exact test was used to compare the prevalence of LOF or LOF+D-mis variants in 172 craniosynostosis probands and 3337 controls, the latter comprising the unaffected parents of offspring with autism. Controls were exome sequenced on the Roche V2 capture reagent followed by sequencing on the Illumina platform (<xref ref-type=\"bibr\" rid=\"bib33\">Sanders et al., 2012</xref>; <xref ref-type=\"bibr\" rid=\"bib20\">Krumm et al., 2015</xref>; <xref ref-type=\"bibr\" rid=\"bib16\">Iossifov et al., 2012</xref>). All control BAM files were processed with sequences aligned and variants called in parallel to aforementioned cases. Cases and controls, on average, both had ~94\u201395% of targeted bases read 8 or more times (<xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1A</xref>). We restricted cases and controls to European (CEU) ancestry using the EIGENSTRAT program, which compared single nucleotide polymorphism (SNP) genotypes from case and control subjects with individuals of known ancestry in HapMap3 (<xref ref-type=\"bibr\" rid=\"bib11\">Frazer et al., 2007</xref>) (<xref ref-type=\"fig\" rid=\"fig3s2\">Figure 3\u2014figure supplement 2</xref>). To avoid bias, exons analyzed were restricted to those that intersected between the Roche V2 and MedExome capture reagents. For genes with more than 1 LOF or D-mis variant in cases, aligned reads were visualized in silico at all variant positions in both cases and controls. For genes displaying p<0.005, we compared the burden of mutated alleles in cases to European subjects in the NHLBI ESP and ExAC databases. The total number of alleles evaluated per gene was taken as the median of the allele numbers reported for all positions across a gene in NHLBI and ExAC respectively (<xref ref-type=\"supplementary-material\" rid=\"SD4-data\">Figure 3\u2014source data 1</xref>).", "type": "paragraph"}], "type": "section", "id": "s4-7", "title": "Case vs. control comparison"}, {"content": [{"text": "Parametric two locus linkage analysis was performed comparing the segregation of rare damaging <italic>SMAD6</italic> alleles and common <italic>BMP2</italic> risk alleles at rs1884302 to the segregation of craniosynostosis in kindreds harboring rare damaging <italic>SMAD6</italic> variants. Risk alleles at both loci were specified as showing zero recombination with underlying trait loci; risk/penetrance of each two locus genotype was estimated from their values at the maximum likelihood (<xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1C</xref>). A phenocopy rate of\u00a00.02% was specified from estimates of disease prevalence and the fraction of disease attributable to risk genotypes. Likelihood ratios of the observed results occurring under the specified model vs. the alternative of chance were calculated for each kindred, converted to lod scores (<xref ref-type=\"supplementary-material\" rid=\"SD5-data\">Supplementary file 1D</xref>) and the sum of lod scores across all kindreds was calculated. For kindreds (n = 2) with missing parental genotypes, the likelihood ratio of observed genotypes in offspring occurring under the parametric model compared to chance was estimated from ethnic-specific <italic>BMP2</italic> genotype frequencies and frequencies of rare damaging <italic>SMAD6</italic> alleles in missing parental genotypes. The likelihood ratio of the best two locus model was compared to that of the best single locus model considering only the segregation of rare damaging <italic>SMAD6</italic> variants.", "type": "paragraph"}], "type": "section", "id": "s4-8", "title": "Two locus linkage analysis"}, {"content": [{"text": "Kinship analysis was performed for all probands and controls using Plink. All trio structures were confirmed with parent-offspring pairs having PiHat values of 0.45\u20130.55.", "type": "paragraph"}], "type": "section", "id": "s4-9", "title": "Kinship analysis"}, {"content": [{"text": "GATK: (<ext-link ext-link-type=\"uri\" xlink:href=\"https://www.broadinstitute.org/gatk\">https://www.broadinstitute.org/gatk</ext-link>); TrioDeNovo: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://genome.sph.umich.edu/wiki/Triodenovo\">http://genome.sph.umich.edu/wiki/Triodenovo</ext-link>); DenovolyzeR: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://denovolyzer.org\">http://denovolyzer.org</ext-link>); Plink: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://pngu.mgh.harvard.edu/~purcell/plink\">http://pngu.mgh.harvard.edu/~purcell/plink</ext-link>); MetaSVM/ANNOVAR: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://annovar.openbioinformatics.org\">http://annovar.openbioinformatics.org</ext-link>); NHLBI ESP: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://evs.gs.washington.edu/EVS\">http://evs.gs.washington.edu/EVS</ext-link>); ExAC03: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://exac.broadinstitute.org\">http://exac.broadinstitute.org</ext-link>); Geneious: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://www.geneious.com\">www.geneious.com</ext-link>). Isohelix Buccal Swab DNA isolation: (<ext-link ext-link-type=\"uri\" xlink:href=\"http://www.isohelix.com/wp-content/uploads/2015/09/BuccalFixIsoKit.pdf\">http://www.isohelix.com/wp-content/uploads/2015/09/BuccalFixIsoKit.pdf</ext-link>).", "type": "paragraph"}], "type": "section", "id": "s4-10", "title": "URLs"}, {"content": [{"text": "Whole-exome sequencing data have been deposited in the database of Genotypes and Phenotypes (dbGaP) under accession phs000744. NCBI RefSeq accessions for all named genes are listed in <xref ref-type=\"supplementary-material\" rid=\"SD1-data\">Table 1\u2014source data 1</xref>.", "type": "paragraph"}], "type": "section", "id": "s4-11", "title": "Accession codes"}], "type": "section", "id": "s4", "title": "Materials and methods"}], "versionDate": "2016-01-01T00:00:00Z", "abstract": {"content": [{"text": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging de novo or rare transmitted mutations in <italic>SMAD6</italic>, an inhibitor of BMP \u2013 induced osteoblast differentiation (p<10<sup>\u221220</sup>). <italic>SMAD6</italic> mutations nonetheless showed striking incomplete penetrance (<60%). Genotypes of a common variant near <italic>BMP2</italic> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" href=\"10.7554/eLife.20125.001\">http://dx.doi.org/10.7554/eLife.20125.001</ext-link>", "type": "paragraph"}], "doi": "10.7554/eLife.20125.001"}, "keywords": ["craniosynostosis", "craniofacial", "exome sequencing", "human genetics", "de novo mutation", "incomplete penetrance", "SMAD6", "BMP2", "SMURF1", "SPRY1", "SPRY4"], "subjects": [{"id": "genes-chromosomes", "name": "Genes and Chromosomes"}, {"id": "genomics-evolutionary-biology", "name": "Genomics and Evolutionary Biology"}], "digest": {"content": [{"text": "The bones in the front, back and sides of the human skull are not fused to one another at birth in order to allow the brain to double in size during the first year of life and continue growing into adulthood. However, one in 2,000 infants is born with a condition called craniosynostosis in which some of these bones have already fused. This fusion prevents the skull from growing properly, and can lead to the brain becoming compressed. As such, surgeons routinely undo the fusion in these infants to allow the brain and skull to grow normally.", "type": "paragraph"}, {"text": "Eighty-five percent of craniosynostosis cases occur in infants with no other abnormalities, (called non-syndromic cases) and most have no other affected family member. It has therefore been unclear whether these infants have craniosynostosis due to a genetic or non-genetic cause. If the cause is genetic, it is also not clear whether a mutation in a single gene, the combined effects of many genes, or something in between is responsible.", "type": "paragraph"}, {"text": "Now, by focusing on a group of 191 infants with premature fusion of bones joined at the midline of the skull, Timberlake et al. asked if any of the approximately 20,000 genes in the human genome were altered more frequently in these infants than would be expected by chance. This search revealed that rare mutations that disable one copy of a gene called <italic>SMAD6</italic> in combination with a common DNA variant near another gene called <italic>BMP2</italic> account for about 7% of infants with midline forms of craniosynostosis. These genes are both known to regulate how bones form, which explains how the mutation of these genes could lead to craniosynostosis.", "type": "paragraph"}, {"text": "In all cases, the parents of these children were unaffected. This was typically because one parent had only the <italic>SMAD6</italic> mutation while the other had only the common <italic>BMP2</italic> variant; the transmission of both to their offspring resulted in craniosynostosis. The finding that a rare mutation\u2019s effect is strongly modified by a common variant from another site in the genome is unprecedented. These findings will allow doctors to counsel families about the risk of having additional children with craniosynostosis.", "type": "paragraph"}, {"text": "Timberlake et al. next plan to study more patients with craniosynostosis to identify additional genes that contribute to this disease. They will also look at other diseases to see whether the combination of rare mutation and common DNA variant could be behind other unexplained disorders.", "type": "paragraph"}, {"text": "<bold>DOI:</bold> <ext-link ext-link-type=\"doi\" href=\"10.7554/eLife.20125.002\">http://dx.doi.org/10.7554/eLife.20125.002</ext-link>", "type": "paragraph"}], "doi": "10.7554/eLife.20125.002"}, "decisionLetter": {"content": [{"text": "Congratulations: we are very pleased to inform you that your article, \"Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles\", has been accepted for publication in <italic>eLife</italic>. The Reviewing Editor for your submission was David Ginsburg. The additional reviewers, who have also agreed to reveal their identities were: Yuji Mishina and James Lupski.", "type": "paragraph"}, {"text": "If you have selected our \"Publish on Acceptance\" option, your PDF will be published within a few days; if you have opted out of the \"Publish on Acceptance\" option, your work will be published in about four weeks' time.", "type": "paragraph"}, {"text": "The reviewers concluded that: this manuscript reports very convincing data demonstrating epistatic interaction between rare loss of function mutations in SMAD6 and a common variant near the BMP2 locus as the genetic etiology of craniosynostosis in a subset of nonsyndromic patients. The data are of very high quality, the manuscript clearly written, and the conclusions convincingly supported by the data. The investigators performed whole exome sequencing (WES) of 132 parent-offspring trios and 59 additional probands. Seven percent of probands had damaging de novo or rare transmitted mutations in SMAD6; an inhibitor of BMP \u2013 induced osteoblast differentiation (P <10-20). Interestingly, SMAD6 mutations showed striking incomplete penetrance for the craniosynostosis trait (<60%). Genotypes of a common variant near BMP2, previously shown to be strongly associated with midline craniosynostosis, explained nearly all of the phenotypic variance in these kindred. Thus, these findings clearly documented digenic inheritance via epistatic interactions of rare and common variants as a defining feature of the most frequent cause of midline craniosynostosis. This work has very important implications for the genetic basis of other disease traits and reveals a potential mechanism for common variant genetic effects to markedly influence the manifestation of disease.", "type": "paragraph"}, {"text": "None of the reviewers had any major suggestions for required revision/correction. However, a few minor points/questions were raised, as listed below, which the reviewers all agreed could be addressed by minor changes to the text (or none), as the authors see fit.", "type": "paragraph"}, {"text": "Minor points:", "type": "paragraph"}, {"text": "1) Subsection \"Exome sequencing of non-syndromic midline craniosynostosis\": the authors \"infer that these de novo mutations contribute to ~15% of non-syndromic midline craniosynostosis\". How was this figure calculated?", "type": "paragraph"}, {"text": "2) The authors note that SMAD6 knockout mice exhibit skull abnormalities reminiscent of craniosynostosis (Estrada et al., 2011 and Retting, 2008). Is there a heterozygous phenotype in the mice? Though clearly beyond the scope of the current manuscript, it will be interesting to see whether genetic interaction between BMP2 gain-of-function and SMAD6 haploinsufficiency can be demonstrated in the mouse.", "type": "paragraph"}, {"text": "3) Though 2 previously identified GWAS hits for nonsyndromic craniosynostosis, one (BMP2) modifies SMAD6 haploinsufficiency, whereas the other (BBS9) does not, despite similar large effect sizes for both variants. Could the authors speculate about a potential similar epistatic interaction of BBS9 with rare variant in another gene(s) in a different subset of craniosynostosis patients?", "type": "paragraph"}, {"text": "4) Though most of the identified SMAD6 mutations would generate clear loss-of-function, two of them are located near the C-terminus (i.e. R465C and I490T). Have any specific functions been ascribed to this region of the molecule?", "type": "paragraph"}, {"text": "5) SMAD7 is another inhibitory Smad that affects both BMP and TGF-\u03b2 pathways. Although a craniofacial phenotype is not appreciated in Smad7 mutant mice, they show similar skeletal phenotypes to Smad6 knockouts. One would think mutations in SMAD7 might also interact with the BMP2 risk allele. Does the lack of SMAD7 mutations in their patient cohort, suggest a particularly unique role for SMAD6 in midline craniosynostosis?", "type": "paragraph"}, {"text": "6) Discussion, paragraph 5: \"The only other clinical finding found[\u2026]\" could be reworded as \"finding present\" or \"observed\".", "type": "paragraph"}], "doi": "10.7554/eLife.20125.028", "description": [{"text": "In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.", "type": "paragraph"}]}, "copyright": {"holder": "Timberlake et al", "statement": "This article is distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use and redistribution provided that the original author and source are credited.", "license": "CC-BY-4.0"}, "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", "authorLine": "Andrew T Timberlake et al", "id": "20125", "version": 3, "statusDate": "2016-01-01T00:00:00Z", "type": "research-article", "status": "vor", "impactStatement": "Epistatic interactions of rare loss of function mutations in <italic>SMAD6</italic> and a common variant modifier near <italic>BMP2</italic> are the most common cause of midline craniosynostosis in humans.", "volume": 5, "researchOrganisms": ["Human"], "authors": [{"name": {"index": "Timberlake, Andrew T", "preferred": "Andrew T Timberlake"}, "competingInterests": "The authors declare that no competing interests exist.", "affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "orcid": "0000-0002-8926-9692", "contribution": "ATT, Recruited and enrolled patients, collected genetic specimens, performed SNP genotyping and Sanger sequencing, performed genetic analyses, wrote the manuscript", "type": "person"}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "JC, Performed genetic analyses", "type": "person", "name": {"index": "Choi, Jungmin", "preferred": "Jungmin Choi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "SZ, Performed genetic analyses", "type": "person", "name": {"index": "Zaidi, Samir", "preferred": "Samir Zaidi"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "QL, Performed genetic analyses", "type": "person", "name": {"index": "Lu, Qiongshi", "preferred": "Qiongshi Lu"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "CN-W, Performed SNP genotyping and Sanger sequencing, performed genetic analyses", "type": "person", "name": {"index": "Nelson-Williams, Carol", "preferred": "Carol Nelson-Williams"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "EDB, Recruited and enrolled patients, collected genetic specimens", "type": "person", "name": {"index": "Brooks, Eric D", "preferred": "Eric D Brooks"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "KB, Directed exome sequence production", "type": "person", "name": {"index": "Bilguvar, Kaya", "preferred": "Kaya Bilguvar"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "IT, Directed exome sequence production", "type": "person", "name": {"index": "Tikhonova, Irina", "preferred": "Irina Tikhonova"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "SM, Directed exome sequence production", "type": "person", "name": {"index": "Mane, Shrikant", "preferred": "Shrikant Mane"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "JFY, Recruited and enrolled patients, collected genetic specimens", "type": "person", "name": {"index": "Yang, Jenny F", "preferred": "Jenny F Yang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "RS-M, Contributed clinical evaluations", "type": "person", "name": {"index": "Sawh-Martinez, Rajendra", "preferred": "Rajendra Sawh-Martinez"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "SP, Contributed clinical evaluations", "type": "person", "name": {"index": "Persing, Sarah", "preferred": "Sarah Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "EGZ, Contributed clinical evaluations", "type": "person", "name": {"index": "Zellner, Elizabeth G", "preferred": "Elizabeth G Zellner"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "EL, Recruited and enrolled patients", "type": "person", "name": {"index": "Loring, Erin", "preferred": "Erin Loring"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "CC, Collected genetic specimens", "type": "person", "name": {"index": "Chuang, Carolyn", "preferred": "Carolyn Chuang"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Craniosynostosis and Positional Plagiocephaly Support"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "contribution": "AG, Recruited and enrolled patients", "type": "person", "name": {"index": "Galm, Amy", "preferred": "Amy Galm"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "PWH, Collected genetic specimens", "type": "person", "name": {"index": "Hashim, Peter W", "preferred": "Peter W Hashim"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "DMS, Contributed clinical evaluations", "type": "person", "name": {"index": "Steinbacher, Derek M", "preferred": "Derek M Steinbacher"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "MLD, Contributed clinical evaluations", "type": "person", "name": {"index": "DiLuna, Michael L", "preferred": "Michael L DiLuna"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Neurosurgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "CCD, Contributed clinical evaluations", "type": "person", "name": {"index": "Duncan, Charles C", "preferred": "Charles C Duncan"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Child Study Center", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "KAP, Recruited and enrolled patients", "type": "person", "name": {"index": "Pelphrey, Kevin A", "preferred": "Kevin A Pelphrey"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Department of Biostatistics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "HZ, Performed genetic analyses", "type": "person", "name": {"index": "Zhao, Hongyu", "preferred": "Hongyu Zhao"}, "competingInterests": "The authors declare that no competing interests exist."}, {"affiliations": [{"name": ["Section of Plastic and Reconstructive Surgery, Department of Surgery", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}], "contribution": "JAP, Conceived, designed, and directed study, contributed clinical evaluations", "type": "person", "name": {"index": "Persing, John A", "preferred": "John A Persing"}, "competingInterests": "The authors declare that no competing interests exist."}, {"name": {"index": "Lifton, Richard P", "preferred": "Richard P Lifton"}, "competingInterests": "The authors declare that no competing interests exist.", "affiliations": [{"name": ["Department of Genetics", "Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Howard Hughes Medical Institute, Yale University School of Medicine"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["Yale Center for Genome Analysis"], "address": {"formatted": ["New Haven", "United States"], "components": {"country": "United States", "locality": ["New Haven"]}}}, {"name": ["The Rockefeller University"], "address": {"formatted": ["New York", "United States"], "components": {"country": "United States", "locality": ["New York"]}}}], "emailAddresses": ["richard.lifton@yale.edu"], "type": "person", "contribution": "RPL, Conceived, designed, and directed the study, performed genetic analyses, wrote the manuscript"}], "elocationId": "e20125", "authorResponse": {"content": [{"text": "<italic>1) Subsection \"Exome sequencing of non-syndromic midline craniosynostosis\": the authors \"infer that these de novo mutations contribute to ~15% of non-syndromic midline craniosynostosis\". How was this figure calculated?</italic> ", "type": "paragraph"}, {"text": "As discussed in the Methods section, among 132 probands, 123 had protein-altering <italic>de novo</italic> mutations, compared to an expected number of 102.4. Thus ~20 more probands (~15% of all probands) had protein-altering de novo mutations than expected by chance, suggesting that at least this fraction of probands has disease owing to <italic>de novo</italic> mutation.", "type": "paragraph"}, {"text": "<italic>2) The authors note that SMAD6 knockout mice exhibit skull abnormalities reminiscent of craniosynostosis (Estrada et al., 2011 and Retting, 2008). Is there a heterozygous phenotype in the mice? Though clearly beyond the scope of the current manuscript, it will be interesting to see whether genetic interaction between BMP2 gain-of-function and SMAD6 haploinsufficiency can be demonstrated in the mouse.</italic> ", "type": "paragraph"}, {"text": "There is no heterozygous phenotype described for <italic>SMAD6</italic> loss of function in mice. We agree that it will be interesting to determine the consequence in mice of combined <italic>BMP2</italic> gain of function with <italic>SMAD6</italic> loss of function.Titration of dosing of BMP2 will likely be important in such an experiment.", "type": "paragraph"}, {"text": "<italic>3) Though 2 previously identified GWAS hits for nonsyndromic craniosynostosis, one (BMP2) modifies SMAD6 haploinsufficiency, whereas the other (BBS9) does not, despite similar large effect sizes for both variants. Could the authors speculate about a potential similar epistatic interaction of BBS9 with rare variant in another gene(s) in a different subset of craniosynostosis patients?</italic>", "type": "paragraph"}, {"text": "This is an interesting point. We speculated in the manuscript that other common variants, particularly those with relatively large effects, may show similar epistatic interactions with rare variants. The common BBS9 risk variant, which clearly falls into this class, would be an excellent candidate for modifying risk of rare variants in another gene or genes.", "type": "paragraph"}, {"text": "<italic>4) Though most of the identified SMAD6 mutations would generate clear loss-of-function, two of them are located near the C-terminus (i.e. R465C and I490T). Have any specific functions been ascribed to this region of the molecule?</italic>", "type": "paragraph"}, {"text": "The C-terminus, which is part of the MH2 domain, is responsible for protein-protein interactions, including SMAD6\u2019s interaction with receptor-SMADs and BMP receptors themselves. It is possible that these variants impair SMAD6 binding to these signaling molecules, impairing inhibition of BMP/SMAD signaling.", "type": "paragraph"}, {"text": "<italic>5) SMAD7 is another inhibitory Smad that affects both BMP and TGF-beta pathways. Although a craniofacial phenotype is not appreciated in Smad7 mutant mice, they show similar skeletal phenotypes to Smad6 knockouts. One would think mutations in SMAD7 might also interact with the BMP2 risk allele. Does the lack of SMAD7 mutations in their patient cohort, suggest a particularly unique role for SMAD6 in midline craniosynostosis?</italic> ", "type": "paragraph"}, {"text": "Yes, the data would support this inference. It has been suggested that <italic>SMAD6</italic> is more specific to regulation of BMP signaling, whereas <italic>SMAD7</italic> is more specific for inhibition of TGFB-receptor - mediated SMAD signaling. Mutations in TGFBR1/2, and its downstream inhibitor SKI, have been shown to cause syndromic forms of craniosynostosis that also involve the cardiovascular system and are markedly more severe than the non-syndromic craniosynostosis phenotype resulting from SMAD6/BMP2 variants. It is thus possible that heterozygous loss of function mutations in <italic>SMAD7</italic> have a more extreme, potentially early lethal, phenotype than <italic>SMAD6</italic> mutations, accounting for why we have not seen these mutations in our cohort. Consistent with this possibility, zero heterozygous loss of function variants in <italic>SMAD7</italic> have been reported in the ExAC database.", "type": "paragraph"}, {"text": "<italic>6) Line 315: \"The only other clinical finding found[\u2026]\" could be reworded as \"finding present\" or \"observed\u201d.</italic>", "type": "paragraph"}, {"text": "We agree, thanks. We have changed the sentence to, 'The only other clinical finding observed[\u2026]'", "type": "paragraph"}], "doi": "10.7554/eLife.20125.029"}, "doi": "10.7554/eLife.20125", "published": "2016-09-08T00:00:00", "pdf": "elife-20125-v3.pdf"}, "journal": {"issn": "2050-084X", "id": "eLife", "title": "eLife"}}
+{
+    "snippet": {
+        "status": "vor", 
+        "doi": "10.7554/eLife.20125", 
+        "elocationId": "e20125", 
+        "impactStatement": "Epistatic interactions of rare loss of function mutations in <italic>SMAD6</italic> and a common variant modifier near <italic>BMP2</italic> are the most common cause of midline craniosynostosis in humans.", 
+        "copyright": {
+            "holder": "Timberlake et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", 
+        "authorLine": "Andrew T Timberlake et al", 
+        "abstract": {
+            "content": [
+                {
+                    "text": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging de novo or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP \u2013 induced osteoblast differentiation (p&lt;10<sup>\u221220</sup>). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", 
+                    "type": "paragraph"
+                }
+            ], 
+            "doi": "10.7554/eLife.20125.001"
+        }, 
+        "authors": [
+            {
+                "name": {
+                    "index": "Timberlake, Andrew T", 
+                    "preferred": "Andrew T Timberlake"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "orcid": "0000-0002-8926-9692", 
+                "contribution": "ATT, Recruited and enrolled patients, collected genetic specimens, performed SNP genotyping and Sanger sequencing, performed genetic analyses, wrote the manuscript", 
+                "type": "person"
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JC, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Choi, Jungmin", 
+                    "preferred": "Jungmin Choi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SZ, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Zaidi, Samir", 
+                    "preferred": "Samir Zaidi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "QL, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Lu, Qiongshi", 
+                    "preferred": "Qiongshi Lu"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CN-W, Performed SNP genotyping and Sanger sequencing, performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Nelson-Williams, Carol", 
+                    "preferred": "Carol Nelson-Williams"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EDB, Recruited and enrolled patients, collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Brooks, Eric D", 
+                    "preferred": "Eric D Brooks"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "KB, Directed exome sequence production", 
+                "type": "person", 
+                "name": {
+                    "index": "Bilguvar, Kaya", 
+                    "preferred": "Kaya Bilguvar"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "IT, Directed exome sequence production", 
+                "type": "person", 
+                "name": {
+                    "index": "Tikhonova, Irina", 
+                    "preferred": "Irina Tikhonova"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SM, Directed exome sequence production", 
+                "type": "person", 
+                "name": {
+                    "index": "Mane, Shrikant", 
+                    "preferred": "Shrikant Mane"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JFY, Recruited and enrolled patients, collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Yang, Jenny F", 
+                    "preferred": "Jenny F Yang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "RS-M, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Sawh-Martinez, Rajendra", 
+                    "preferred": "Rajendra Sawh-Martinez"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SP, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, Sarah", 
+                    "preferred": "Sarah Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EGZ, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Zellner, Elizabeth G", 
+                    "preferred": "Elizabeth G Zellner"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EL, Recruited and enrolled patients", 
+                "type": "person", 
+                "name": {
+                    "index": "Loring, Erin", 
+                    "preferred": "Erin Loring"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CC, Collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Chuang, Carolyn", 
+                    "preferred": "Carolyn Chuang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Craniosynostosis and Positional Plagiocephaly Support"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "AG, Recruited and enrolled patients", 
+                "type": "person", 
+                "name": {
+                    "index": "Galm, Amy", 
+                    "preferred": "Amy Galm"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "PWH, Collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Hashim, Peter W", 
+                    "preferred": "Peter W Hashim"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DMS, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Steinbacher, Derek M", 
+                    "preferred": "Derek M Steinbacher"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MLD, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "DiLuna, Michael L", 
+                    "preferred": "Michael L DiLuna"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CCD, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Duncan, Charles C", 
+                    "preferred": "Charles C Duncan"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Child Study Center", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "KAP, Recruited and enrolled patients", 
+                "type": "person", 
+                "name": {
+                    "index": "Pelphrey, Kevin A", 
+                    "preferred": "Kevin A Pelphrey"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "HZ, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Zhao, Hongyu", 
+                    "preferred": "Hongyu Zhao"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JAP, Conceived, designed, and directed study, contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, John A", 
+                    "preferred": "John A Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "name": {
+                    "index": "Lifton, Richard P", 
+                    "preferred": "Richard P Lifton"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "The Rockefeller University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "richard.lifton@yale.edu"
+                ], 
+                "type": "person", 
+                "contribution": "RPL, Conceived, designed, and directed the study, performed genetic analyses, wrote the manuscript"
+            }
+        ], 
+        "volume": 5, 
+        "version": 3, 
+        "published": "2016-09-08T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20125/pdf/elife-20125.pdf", 
+        "subjects": [
+            {
+                "id": "genes-chromosomes", 
+                "name": "Genes and Chromosomes"
+            }, 
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "researchOrganisms": [
+            "Human"
+        ], 
+        "type": "research-article", 
+        "id": "20125"
+    }, 
+    "article": {
+        "body": [
+            {
+                "content": [
+                    {
+                        "text": "The cranial sutures are not fused at birth, allowing for doubling of brain volume in the first year of life and continued growth through adolescence (<a href=\"#bib29\">Persing et al., 1989</a>). The metopic suture normally closes between 6 and 12 months, while the sagittal, coronal, and lambdoid sutures typically fuse in adulthood (<a href=\"#bib29\">Persing et al., 1989</a>; <a href=\"#bib44\">Weinzweig et al., 2003</a>). Premature fusion of any of these sutures can result in brain compression and suture-specific craniofacial dysmorphism (<a href=\"#fig1\">Figure 1</a>). Studies of syndromic forms of craniosynostosis, each with prevalence of ~1/60,000 to 1/1,000,000 live births and collectively accounting for 15\u201320% of all cases, have implicated mutations in more than 50 genes (<a href=\"#bib40\">Twigg and Wilkie, 2015</a>; <a href=\"#bib10\">Flaherty et al., 2016</a>). For example, mutations that increase MAPK/ERK signaling (e.g. <i>FGFR1-3</i> (<a href=\"#bib40\">Twigg and Wilkie, 2015</a>; <a href=\"#bib10\">Flaherty et al., 2016</a>), <i>ERF</i> [<a href=\"#bib39\">Twigg et al., 2013</a>]) cause rare syndromic coronal or multisuture craniosynostosis, while mutations that perturb SMAD signaling (e.g. <i>TGFBR1/2</i> [<a href=\"#bib21\">Loeys et al., 2005</a>], <i>SKI</i> [<a href=\"#bib7\">Doyle et al., 2012</a>], <i>RUNX2</i> [<a href=\"#bib24\">Mefford et al., 2010</a>; <a href=\"#bib17\">Javed et al., 2008</a>]) cause rare syndromes involving the midline (sagittal and metopic) sutures. While the detailed pathophysiology of premature suture fusion has not been elucidated, aberrant signaling in cranial neural crest cells during craniofacial development has been suggested as a common mechanism (<a href=\"#bib25\">Mishina and Snider, 2014</a>; <a href=\"#bib19\">Komatsu et al., 2013</a>).", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "doi": "10.7554/eLife.20125.003", 
+                        "title": "Phenotypes of midline craniosynostosis.", 
+                        "uri": "https://example.org/elife-20125-fig1-v3", 
+                        "label": "Figure 1.", 
+                        "caption": [
+                            {
+                                "text": "(<b>a</b>) Normal infant skull with patent sagittal (S) and metopic (M) sutures. (<b>b</b>) Three-dimensional reconstruction of computed tomography (3D CT) demonstrating premature fusion of both the sagittal and metopic sutures. (<b>c</b>) A three-month-old boy with sagittal craniosynostosis featuring scaphocephaly (narrow and elongated cranial vault), and frontal bossing. (<b>d</b>) 3D CT reconstruction of a one-month-old boy found to have sagittal craniosynostosis. (<b>e</b>) A six-month-old boy presenting with trigonocephaly (triangulation of the cranial vault, with prominent forehead ridge resulting from premature fusion of the metopic suture) and hypotelorism (abnormally decreased intercanthal distance, also a result of premature fusion of the metopic suture). 3D CT reconstruction demonstrated metopic craniosynostosis. (<b>f</b>) 3D CT reconstruction demonstrating premature fusion of the metopic suture with characteristic trigonocephaly and hypotelorism.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "alt": "", 
+                        "filename": "elife-20125-fig1-v3", 
+                        "type": "image", 
+                        "id": "fig1"
+                    }, 
+                    {
+                        "text": "Despite success in identifying the genes underlying rare syndromic craniosynostosis, mutations in these genes are very rarely found in their non-syndromic counterparts (<a href=\"#bib2\">Boyadjiev and International Craniosynostosis Consortium, 2007</a>). Non-syndromic craniosynostosis of the midline sutures account for 50% of all craniosynostosis (<a href=\"#bib38\">Slater et al., 2008</a>; <a href=\"#bib12\">Greenwood et al., 2014</a>). A GWAS of non-syndromic sagittal craniosynostosis has implicated common variants in a segment of a gene desert ~345 kb downstream of <i>BMP2</i>, and within an intron of <i>BBS9</i>; these risk alleles have unusually large effect (odds ratios &gt; 4 at each locus) (<a href=\"#bib18\">Justice et al., 2012</a>). Nonetheless, rare alleles with large effect have not been identified to date in non-syndromic sagittal or metopic craniosynostosis. We considered that the often sporadic occurrence of non-syndromic craniosynostosis might frequently be attributable to de novo mutation or incomplete penetrance of rare transmitted variants.", 
+                        "type": "paragraph"
+                    }
+                ], 
+                "type": "section", 
+                "id": "s1", 
+                "title": "Introduction"
+            }, 
+            {
+                "content": [
+                    {
+                        "content": [
+                            {
+                                "text": "We recruited a cohort of 191 probands with non-syndromic midline craniosynostosis, including 132 parent-offspring trios and 59 probands with one parent, along with selected extended family members (see Materials\u00a0and\u00a0methods). All probands had undergone reconstructive surgery for either isolated sagittal (n\u00a0=\u00a0113), metopic (n\u00a0=\u00a070) or combined sagittal and metopic (n\u00a0=\u00a08) craniosynostosis. Seventeen kindreds had 1 to 3 additional affected family members, including 7 parents, 12 siblings, 3 aunts/uncles and 4 more distant relatives of probands. DNA was prepared from buccal swab samples. Exome sequencing was performed as described in Materials and methods; summary data are shown in <a href=\"#SD5-data\">Supplementary file 1A</a>. Variants were called using the GATK pipeline (see Materials and methods) and de novo mutations in parent-offspring trios were called using TrioDeNovo (<a href=\"#bib43\">Wei et al., 2015</a>). The impact of identified missense variants on protein function was inferred using MetaSVM (<a href=\"#bib6\">Dong et al., 2015</a>). All de novo calls were verified by in silico visualization of aligned reads (<a href=\"#fig2s1\">Figure 2\u2014figure supplement 1</a>), and all calls contributing to significant results for individual genes were verified by direct Sanger sequencing.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "We identified a total of 144 de novo mutations, providing a de novo mutation rate of 1.64 \u00d7 10<sup>\u20138</sup> per base pair, and 1.09 de novo mutations in the coding region per offspring, consistent with prior experimental results and expectation (<a href=\"#bib42\">Ware et al., 2015</a>; <a href=\"#bib14\">Homsy et al., 2015</a>) (<a href=\"#tbl1\">Table 1</a>). Comparison of the observed distribution of mutation types to the expected from the Poisson distribution demonstrated significant enrichment of protein-altering mutations, predominantly accounted for by an excess of damaging missense mutations (MetaSVM D-mis; 28 observed D-mis compared to 14.5 expected, p=1.0 \u00d7 10<sup>\u20133</sup>, 1.93-fold enrichment), with a corresponding paucity of silent mutations (21 compared to 40.4 expected, p=3.0 \u00d7 10<sup>\u20134</sup>). From the difference in the observed vs. expected number of de novo protein-altering mutations per subject, we infer that these de novo mutations contribute to ~15% of non-syndromic midline craniosynostosis.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "tables": [
+                                    "<table><thead><tr><th></th><th colspan=\"2\">Observed</th><th colspan=\"2\">Expected</th><th>Enrichment</th><th>p-value</th></tr><tr><th>Class</th><th>#</th><th>#/subject</th><th>#</th><th>#/subject</th><th></th><th></th></tr></thead><tbody><tr><td>All mutations</td><td>144</td><td>1.09</td><td>142.8</td><td>1.08</td><td>1.01</td><td>0.47</td></tr><tr><td>Synonymous</td><td>21</td><td>0.16</td><td>40.4</td><td>0.31</td><td>0.52</td><td>3.0 \u00d7 10<sup>\u22124</sup></td></tr><tr><td>Protein altering</td><td>123</td><td>0.93</td><td>102.4</td><td>0.78</td><td>1.17</td><td>0.03</td></tr><tr><td>Total missense</td><td>110</td><td>0.83</td><td>89.7</td><td>0.68</td><td>1.23</td><td>0.02</td></tr><tr><td>T-mis</td><td>82</td><td>0.62</td><td>75.2</td><td>0.57</td><td>1.09</td><td>0.23</td></tr><tr><td>D-mis</td><td>28</td><td>0.21</td><td>14.5</td><td>0.11</td><td>1.93</td><td>1.0 \u00d7 10<sup>\u22123</sup></td></tr><tr><td>Loss of function (LOF)</td><td>13</td><td>0.10</td><td>12.7</td><td>0.10</td><td>1.03</td><td>0.50</td></tr><tr><td>LOF + D-mis</td><td>41</td><td>0.31</td><td>27.1</td><td>0.21</td><td>1.51</td><td>7.8 \u00d7 10<sup>\u22123</sup></td></tr></tbody></table>"
+                                ], 
+                                "doi": "10.7554/eLife.20125.004", 
+                                "title": "De novo mutations in 132 trios with sagittal and/or metopic craniosynostosis.", 
+                                "label": "Table 1.", 
+                                "caption": [
+                                    {
+                                        "text": "Enrichment of protein-altering de novo mutations in 132 subjects with sagittal and/or metopic craniosynostosis.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "sourceData": [
+                                    {
+                                        "doi": "10.7554/eLife.20125.005", 
+                                        "title": "De novo mutations in 132 trios with sagittal and/or metopic craniosynostosis.", 
+                                        "mediaType": "application/xlsx", 
+                                        "uri": "https://example.org/elife-20125-table1-data1-v3.xlsx", 
+                                        "filename": "elife-20125-table1-data1-v3.xlsx", 
+                                        "label": "Table 1\u2014source data 1.", 
+                                        "id": "SD1-data"
+                                    }
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "text": [
+                                            {
+                                                "text": "#, number of de novo mutations in 132 subjects; #/subject, number of de novo mutations per subject; Damaging and tolerated missense called by MetaSVM (D-mis, T-mis respectively); Loss of function denotes premature termination, frameshift, or splice site mutation. For mutation classes with enrichment compared to expectation, p-values represent the upper tail of the Poisson probability density function. For mutation classes in which we observed a paucity of mutations compared to expectation, p-values represent the lower tail.", 
+                                                "type": "paragraph"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "type": "table", 
+                                "id": "tbl1"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s2-1", 
+                        "title": "Exome sequencing of non-syndromic midline craniosynostosis"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "Analysis of de novo mutation burden revealed that a single gene, <i>SMAD6</i>, harbored three de novo mutations, including two inferred loss of function (LOF) mutations (p.Q78fs*41 and p.E374*) and one D-mis mutation (p.G390C). All three were heterozygous and occurred in families in which the proband was the sole affected member. Two de novo mutations occurred in probands and one occurred in an unaffected mother of a proband (<a href=\"#fig2\">Figure 2</a>). All three de novo mutations were confirmed by Sanger sequencing of PCR amplicons containing the putative mutation (<a href=\"#fig2s2\">Figure 2\u2014figure supplement 2</a>). <i>TTN</i>, which encodes the largest human protein, was the only other gene with more than one protein altering de novo mutation, and both of these were predicted by MetaSVM to encode tolerated variants (p.I3580M, p.T19373S). From the prior probability of de novo mutation of each base in <i>SMAD6</i> and the impact on the encoded protein (<a href=\"#bib32\">Samocha et al., 2014</a>), the probability of seeing at least two de novo LOFs and one missense mutation by chance in a cohort of this size was 3.6 \u00d7 10<sup>\u20139</sup>\u00a0(<a href=\"#tbl2\">Table 2</a>). Similarly, observing two or more de novo LOF mutations in any gene in this cohort was not expected by chance (p=8.4 \u00d7 10<sup>\u20133</sup>, see Materials and methods). Lastly, <i>SMAD6</i> is not unusually mutable, as we found no de novo <i>SMAD6</i> mutations in 900 control trios comprising healthy siblings of individuals with autism (<a href=\"#bib15\">Iossifov et al., 2014</a>; <a href=\"#bib27\">O'Roak et al., 2011</a>; <a href=\"#bib33\">Sanders et al., 2012</a>). These findings provide highly significant evidence implicating damaging mutations in <i>SMAD6</i> as a cause of midline suture craniosynostosis.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "supplements": [
+                                    {
+                                        "doi": "10.7554/eLife.20125.009", 
+                                        "title": "Plots of independent Illumina sequencing reads in a parent-offspring trio showing de novo <i>SMAD6</i> mutation.", 
+                                        "uri": "https://example.org/elife-20125-fig2-figsupp1-v3", 
+                                        "label": "Figure 2\u2014figure supplement 1.", 
+                                        "caption": [
+                                            {
+                                                "text": "The reference sequence of a segment of <i>SMAD6</i> that includes base 15:67073502 (denoted by arrow) is shown in the top row, with red, blue, green and yellow squares representing A, C, G, T, respectively. Below, all independent reads that map to this interval are shown. The results show that the proband has 23 reads of reference \u2018G\u2019, and 10 reads of non-reference \u2018T\u2019. Only the reference \u2018G\u2019 is seen in both parents, providing evidence of a de novo mutation.", 
+                                                "type": "paragraph"
+                                            }
+                                        ], 
+                                        "alt": "", 
+                                        "filename": "elife-20125-fig2-figsupp1-v3", 
+                                        "type": "image", 
+                                        "id": "fig2s1"
+                                    }, 
+                                    {
+                                        "doi": "10.7554/eLife.20125.010", 
+                                        "title": "Confirmation of <i>SMAD6</i> mutations by Sanger sequencing of PCR products.", 
+                                        "uri": "https://example.org/elife-20125-fig2-figsupp2-v3", 
+                                        "label": "Figure 2\u2014figure supplement 2.", 
+                                        "caption": [
+                                            {
+                                                "text": "Sanger sequencing traces of PCR amplicons containing <i>SMAD6</i> mutations identified by exome sequencing are shown. Above each trace or set of traces, the kindred ID, mutation identified in the DNA sequence and its impact on SMAD6 protein is indicated. Above sequence traces, the inferred DNA sequence is shown, along with the inferred amino acid sequence (shown in single letter code). Heterozygous mutations are indicated beneath the wild-type sequence and non-reference amino acid sequences are shown in red. Deleted and inserted bases are denoted, and result in an overlap of wild-type and mutant sequences.", 
+                                                "type": "paragraph"
+                                            }
+                                        ], 
+                                        "alt": "", 
+                                        "filename": "elife-20125-fig2-figsupp2-v3", 
+                                        "type": "image", 
+                                        "id": "fig2s2"
+                                    }
+                                ], 
+                                "doi": "10.7554/eLife.20125.006", 
+                                "title": "Segregation of <i>SMAD6</i> mutations and <i>BMP2</i> SNP genotypes in pedigrees with midline craniosynostosis.", 
+                                "uri": "https://example.org/elife-20125-fig2-v3", 
+                                "label": "Figure 2.", 
+                                "caption": [
+                                    {
+                                        "text": "(<b>a</b>) Domain structure of <i>SMAD6</i> showing location of the MH1 and MH2 domains. The MH1 domain mediates DNA binding and negatively regulates the functions of the MH2 domain, while the MH2 domain is responsible for transactivation and mediates phosphorylation-triggered heteromeric assembly with receptor\u00a0SMADs. De novo or rare damaging mutations identified in craniosynostosis probands are indicated. Color of text denotes suture(s) showing premature closure. (<b>b</b>) Pedigrees harboring de novo (denoted by stars within pedigree symbols) or rare transmitted variants in <i>SMAD6</i>. Filled and unfilled symbols denote individuals with and without craniosynostosis, respectively. The <i>SMAD6</i> mutation identified in each kindred is noted above each pedigree. Below each symbol, genotypes are shown first for <i>SMAD6</i> (with 'D' denoting the damaging allele) and for rs1884302 risk locus downstream of <i>BMP2</i>, (with 'T' conferring protection from and 'C' conferring increased risk of craniosynostosis). All 17 subjects with craniosynostosis have <i>SMAD6</i> mutations, and 14/17 have also inherited the risk allele at rs1884302, whereas only 3 of 16 <i>SMAD6</i> mutation carriers without the rs1884302 risk allele have craniosynostosis.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "sourceData": [
+                                    {
+                                        "doi": "10.7554/eLife.20125.007", 
+                                        "title": "Variants identified in <i>SMAD6</i>.", 
+                                        "mediaType": "application/docx", 
+                                        "uri": "https://example.org/elife-20125-fig2-data1-v3.docx", 
+                                        "filename": "elife-20125-fig2-data1-v3.docx", 
+                                        "label": "Figure 2\u2014source data 1.", 
+                                        "id": "SD2-data"
+                                    }, 
+                                    {
+                                        "doi": "10.7554/eLife.20125.008", 
+                                        "title": "PCR primer sequences for Sanger sequencing of reported variants.", 
+                                        "mediaType": "application/docx", 
+                                        "uri": "https://example.org/elife-20125-fig2-data2-v3.docx", 
+                                        "filename": "elife-20125-fig2-data2-v3.docx", 
+                                        "label": "Figure 2\u2014source data 2.", 
+                                        "id": "SD3-data"
+                                    }
+                                ], 
+                                "alt": "", 
+                                "filename": "elife-20125-fig2-v3", 
+                                "type": "image", 
+                                "id": "fig2"
+                            }, 
+                            {
+                                "tables": [
+                                    "<table><thead><tr><th valign=\"top\">Gene(s)</th><th valign=\"top\">Mutations</th><th valign=\"top\">Number of observed mutations</th><th valign=\"top\">Number of expected mutations</th><th valign=\"top\">p value</th></tr></thead><tbody><tr><td valign=\"top\"><i>SMAD6</i></td><td valign=\"top\">Loss of function</td><td valign=\"top\">2</td><td valign=\"top\">0.00026</td><td valign=\"top\">3.31 \u00d7 10<sup>\u22128</sup></td></tr><tr><td valign=\"top\"><i>SMAD6</i></td><td valign=\"top\">Missense</td><td valign=\"top\">1</td><td valign=\"top\">0.0046</td><td valign=\"top\">4.67 \u00d7 10<sup>\u22123</sup></td></tr><tr><td valign=\"top\"><i>SPRY1, SPRY2, SPRY3, SPRY4</i></td><td valign=\"top\">Nonsense, splice site, frameshift</td><td valign=\"top\">2</td><td valign=\"top\">0.001193</td><td valign=\"top\">7.11 \u00d7 10<sup>\u22127</sup></td></tr></tbody></table>"
+                                ], 
+                                "doi": "10.7554/eLife.20125.011", 
+                                "title": "Probability of observed de novo mutations in <i>SMAD6</i> and Sprouty genes occurring by chance in 132 subjects using gene-specific mutation probabilities.", 
+                                "label": "Table 2.", 
+                                "caption": [
+                                    {
+                                        "text": "Probability of observed de novo mutations in <i>SMAD6</i> and Sprouty genes occurring by chance in 132 subjects using gene-specific mutation probabilities.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "text": [
+                                            {
+                                                "text": "Probabilities calculated from the Poisson distribution using DenovolyzeR. The probability of observing at least 2 LOF and 1 missense mutation in <i>SMAD6</i> was 3.6 10<sup>\u22129</sup> via Fisher\u2019s method.", 
+                                                "type": "paragraph"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "type": "table", 
+                                "id": "tbl2"
+                            }, 
+                            {
+                                "text": "We next considered the total burden of rare (prospectively specified allele frequency in ExAC database &lt;2 \u00d7 10<sup>\u20135</sup>) LOF and D-mis mutations in each gene in probands. Among 191 probands, we found 1135 rare LOF and 3156 rare damaging (LOF + D-mis) alleles. The probability of the observed number of rare variants in each gene occurring by chance was calculated from the binomial distribution after adjusting for the length of each gene; Q-Q plots comparing the observed and expected P-value distributions are shown in <a href=\"#fig3\">Figure 3</a>. The observed distribution conforms closely to expected with the exception of <i>SMAD6</i>. The expected number of rare LOF alleles in <i>SMAD6</i> in probands was 0.05, and the observed number was 8 (p=1.1 \u00d7 10<sup>\u201315</sup>, 156-fold enrichment). Similarly, there were 13 rare damaging variants in <i>SMAD6</i> compared to 0.14 expected (p=1.3 \u00d7 10<sup>\u201321</sup>, 91.4-fold enrichment). All of these <i>SMAD6</i> variants were confirmed by direct Sanger sequencing (<a href=\"#fig2s2\">Figure 2\u2014figure supplement 2</a>). All were heterozygous and different from one another (<a href=\"#SD2-data\">Figure 2\u2014source data 1</a>); 11 were absent among &gt;10<sup>5</sup> alleles in the ExAC database, while two were previously seen, each once in ExAC (p.E407* and p.R465C, ExAC allele frequencies 9.0\u00a0\u00d7 10<sup>\u20136</sup> and 9.4 \u00d7 10<sup>\u20136</sup> respectively). The results for <i>SMAD6</i> remain highly significant after excluding de novo mutations and only analyzing transmitted variants (<a href=\"#fig3s1\">Figure 3\u2014figure supplement 1</a>), demonstrating a\u00a0significant contribution of both de novo and transmitted variants (<a href=\"#tbl3\">Table 3</a>). The fact that eight of the 13 rare heterozygous damaging variants in <i>SMAD6</i> seen in our cohort are frameshift (n = 5) or premature termination (n = 3) mutations, which are distributed throughout the encoded protein (<a href=\"#fig2\">Figure 2a</a>), strongly supports haploinsufficiency as the mechanism of the genetic contribution of <i>SMAD6</i> to craniosynostosis.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "supplements": [
+                                    {
+                                        "doi": "10.7554/eLife.20125.014", 
+                                        "title": "Quantile-quantile plots comparing all transmitted, damaging variants in protein-coding genes in 191 probands with midline craniosynostosis to the expected binomial distribution.", 
+                                        "uri": "https://example.org/elife-20125-fig3-figsupp1-v3", 
+                                        "label": "Figure 3\u2014figure supplement 1.", 
+                                        "caption": [
+                                            {
+                                                "text": "De novo variants were excluded from this analysis, leaving 1122 rare (ExAC allele frequency &lt; 2 x10<sup>\u22125</sup>), transmitted LOF variants and 3115 transmitted damaging (LOF + D-mis) variants. All genes closely matched expectation, with the exception of <i>SMAD6</i>. (<b>a</b>) There were 6 transmitted <i>SMAD6</i> LOF mutations, a 118-fold enrichment compared to the expected 0.05 (p=2.2 \u00d7 10<sup>\u201311</sup>). (<b>b</b>) Similarly, there were 10 transmitted damaging <i>SMAD6</i> variants, a 71-fold enrichment compared to the expected 0.14 (p=7.0 \u00d7 10<sup>\u201316</sup>). The results demonstrate genome-wide significance of rare transmitted variants in <i>SMAD6</i> independent of de novo mutations.", 
+                                                "type": "paragraph"
+                                            }
+                                        ], 
+                                        "alt": "", 
+                                        "filename": "elife-20125-fig3-figsupp1-v3", 
+                                        "type": "image", 
+                                        "id": "fig3s1"
+                                    }, 
+                                    {
+                                        "doi": "10.7554/eLife.20125.015", 
+                                        "title": "Principal-component analysis of 191 probands and 3337 European autism controls.", 
+                                        "uri": "https://example.org/elife-20125-fig3-figsupp2-v3", 
+                                        "label": "Figure 3\u2014figure supplement 2.", 
+                                        "caption": [
+                                            {
+                                                "text": "(<b>a</b>) Principal component analysis of exome sequence genotypes from 191 probands with sagittal, metopic, or combined sagittal and metopic craniosynostosis clustered along with HapMap subjects. Results identify 172 craniosynostosis subjects that cluster with HapMap European subjects. (<b>b</b>) Principal component analysis of genotypes from exome sequencing data of European autism parent controls (n\u00a0=\u00a03337) showing clustering with HapMap subjects. In both panels, subjects considered to be of European ancestry are circled.", 
+                                                "type": "paragraph"
+                                            }
+                                        ], 
+                                        "alt": "", 
+                                        "filename": "elife-20125-fig3-figsupp2-v3", 
+                                        "type": "image", 
+                                        "id": "fig3s2"
+                                    }, 
+                                    {
+                                        "doi": "10.7554/eLife.20125.016", 
+                                        "title": "Quantile-quantile plot of observed versus expected p-values comparing the burden of damaging (LOF + D-mis) variants in protein-coding genes in craniosynostosis cases and controls.", 
+                                        "uri": "https://example.org/elife-20125-fig3-figsupp3-v3", 
+                                        "label": "Figure 3\u2014figure supplement 3.", 
+                                        "caption": [
+                                            {
+                                                "text": "The frequency of rare (allele frequency &lt; 2 \u00d7 10<sup>\u20135</sup>\u00a0in the ExAC03 database) loss of function and D-mis variants in each gene was compared in 172 European probands with midline craniosynostosis and 3337 European controls. The distribution of observed p-values conforms to expectation with the exception of <i>SMAD6</i>, which deviates significantly from expectation. Because exon 1 of <i>SMAD6</i> was poorly captured using the V2 capture reagent (used in control samples), 3 damaging variants in exon 1 in cases were excluded from this analysis.", 
+                                                "type": "paragraph"
+                                            }
+                                        ], 
+                                        "alt": "", 
+                                        "filename": "elife-20125-fig3-figsupp3-v3", 
+                                        "type": "image", 
+                                        "id": "fig3s3"
+                                    }
+                                ], 
+                                "doi": "10.7554/eLife.20125.012", 
+                                "title": "Quantile-quantile plots of observed versus expected p-values comparing the burden of rare LOF and damaging (LOF + D-mis) variants in protein-coding genes in craniosynostosis cases.", 
+                                "uri": "https://example.org/elife-20125-fig3-v3", 
+                                "label": "Figure 3.", 
+                                "caption": [
+                                    {
+                                        "text": "Rare (allele frequency &lt;2 \u00d7 10<sup>\u20135</sup>\u00a0in the ExAC03 database) loss of function (LOF) and damaging missense (D-mis) variants were identified in 191 probands. The probability of the observed number of variants in each gene occurring by chance was calculated from the total number of observed variants and the length of the coding region of each gene using the binomial test. The distribution of observed P-values compared to the expected distribution is shown. (<b>a</b>) Q-Q plot for rare LOF variants in each gene from a total of 1135 LOF variants identified in probands. The distribution of observed p-values closely conforms to expectation with the exception of <i>SMAD6</i>, which shows p=1.1 \u00d7 10<sup>\u201315</sup>\u00a0and 156-fold enrichment in cases. (<b>b</b>) Q-Q plot for rare damaging (LOF + D-mis) variants in each gene from a total of 3156 damaging variants in probands. Again, <i>SMAD6</i> deviates greatly from the expected distribution, with p&lt;10<sup>\u201320</sup> and 91-fold enrichment.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "sourceData": [
+                                    {
+                                        "doi": "10.7554/eLife.20125.013", 
+                                        "title": "Source data for <a href=\"#fig3s3\">Figure 3\u2014figure supplement 3</a>.", 
+                                        "mediaType": "application/docx", 
+                                        "uri": "https://example.org/elife-20125-fig3-data1-v3.docx", 
+                                        "filename": "elife-20125-fig3-data1-v3.docx", 
+                                        "label": "Figure 3\u2014source data 1.", 
+                                        "id": "SD4-data"
+                                    }
+                                ], 
+                                "alt": "", 
+                                "filename": "elife-20125-fig3-v3", 
+                                "type": "image", 
+                                "id": "fig3"
+                            }, 
+                            {
+                                "tables": [
+                                    "<table><thead><tr><th valign=\"top\"></th><th valign=\"top\">Observed</th><th valign=\"top\">Expected</th><th valign=\"top\">Enrichment</th><th valign=\"top\">p-value</th></tr></thead><tbody><tr><td valign=\"top\">De novo LOF and D-mis</td><td valign=\"top\">3</td><td valign=\"top\">0.0049</td><td valign=\"top\">612</td><td valign=\"top\">3.6 \u00d7 10<sup>\u22129</sup></td></tr><tr><td valign=\"top\">Transmitted LOF and D-mis</td><td valign=\"top\">10</td><td valign=\"top\">0.1404</td><td valign=\"top\">71.2</td><td valign=\"top\">7.0 \u00d7 10<sup>\u221216</sup></td></tr><tr><td valign=\"top\">Total</td><td valign=\"top\">13</td><td valign=\"top\">0.1453</td><td valign=\"top\">89.5</td><td valign=\"top\">1.4 \u00d7 10<sup>\u221222</sup></td></tr></tbody></table>"
+                                ], 
+                                "doi": "10.7554/eLife.20125.017", 
+                                "title": "Enrichment of de novo and transmitted damaging variants in <i>SMAD6</i> in craniosynostosis.", 
+                                "label": "Table 3.", 
+                                "caption": [
+                                    {
+                                        "text": "Enrichment of de novo and transmitted damaging variants in <i>SMAD6</i> in craniosynostosis.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "text": [
+                                            {
+                                                "text": "LOF, loss of function; D-mis, damaging missense variants per MetaSVM; The total number of <i>SMAD6</i> variants expected in this cohort was calculated by summing the expected number of de novo and transmitted variants. P-value combining probabilities from de novo and transmitted protein damaging <i>SMAD6</i> variants was determined by Fisher\u2019s method.", 
+                                                "type": "paragraph"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "type": "table", 
+                                "id": "tbl3"
+                            }, 
+                            {
+                                "text": "Lastly, we compared the frequency of rare (allele frequency &lt;2\u00a0\u00d7 10<sup>\u20135</sup> in the ExAC database) damaging (LOF + D-mis) variants in all genes in 172 European probands and 3337 unrelated European controls, who were parents of autism probands sequenced to a similar depth of coverage and analyzed in a similar fashion (see Materials and methods, <a href=\"#SD5-data\">Supplementary file 1A</a>). European ancestry was determined by principal component analysis of exome sequence data (<a href=\"#fig3s2\">Figure 3\u2014figure supplement 2</a>). Q-Q plots showed that the observed distribution of Fisher\u2019s exact statistics comparing the frequency of damaging variants in cases and controls closely corresponded to the expected distribution, again with the exception of <i>SMAD6,</i> in which cases showed enrichment of damaging variants (p=6.3 \u00d7 10<sup>\u20138</sup>) and LOF variants (p=5.7 \u00d7 10<sup>\u20136</sup>) (<a href=\"#fig3s3\">Figure 3\u2014figure supplement 3</a>). Significant enrichment was also seen in comparison to European NHLBI and ExAC controls (<a href=\"#SD4-data\">Figure 3\u2014source data 1</a>). The odds ratios for association of all damaging variants in <i>SMAD6</i> in cases vs. controls was consistent across control cohorts, ranging from 26.9 to 35.1; the odds ratios for LOFs ranged from 102.6 to infinity (owing to zero LOF\u2019s in autism controls).", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "Aside from <i>SMAD6</i>, no other single gene approached genome-wide significance in these analyses of dominant alleles. Analysis of recessive genotypes, considering alleles with frequency &lt;10<sup>\u20133</sup>, identified no genes with more than one rare recessive genotype.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "Collectively, the significant burden of both de novo and rare transmitted mutations, along with significant association results in case-control analysis provide extremely strong evidence that rare damaging <i>SMAD6</i> alleles impart large effects on risk of non-syndromic midline craniosynostosis.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "<i>SMAD6</i> mutations were significantly more frequent in kindreds with any metopic craniosynostosis (10 of 78, 12.8%) compared to those with isolated sagittal craniosynostosis (3 of 113, 2.7%; p=8.1 \u00d7 10<sup>\u20133</sup> by Fisher\u2019s exact test, odds ratio 5.3). These results suggest that mutations in <i>SMAD6</i> confer greater risk for metopic suture closure. We found no significant correlation between the type of mutation (LOF vs. D-mis) or location within the gene of <i>SMAD6</i> mutation and phenotypic class (<a href=\"#tbl4\">Table 4</a>).", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "tables": [
+                                    "<table><thead><tr><th></th><th>Total # kindreds</th><th>Total # <i>SMAD6</i> mutations (%)</th><th># LOF (%)</th></tr></thead><tbody><tr><td>Sagittal</td><td>113</td><td>3 (2.7)</td><td>2 (1.8)</td></tr><tr><td>Metopic</td><td>70</td><td>7 (10)</td><td>3 (3.9)</td></tr><tr><td>Sagittal and Metopic</td><td>8</td><td>3 (37.5)</td><td>3 (37.5)</td></tr><tr><td>Total</td><td>191</td><td>13 (6.8)</td><td>8 (4.2)</td></tr></tbody></table>"
+                                ], 
+                                "doi": "10.7554/eLife.20125.018", 
+                                "title": "Distribution of suture involvement in kindreds with and without rare (allele frequency &lt; 2\u00a0\u00d7 10<sup>\u22125</sup>) de novo and transmitted damaging (LOF + D-mis) variants in <i>SMAD6</i>.", 
+                                "label": "Table 4.", 
+                                "caption": [
+                                    {
+                                        "text": "Distribution of suture involvement in kindreds with and without rare (allele frequency &lt; 2\u00a0\u00d7 10<sup>\u22125</sup>) de novo and transmitted damaging (LOF + D-mis) variants in <i>SMAD6</i>.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "type": "table", 
+                                "id": "tbl4"
+                            }, 
+                            {
+                                "text": "Interestingly, transmitted <i>SMAD6</i> mutations were significantly enriched in kindreds with familial craniosynostosis, accounting for 4 of 17 kindreds with more than one affected subject (p=0.02, Fisher\u2019s exact test; odds ratio 5.6). In these kindreds, all four additional affected subjects carried the <i>SMAD6</i> mutation found in the proband (<a href=\"#fig2\">Figure 2</a>).", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "SMAD6 is a member of the inhibitory-SMAD family. Activation of BMP receptors leads to phosphorylation of receptor SMADs, which can complex with SMAD4, translocate to the nucleus and partner with RUNX2 to induce transcription of genes that promote osteoblast differentiation (<a href=\"#bib17\">Javed et al., 2008</a>; <a href=\"#bib13\">Hata et al., 1998</a>) (<a href=\"#fig4\">Figure 4a</a>). This process is inhibited by SMAD6 binding to phosphorylated receptor SMADs, forming an inactive complex. SMAD6 also inhibits BMP signaling by complexing with the ubiquitin ligase SMURF1, which ubiquitylates BMP receptors, receptor SMADs and RUNX2, leading to their proteasomal degradation (<a href=\"#fig4\">Figure 4b</a>) (<a href=\"#bib26\">Murakami et al., 2003</a>). This pathway plays a well-established role in the\u00a0development of the cranial vault and closure of cranial sutures. In mice, constitutive activity of BMPR1A in cranial neural crest results in SMAD-dependent development of metopic craniosynostosis (<a href=\"#bib19\">Komatsu et al., 2013</a>), and genetic deficiency for the SMAD inhibitor <i>SMURF1</i> causes midline craniosynostosis (<a href=\"#bib34\">Shimazu et al., 2016</a>). Similarly, duplication of <i>RUNX2</i> causes syndromic metopic craniosynostosis in humans (<a href=\"#bib24\">Mefford et al., 2010</a>). Lastly, <i>SMAD6</i> knockout mice are born with domed skulls and show anomalous bone deposition in the metopic suture; they also show an augmented and prolonged response to BMP2 stimulation (<a href=\"#bib8\">Estrada et al., 2011</a>; <a href=\"#bib30\">Retting, 2008</a>). These findings are consistent with haploinsufficiency as the mechanism of <i>SMAD6</i> mutations in craniosynostosis, with loss of the inhibitory effect of SMAD6 promoting increased BMP signaling and premature closure of sutures.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "doi": "10.7554/eLife.20125.019", 
+                                "title": "SMAD6 inhibits osteoblast differentiation by inhibiting BMP-mediated SMAD signaling (<a href=\"#bib31\">Salazar et al., 2016</a>).", 
+                                "uri": "https://example.org/elife-20125-fig4-v3", 
+                                "label": "Figure 4.", 
+                                "caption": [
+                                    {
+                                        "text": "(<b>a</b>) BMP ligands activate BMP receptors, leading to phosphorylation of receptor-regulated SMADs (R-SMADs), which complex with SMAD4 and enter the nucleus, cooperating with RUNX2 to induce osteoblast differentiation. SMAD6 inhibits this signal by competing with SMAD4 for binding to R-SMADs, preventing nuclear translocation. (<b>b</b>) SMAD6 also cooperates with SMURF1, an E3 ubiquitin ligase, to induce ubiquitin-mediated proteasomal degradation of R-SMADs, BMP receptor complexes, and RUNX2.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "alt": "", 
+                                "filename": "elife-20125-fig4-v3", 
+                                "type": "image", 
+                                "id": "fig4"
+                            }, 
+                            {
+                                "text": "We explored our kindreds for other mutations in this signaling pathway. Interestingly, we identified one de novo D-mis mutation in <i>SMURF1</i> in a proband with sporadic metopic craniosynostosis (<a href=\"#fig5\">Figure 5</a>).", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "doi": "10.7554/eLife.20125.020", 
+                                "title": "A de novo variant identified in <i>SMURF1</i>.", 
+                                "uri": "https://example.org/elife-20125-fig5-v3", 
+                                "label": "Figure 5.", 
+                                "caption": [
+                                    {
+                                        "text": "(<b>a</b>) Sanger sequence electropherogram of a PCR product amplified from the genomic DNA of a proband with metopic craniosynostosis, confirming a de novo R468W mutation in <i>SMURF1</i>, a <i>SMAD6</i> binding partner. (<b>b</b>) Patient photographs of the proband, who presented with trigonocephaly and mild orbital abnormalities. 3D CT reconstruction demonstrates metopic craniosynostosis, trigonocephaly, and a patent sagittal suture.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "alt": "", 
+                                "filename": "elife-20125-fig5-v3", 
+                                "type": "image", 
+                                "id": "fig5"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s2-2", 
+                        "title": "De novo and transmitted mutations in <i>SMAD6</i>"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "Within the 13 kindreds harboring rare damaging <i>SMAD6</i> variants, all 17 affected subjects had the <i>SMAD6</i> mutation found in the proband (<a href=\"#fig2\">Figure 2</a>). Nonetheless, <i>SMAD6</i> mutations showed striking incomplete penetrance. In particular, zero of 10 parental <i>SMAD6</i> mutation carriers had a diagnosis of, or showed evidence of craniosynostosis. Examination of Illumina read counts and Sanger sequence traces provided no suggestion that the mutations were mosaic in unaffected parents (mean/median of 52.9%/52.4% variant reads in transmitting parents, respectively; range 37.3% to 71.4%). There was no significant effect of gender on penetrance. From the data in these kindreds, the penetrance of <i>SMAD6</i> mutations is estimated at 24% following exclusion of probands, who were ascertained for the presence of disease (57% if probands are included). The striking absence of craniosynostosis among transmitting parents suggests the possibility of purifying selection, with subjects having craniosynostosis less likely to have offspring.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "We considered whether inheritance at other genetic loci might account for the striking incomplete penetrance of <i>SMAD6</i> mutations in these kindreds. A previous GWAS of non-syndromic sagittal craniosynostosis implicated common variants ~345 kb downstream of the closest gene, <i>BMP2</i> (encoding bone morphogenetic protein 2), with unusually large effect size (e.g., rs1884302, with risk allele frequency of 0.34 and odds ratio of 4.6). BMP2 is a ligand for BMP receptors upstream of SMAD signaling (<a href=\"#bib31\">Salazar et al., 2016</a>) and is an inducer of osteogenesis. We posited that risk alleles at this locus might increase the penetrance of <i>SMAD6</i> mutations by increasing BMP2 levels and further increasing SMAD signaling. Genotypes for rs1884302 are shown in <a href=\"#fig2\">Figure 2</a> and provide strong evidence of epistatic interaction between <i>SMAD6</i> and <i>BMP2</i> alleles. Fourteen individuals had both a <i>SMAD6</i> mutation and the rs1884302 risk allele; 100% of these had craniosynostosis. In contrast, 16 subjects had a <i>SMAD6</i> mutation but no rs1884302 risk allele; only 3 of these individuals (19%) had craniosynostosis. Lastly, 0 of 18 members of these kindreds who had only the rs1884302 risk allele had craniosynostosis. The relationship of these two genotypes to craniosynostosis in these kindreds was highly significant (p=1.4\u00a0\u00d7 10<sup>\u201310</sup> by the Freeman-Halton extension of Fisher\u2019s exact test; <a href=\"#tbl5\">Table 5</a>).", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "tables": [
+                                    "<table><thead><tr><th><i>SMAD6/BMP2</i> Genotypes</th><th>Craniosynostosis (+)</th><th>Craniosynostosis (\u2212)</th></tr></thead><tbody><tr><td><i>SMAD6</i> (+) <i>/ BMP2</i> risk allele (+)</td><td>14</td><td>0</td></tr><tr><td><i>SMAD6</i> (+) <i>/ BMP2</i> risk allele (\u2212)</td><td>3</td><td>13</td></tr><tr><td><i>SMAD6</i> (\u2212) <i>/ BMP2</i> risk allele (+)</td><td>0</td><td>18</td></tr></tbody></table>"
+                                ], 
+                                "doi": "10.7554/eLife.20125.021", 
+                                "title": "Risk of craniosynostosis in <i>SMAD6</i> mutation carriers in the presence or absence of a <i>BMP2</i> risk allele.", 
+                                "label": "Table 5.", 
+                                "caption": [
+                                    {
+                                        "text": "Risk of craniosynostosis in <i>SMAD6</i> mutation carriers in the presence or absence of a <i>BMP2</i> risk allele.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "text": [
+                                            {
+                                                "text": "All members of kindreds found to have a mutation in <i>SMAD6</i> were included. <i>SMAD6</i>(+) indicates the presence of a heterozygous LOF or D-mis allele. The reported <i>BMP2</i> risk allele is \u2018C\u2019 at risk locus rs1884302, found within a gene desert ~345kb downstream of <i>BMP2</i>. p=1.4 \u00d7 10<sup>\u221210</sup> by the Freeman-Halton extension of Fisher\u2019s exact test. Odds ratio in favor of disease was incalculable due to the absence of craniosynostosis in <i>SMAD6</i> (\u2212) individuals in these kindreds.", 
+                                                "type": "paragraph"
+                                            }
+                                        ]
+                                    }
+                                ], 
+                                "type": "table", 
+                                "id": "tbl5"
+                            }, 
+                            {
+                                "text": "Confining analysis just to subjects with <i>SMAD6</i> mutation, there was dramatically increased occurrence of craniosynostosis among those with the rs1884302 risk allele compared to those without (p=4.8 \u00d7 10<sup>\u20136</sup> by Fisher\u2019s exact test). The presence of the rs1884302 risk allele increased the risk of craniosynostosis &gt;5-fold with a very high odds ratio that includes infinity owing to 100% penetrance among those with risk genotypes at both loci. This two locus contribution is further supported by significant transmission disequilibrium, with rs1884302 risk alleles transmitted from heterozygous parents to affected offspring in 11 of 13 transmissions (p=0.013 by Chi-square, <a href=\"#SD5-data\">Supplementary file 1B</a>). In sum, inheritance at rs1884302 explains nearly all of the variation in phenotype among subjects with <i>SMAD6</i> mutations and demonstrates two locus transmission of craniosynostosis.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "In contrast, common variants at the <i>BBS9</i> locus that also showed strong association with midline craniosynostosis in case-control analysis (OR &gt; 4) (<a href=\"#bib18\">Justice et al., 2012</a>) showed no significant interaction with <i>SMAD6</i> (TDT p=0.89; <a href=\"#SD5-data\">Supplementary file 1B</a>), demonstrating specificity of the observed interaction of rare variants in <i>SMAD6</i> and a common variant near <i>BMP2</i>.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "Lastly, we compared the joint segregation of rare damaging <i>SMAD6</i> and common <i>BMP2</i> risk alleles to the segregation of craniosynostosis in a parametric two locus linkage model in these kindreds (see Materials and methods, <a href=\"#SD5-data\">Supplementary file 1C</a>). The results provided extremely strong evidence supporting linkage under a two locus model, with a maximum lod score of 7.37 (odds ratio 2.3 \u00d7 10<sup>7</sup>:1 in favor of linkage compared to the null hypothesis; family-specific lod scores are shown in <a href=\"#SD5-data\">Supplementary file 1D</a>). The maximum likelihood model specified 100% penetrance of craniosynostosis when risk alleles at both loci are present, 9% penetrance when only a damaging <i>SMAD6</i> allele is present, 0.08% or 0.32% penetrance when only one or two <i>BMP2</i> risk alleles are present, and a 0.02% phenocopy rate, with zero recombination between trait and both marker loci. This two locus model was 1410 \u2013 fold more likely than than the best single locus model, in which damaging <i>SMAD6</i> variants had penetrance of 20%. These results provide extremely strong statistical support for the two locus model by linkage and extends the genetic evidence beyond simple association to linkage within pedigrees, which is not susceptible to potential confounders such as population stratification, and is insensitive to misspecification of allele frequency.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s2-3", 
+                        "title": "Incomplete penetrance of <i>SMAD6</i> mutations explained by a common variant near <i>BMP2</i>"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "Previous research has implicated increased activity of the MAP kinase/ERK pathway in craniosynostosis (<a href=\"#bib39\">Twigg et al., 2013</a>; <a href=\"#bib36\">Shukla et al., 2007</a>). We identified one de novo LOF in both <i>SPRY1</i> and <i>SPRY4,</i> developmental regulators of the MAP kinase/ERK pathway; these variants comprised two of only 11 de novo LOFs other than those in <i>SMAD6</i>. The <i>SPRY4</i> mutation (p.E160*) arose de novo in a proband with sagittal craniosynostosis and no family history (<a href=\"#fig6\">Figure 6a</a>). The <i>SPRY1</i> mutation (p.Q6fs*8) was de novo in a woman with mild cranial dysmorphism who did not undergo surgery, and was transmitted to both of her children, who both had sagittal craniosynostosis (<a href=\"#fig6\">Figure 6b</a>). The probability of observing two or more de novo LOF mutations in any of the 4 Sprouty genes by chance in this cohort surpassed genome-wide significance (p=7.1 \u00d7 10<sup>\u20137</sup>, <a href=\"#tbl2\">Table 2</a>). Consistent with a role for <i>SPRY1</i> haploinsufficiency, a de novo microdeletion that included <i>SPRY1</i> has previously been reported in a child with sagittal craniosynostosis (<a href=\"#bib9\">Fern\u00e1ndez-Ja\u00e9n et al., 2014</a>). Moreover, in mice with <i>TWIST1</i> haploinsufficiency, a model of syndromic craniosynostosis, overexpression of <i>SPRY1</i> prevents suture fusion (<a href=\"#bib3\">Connerney et al., 2008</a>). Lastly, protein altering de novo mutations were also identified in other regulators and mediators of MAP kinase signaling, including <i>RASAL2, DUSP5, MAP3K8, KSR2, RPS6KA4</i>, and <i>RGS3</i>. 5 of 6 occurred in probands with sagittal craniosynostosis (<a href=\"#SD1-data\">Table 1\u2014source data 1</a>). Determining the significance of these findings will require further study.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "doi": "10.7554/eLife.20125.022", 
+                                "title": "De novo loss-of-function mutations in Sprouty genes.", 
+                                "uri": "https://example.org/elife-20125-fig6-v3", 
+                                "label": "Figure 6.", 
+                                "caption": [
+                                    {
+                                        "text": "(<b>a</b>) Pedigree and Sanger sequencing traces for kindred SAG150, demonstrating a de novo nonsense mutation in <i>SPRY4</i> (p.E160*) in the proband. (<b>b</b>) Pedigree and Sanger sequencing traces in a kindred with a de novo <i>SPRY1</i> frameshift mutation (p.Q6fs*8) that was transmitted to two affected offspring.", 
+                                        "type": "paragraph"
+                                    }
+                                ], 
+                                "alt": "", 
+                                "filename": "elife-20125-fig6-v3", 
+                                "type": "image", 
+                                "id": "fig6"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s2-4", 
+                        "title": "Mutations in MAP kinase regulators"
+                    }
+                ], 
+                "type": "section", 
+                "id": "s2", 
+                "title": "Results"
+            }, 
+            {
+                "content": [
+                    {
+                        "text": "These findings implicate a two locus model of inheritance in non-syndromic midline craniosynostosis via epistatic interactions of rare heterozygous <i>SMAD6</i> mutations and common risk alleles near <i>BMP2</i>. There is extremely strong evidence implicating each locus independently, along with highly significant evidence from both analysis of association and linkage that the risk of craniosynostosis is markedly increased in individuals carrying risk alleles at both loci compared to those with only a single risk allele at either locus. Rare damaging variants in <i>SMAD6</i> alone impart very large effects on disease risk with low penetrance, with inheritance at <i>BMP2</i> explaining nearly all of the variation in occurrence of craniosynostosis seen among <i>SMAD6</i> mutation carriers. The results support a threshold effect model, with quantitative increases in SMAD signaling resulting from reduced inhibition of SMAD signaling by SMAD6, owing to haploinsufficiency (strongly supported by a plethora of LOF variants distributed across <i>SMAD6</i>), along with a putative increase in SMAD signaling owing to increased BMP2 expression via the risk SNP rs1884302 leading to accelerated closure of midline sutures. Consistent with this model, as articulated previously, substantial prior evidence in mouse and human has implicated BMP signaling via SMADs in closure of the midline sutures, and <i>SMAD6</i> in inhibiting this pathway. Moreover, consistent with the common variant near <i>BMP2</i> modifying BMP2 expression, duplication of a nearby limb-specific enhancer increased BMP2 expression, leading to a Mendelian limb defect (<a href=\"#bib4\">Dathe et al., 2009</a>). While the genetic data provide unequivocal support for the role of these two loci in midline craniosynostosis, and for haploinsufficiency as the mechanism of <i>SMAD6</i> contribution, further studies will be necessary to delineate the precise mechanism by which the risk genotypes cause disease.", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "text": "<i>SMAD6</i> mutations with and without <i>BMP2</i> risk alleles account for ~7% of probands in this cohort of non-syndromic midline craniosynostosis. This frequency is much greater than any other genotype causing syndromic midline craniosynostosis (e.g., <i>TGFBR1/2, SKI, RUNX2</i>), which are sufficiently rare that their prevalence has not been well-established. Moreover, because non-syndromic sagittal and metopic craniosynostosis comprise half of all craniosynostoses (<a href=\"#bib38\">Slater et al., 2008</a>; <a href=\"#bib12\">Greenwood et al., 2014</a>), <i>SMAD6/BMP2</i> genotypes are inferred to account for ~3.5% of all craniosynostosis, and are likely rivaled in frequency only by mutations in <i>FGFR2</i> as the most frequent cause of all craniosynostoses (<a href=\"#bib40\">Twigg and Wilkie, 2015</a>).", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "text": "These findings will be of immediate utility in clinical diagnosis and genetic counseling. The combination of a rare damaging <i>SMAD6</i> mutation plus a common <i>BMP2</i> risk allele conferred 100% risk of craniosynostosis in our cohort, while those with a <i>SMAD6</i> mutation but no <i>BMP2</i> risk allele were at markedly lower risk. Interestingly, these <i>SMAD6</i> mutation-only cases thus far have all had isolated metopic craniosynostosis (<a href=\"#fig2\">Figure 2</a>). Rare damaging SMAD6 mutations were found in nearly 25% of kindreds with recurrent midline craniosynostosis, and 37.5% of patients with combined sagittal and metopic craniosynostosis in our cohort. The precision of penetrance estimates and prevalence in specific disease subsets will improve with larger sample sizes.", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "text": "Given the suggestion of a threshold for phenotypic effect, we also considered whether there might be additional <i>SMAD6</i> alleles that impart phenotypic effect that have a\u00a0higher frequency than the 2 \u00d7 10<sup>\u20135</sup> threshold that we used. We found only one additional <i>SMAD6</i> damaging allele among parents in our cohort with allele frequency &lt;0.001. Interestingly, this allele, p.E287K, (ExAC frequency 3.3 \u00d7 10<sup>\u20135</sup>) was transmitted to a proband with sagittal and metopic craniosynostosis along with two doses of the <i>BMP2</i> risk allele, each inherited from a heterozygous parent.", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "text": "Considering neurodevelopmental outcomes, 11 of 15 subjects with rare damaging <i>SMAD6</i> variants who are more than one year of age (and hence can have neurodevelopmental evaluation) had some form of developmental delay (<a href=\"#SD5-data\">Supplementary file 1E</a>). While early surgical intervention provides the best neurological outcomes (<a href=\"#bib28\">Patel et al., 2014</a>), more than a third of patients with non-syndromic midline craniosynostosis have subtle learning disability (<a href=\"#bib23\">Magge et al., 2002</a>; <a href=\"#bib35\">Shipster et al., 2003</a>; <a href=\"#bib37\">Sidoti et al., 1996</a>). BMP signaling plays an essential role in vertebrate brain development (<a href=\"#bib1\">Bier and De Robertis, 2015</a>), raising the possibility that aberrant BMP signaling could contribute to neurodevelopmental outcome independent of its effect on craniosynostosis. The only other clinical finding observed in more than one subject with <i>SMAD6</i> mutation was a\u00a0congenital inguinal hernia in 3 patients (16.7%; <a href=\"#SD5-data\">Supplementary file 1E</a>).", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "text": "While <i>SMAD6</i> was the only single gene showing genome-wide significant burden of de novo mutation, de novo protein-altering mutations are estimated to contribute to ~15% of cases. This estimated fraction is similar to estimates for autism and congenital heart disease, other diseases in which large-scale studies have shown a role for de novo mutations (<a href=\"#bib14\">Homsy et al., 2015</a>; <a href=\"#bib15\">Iossifov et al., 2014</a>; <a href=\"#bib33\">Sanders et al., 2012</a>; <a href=\"#bib45\">Zaidi et al., 2013</a>; <a href=\"#bib5\">De Rubeis et al., 2014</a>). Also like autism and congenital heart disease, few individual genes were implicated after sequencing modest numbers of trios, implying that de novo mutation in a large number of genes are likely to contribute to sagittal and metopic craniosynostosis. This observation strongly supports sequencing substantially larger numbers of non-syndromic patients, an approach that has proved highly productive for discovery of genes and pathways underlying autism and CHD.", 
+                        "type": "paragraph"
+                    }, 
+                    {
+                        "text": "Lastly, these results provide a clear example of the epistatic (non-additive) interaction of very rare mutations at one locus with a common variant at a second, unlinked locus. This observation adds to the small number of two locus phenotypes that have been defined with robust genetic data (<a href=\"#bib22\">Lupski, 2012</a>), and suggest that other common variants, particularly those with relatively large effect, may combine with rare alleles at one or more loci to produce genotypes with high penetrance that together may account for a substantial fraction of disease risk.", 
+                        "type": "paragraph"
+                    }
+                ], 
+                "type": "section", 
+                "id": "s3", 
+                "title": "Discussion"
+            }, 
+            {
+                "content": [
+                    {
+                        "content": [
+                            {
+                                "text": "Participants were ascertained from either the Yale Pediatric Craniofacial Clinic or by responding to an invitation posted on the Cranio Kids- Craniosynostosis Support and Craniosynostosis-Positional Plagiocephaly Support Facebook pages. All participants or their parents provided written informed consent to participate in a study of the\u00a0genetic causes of craniosynostosis in their family. Inclusion criteria included a\u00a0diagnosis of sagittal and/or metopic craniosynostosis in the absence of known syndromic forms of disease by a craniofacial plastic surgeon or pediatric neurosurgeon. All probands had undergone reconstructive surgery. Participating family members provided buccal swab samples (Isohelix SK-2S buccal swabs), craniofacial phenotype data, medical records, operative reports, and imaging studies. Written consent was obtained for publication of patient photographs. The study protocol was approved by the Yale Human Investigation Committee Institutional Review Board (IRB).", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "Control cohorts comprised 3337 previously studied healthy European parents of probands with autism, Europeans found in the NHLBI Exome Sequencing Project database (NHLBI), and Non-Finnish Europeans found in the Exome Aggregation Consortium v0.3 database (ExAC).", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-1", 
+                        "title": "Subjects and samples"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "DNA was prepared from buccal swab samples according to the manufacturer\u2019s protocol. Exome sequencing was performed by exon capture using the Roche MedExome or Roche V2 capture reagent followed by 74 base paired-end sequencing on the Illumina HiSeq 2000 instrument as previously described (<a href=\"#bib45\">Zaidi et al., 2013</a>). Samples were barcoded then captured and sequenced in multiplex. Quality metrics are shown in <a href=\"#SD5-data\">Supplementary file 1A</a>.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "Sequence reads were aligned to the GRCh37/hg19 human reference genome using BWA-Mem. Local realignment and quality score recalibration were performed using the GATK pipeline, after which variants were called using the Genome Analysis Toolkit Haplotype Caller. A Bayesian algorithm, TrioDeNovo, was used to call de novo mutations (<a href=\"#bib43\">Wei et al., 2015</a>). VQSR \"PASS\" variants with ExAC allele frequency \u22640.001 sequenced to a depth of 8 or greater in the proband and 12 or greater in each parent with Phred-scaled genotype likelihood scores &gt;30 and de novo quality scores (log<sub>10</sub>(Bayes factor)) &gt;6 were considered. Independent aligned reads at variant positions were visualized in silico to remove false calls (<a href=\"#fig2s1\">Figure 2\u2014figure supplement 1</a>). For de novo calls passing visual inspection, variants receiving the highest de novo genotype quality score (100) were deemed valid. Forty of these de novo mutations were selected at random for validation by bidirectional Sanger sequencing of the proband and both parents; 100% of these tests confirmed de novo mutation in the proband. The observed number of de novo variants identified per trio closely matched the expected Poisson distribution (<a href=\"#SD5-data\">Supplementary file 1F</a>). All de novo variants named in the main text were confirmed by Sanger sequencing. Transmitted variants were similarly aligned and called as per above. All de novo and transmitted variants were annotated using ANNOVAR (<a href=\"#bib41\">Wang et al., 2010</a>). Allele frequencies of identified variants were taken from the ExAC database. The impact of nonsynonymous variants was predicted using the MetaSVM rank score, with scores greater than 0.83357 serving as a threshold for predicting that the mutation was deleterious (MetaSVM 'D', D-mis) (<a href=\"#bib6\">Dong et al., 2015</a>). For case control burden analysis of all protein coding genes, all GATK VQSR 'PASS' variants were considered.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "In assessing the association of known risk alleles near <i>BMP2</i> and within <i>BBS9</i> with craniosynostosis in <i>SMAD6</i> mutation carriers, genotypes for rs1884302 and rs10262453 were determined by direct Sanger sequencing.", 
+                                "type": "paragraph"
+                            }, 
+                            {
+                                "text": "All mutations reported in <i>SMAD6, SMURF1, SPRY1</i>, and <i>SPRY4</i> were confirmed by direct bidirectional Sanger sequencing of the products of PCR amplification of segments containing putative mutations (<a href=\"#fig2s2\">Figure 2\u2014figure supplement 2</a>, <a href=\"#fig5\">Figure 5</a>, <a href=\"#fig6\">Figure 6</a>). PCR primers are listed in <a href=\"#SD3-data\">Figure 2\u2014source data 2</a>. Sanger sequencing electropherograms were manually inspected using Geneious after alignment to the reference genome sequence in GRCh37/hg19.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-2", 
+                        "title": "Exome sequencing, risk allele genotyping, and analysis"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "The observed distribution of mutation type was compared to pre-computed expected values across the exome using Poisson statistics as described (<a href=\"#bib42\">Ware et al., 2015</a>; <a href=\"#bib14\">Homsy et al., 2015</a>). Pre-calculated gene-specific mutation probabilities were used to determine the probability of the observed number and type of de novo mutations in <i>SMAD6</i> occurring by chance using denovolyzeR (<a href=\"#bib42\">Ware et al., 2015</a>; <a href=\"#bib32\">Samocha et al., 2014</a>).\u00a0To assess the probability of observing 3 protein damaging mutations, P values for observing 2 de novo LOF\u2019s and one de novo missense mutation were combined using the\u00a0Fisher\u2019s combined probability test. To assess the burden of de novo mutation in Sprouty genes, a gene set was curated in denovolyzeR including: <i>SPRY1, SPRY2, SPRY3, SPRY4</i>. The probability of observing 2 de novo LOF mutations in this gene set was calculated by comparing this number to expectation in denovolyzeR. The probability of observing more than one de novo LOF mutation in any gene in our cohort was determined using a permutation function- denovolyzeMultiHits() (<a href=\"#bib42\">Ware et al., 2015</a>). In total, 13 de novo LOF variants were observed in our cohort. The probability of observing &gt;1 de novo LOF in any gene by chance with a set of 13 mutations was determined by 1 million iterations in which these 13 \u2018hits\u2019 were sampled from all genes given the probability of de novo mutation in each (<a href=\"#bib14\">Homsy et al., 2015</a>). The number of times any gene had more than one hit in an iteration was counted, and that number divided by 1 million represented the probability of observing more than one de novo LOF mutation in our cohort.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-3", 
+                        "title": "Burden of de novo mutations"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "We infer that the number of probands with protein altering de novo mutations (n\u00a0=\u00a0123) in excess of expectation by chance (n\u00a0=\u00a0102.4) represents the number of subjects in whom these mutations confer craniosynostosis risk (n\u00a0=\u00a020.6). Comparing this fraction to the total number of trios (20.6/132) yields the fraction of patients in our cohort in whom we expect these mutations contribute to disease: ~15.6%.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-4", 
+                        "title": "Contribution of de novo mutation to craniosynostosis"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "The observed distribution of rare (ExAC frequency &lt;2 \u00d7 10<sup>\u20135</sup>) LOF and D-mis alleles was compared to the expected distribution using the binomial test. The total number of LOF and D-mis alleles in 191 probands was tabulated, totaling 1135 LOF alleles and 2021 D-mis alleles (3156 total damaging alleles). The expected number of variants in each gene was calculated from the proportion of the exome comprising the coding region of each gene multiplied by the total number of alleles identified in cases. Enrichment was calculated as the number of observed mutations divided by the expected number.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-5", 
+                        "title": "Binomial test"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "We used a transmission disequilibrium test to compare the transmission (M<sub>1</sub>) and non-transmission (M<sub>2</sub>) of <i>BMP2</i> and <i>BBS9</i> risk alleles (rs1884302 and rs10262453 respectively) to affected offspring in kindreds with <i>SMAD6</i> mutations. We tested for deviation from the expected transmission value of 50% by the binomial Chi-square test with 1 Df.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-6", 
+                        "title": "Transmission disequilibrium test"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "A fisher exact test was used to compare the prevalence of LOF or LOF+D-mis variants in 172 craniosynostosis probands and 3337 controls, the latter comprising the unaffected parents of offspring with autism. Controls were exome sequenced on the Roche V2 capture reagent followed by sequencing on the Illumina platform (<a href=\"#bib33\">Sanders et al., 2012</a>; <a href=\"#bib20\">Krumm et al., 2015</a>; <a href=\"#bib16\">Iossifov et al., 2012</a>). All control BAM files were processed with sequences aligned and variants called in parallel to aforementioned cases. Cases and controls, on average, both had ~94\u201395% of targeted bases read 8 or more times (<a href=\"#SD5-data\">Supplementary file 1A</a>). We restricted cases and controls to European (CEU) ancestry using the EIGENSTRAT program, which compared single nucleotide polymorphism (SNP) genotypes from case and control subjects with individuals of known ancestry in HapMap3 (<a href=\"#bib11\">Frazer et al., 2007</a>) (<a href=\"#fig3s2\">Figure 3\u2014figure supplement 2</a>). To avoid bias, exons analyzed were restricted to those that intersected between the Roche V2 and MedExome capture reagents. For genes with more than 1 LOF or D-mis variant in cases, aligned reads were visualized in silico at all variant positions in both cases and controls. For genes displaying p&lt;0.005, we compared the burden of mutated alleles in cases to European subjects in the NHLBI ESP and ExAC databases. The total number of alleles evaluated per gene was taken as the median of the allele numbers reported for all positions across a gene in NHLBI and ExAC respectively (<a href=\"#SD4-data\">Figure 3\u2014source data 1</a>).", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-7", 
+                        "title": "Case vs. control comparison"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "Parametric two locus linkage analysis was performed comparing the segregation of rare damaging <i>SMAD6</i> alleles and common <i>BMP2</i> risk alleles at rs1884302 to the segregation of craniosynostosis in kindreds harboring rare damaging <i>SMAD6</i> variants. Risk alleles at both loci were specified as showing zero recombination with underlying trait loci; risk/penetrance of each two locus genotype was estimated from their values at the maximum likelihood (<a href=\"#SD5-data\">Supplementary file 1C</a>). A phenocopy rate of\u00a00.02% was specified from estimates of disease prevalence and the fraction of disease attributable to risk genotypes. Likelihood ratios of the observed results occurring under the specified model vs. the alternative of chance were calculated for each kindred, converted to lod scores (<a href=\"#SD5-data\">Supplementary file 1D</a>) and the sum of lod scores across all kindreds was calculated. For kindreds (n = 2) with missing parental genotypes, the likelihood ratio of observed genotypes in offspring occurring under the parametric model compared to chance was estimated from ethnic-specific <i>BMP2</i> genotype frequencies and frequencies of rare damaging <i>SMAD6</i> alleles in missing parental genotypes. The likelihood ratio of the best two locus model was compared to that of the best single locus model considering only the segregation of rare damaging <i>SMAD6</i> variants.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-8", 
+                        "title": "Two locus linkage analysis"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "Kinship analysis was performed for all probands and controls using Plink. All trio structures were confirmed with parent-offspring pairs having PiHat values of 0.45\u20130.55.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-9", 
+                        "title": "Kinship analysis"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "GATK: (<a href=\"https://www.broadinstitute.org/gatk\">https://www.broadinstitute.org/gatk</a>); TrioDeNovo: (<a href=\"http://genome.sph.umich.edu/wiki/Triodenovo\">http://genome.sph.umich.edu/wiki/Triodenovo</a>); DenovolyzeR: (<a href=\"http://denovolyzer.org\">http://denovolyzer.org</a>); Plink: (<a href=\"http://pngu.mgh.harvard.edu/~purcell/plink\">http://pngu.mgh.harvard.edu/~purcell/plink</a>); MetaSVM/ANNOVAR: (<a href=\"http://annovar.openbioinformatics.org\">http://annovar.openbioinformatics.org</a>); NHLBI ESP: (<a href=\"http://evs.gs.washington.edu/EVS\">http://evs.gs.washington.edu/EVS</a>); ExAC03: (<a href=\"http://exac.broadinstitute.org\">http://exac.broadinstitute.org</a>); Geneious: (<a href=\"http://www.geneious.com\">www.geneious.com</a>). Isohelix Buccal Swab DNA isolation: (<a href=\"http://www.isohelix.com/wp-content/uploads/2015/09/BuccalFixIsoKit.pdf\">http://www.isohelix.com/wp-content/uploads/2015/09/BuccalFixIsoKit.pdf</a>).", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-10", 
+                        "title": "URLs"
+                    }, 
+                    {
+                        "content": [
+                            {
+                                "text": "Whole-exome sequencing data have been deposited in the database of Genotypes and Phenotypes (dbGaP) under accession phs000744. NCBI RefSeq accessions for all named genes are listed in <a href=\"#SD1-data\">Table 1\u2014source data 1</a>.", 
+                                "type": "paragraph"
+                            }
+                        ], 
+                        "type": "section", 
+                        "id": "s4-11", 
+                        "title": "Accession codes"
+                    }
+                ], 
+                "type": "section", 
+                "id": "s4", 
+                "title": "Materials and methods"
+            }
+        ], 
+        "versionDate": "2016-01-01T00:00:00Z", 
+        "abstract": {
+            "content": [
+                {
+                    "text": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging de novo or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP \u2013 induced osteoblast differentiation (p&lt;10<sup>\u221220</sup>). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases.", 
+                    "type": "paragraph"
+                }
+            ], 
+            "doi": "10.7554/eLife.20125.001"
+        }, 
+        "references": [
+            {
+                "doi": "10.1126/science.aaa5838", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
+                "pages": "aaa5838", 
+                "volume": "348", 
+                "articleTitle": "Embryo development. BMP gradients: A paradigm for morphogen-mediated developmental patterning", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bier, E", 
+                            "preferred": "E Bier"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "De Robertis, EM", 
+                            "preferred": "EM De Robertis"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib1"
+            }, 
+            {
+                "doi": "10.1111/j.1601-6343.2007.00393.x", 
+                "journal": {
+                    "name": [
+                        "Orthodontics & Craniofacial Research"
+                    ]
+                }, 
+                "pages": {
+                    "range": "129\u2013137", 
+                    "last": "137", 
+                    "first": "129"
+                }, 
+                "volume": "10", 
+                "articleTitle": "Genetic analysis of non-syndromic craniosynostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boyadjiev, SA", 
+                            "preferred": "SA Boyadjiev"
+                        }
+                    }, 
+                    {
+                        "type": "group", 
+                        "name": "International Craniosynostosis Consortium"
+                    }
+                ], 
+                "date": "2007", 
+                "type": "journal", 
+                "id": "bib2"
+            }, 
+            {
+                "doi": "10.1016/j.ydbio.2008.03.037", 
+                "journal": {
+                    "name": [
+                        "Developmental Biology"
+                    ]
+                }, 
+                "pages": {
+                    "range": "323\u2013334", 
+                    "last": "334", 
+                    "first": "323"
+                }, 
+                "volume": "318", 
+                "articleTitle": "Twist1 homodimers enhance FGF responsiveness of the cranial sutures and promote suture closure", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Connerney, J", 
+                            "preferred": "J Connerney"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Andreeva, V", 
+                            "preferred": "V Andreeva"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leshem, Y", 
+                            "preferred": "Y Leshem"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mercado, MA", 
+                            "preferred": "MA Mercado"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dowell, K", 
+                            "preferred": "K Dowell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yang, X", 
+                            "preferred": "X Yang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lindner, V", 
+                            "preferred": "V Lindner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Friesel, RE", 
+                            "preferred": "RE Friesel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Spicer, DB", 
+                            "preferred": "DB Spicer"
+                        }
+                    }
+                ], 
+                "date": "2008", 
+                "type": "journal", 
+                "id": "bib3"
+            }, 
+            {
+                "doi": "10.1016/j.ajhg.2009.03.001", 
+                "journal": {
+                    "name": [
+                        "American Journal of Human Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "483\u2013492", 
+                    "last": "492", 
+                    "first": "483"
+                }, 
+                "volume": "84", 
+                "articleTitle": "Duplications involving a conserved regulatory element downstream of BMP2 are associated with brachydactyly type A2", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dathe, K", 
+                            "preferred": "K Dathe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kjaer, KW", 
+                            "preferred": "KW Kjaer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brehm, A", 
+                            "preferred": "A Brehm"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Meinecke, P", 
+                            "preferred": "P Meinecke"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "N\u00fcrnberg, P", 
+                            "preferred": "P N\u00fcrnberg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Neto, JC", 
+                            "preferred": "JC Neto"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brunoni, D", 
+                            "preferred": "D Brunoni"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tommerup, N", 
+                            "preferred": "N Tommerup"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ott, CE", 
+                            "preferred": "CE Ott"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Klopocki, E", 
+                            "preferred": "E Klopocki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Seemann, P", 
+                            "preferred": "P Seemann"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mundlos, S", 
+                            "preferred": "S Mundlos"
+                        }
+                    }
+                ], 
+                "date": "2009", 
+                "type": "journal", 
+                "id": "bib4"
+            }, 
+            {
+                "doi": "10.1038/nature13772", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
+                "pages": {
+                    "range": "209\u2013215", 
+                    "last": "215", 
+                    "first": "209"
+                }, 
+                "volume": "515", 
+                "articleTitle": "Synaptic, transcriptional and chromatin genes disrupted in autism", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "De Rubeis, S", 
+                            "preferred": "S De Rubeis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "He, X", 
+                            "preferred": "X He"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Goldberg, AP", 
+                            "preferred": "AP Goldberg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Poultney, CS", 
+                            "preferred": "CS Poultney"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Samocha, K", 
+                            "preferred": "K Samocha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cicek, AE", 
+                            "preferred": "AE Cicek"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kou, Y", 
+                            "preferred": "Y Kou"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Liu, L", 
+                            "preferred": "L Liu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fromer, M", 
+                            "preferred": "M Fromer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Walker, S", 
+                            "preferred": "S Walker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Singh, T", 
+                            "preferred": "T Singh"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Klei, L", 
+                            "preferred": "L Klei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kosmicki, J", 
+                            "preferred": "J Kosmicki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shih-Chen, F", 
+                            "preferred": "F Shih-Chen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Aleksic, B", 
+                            "preferred": "B Aleksic"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Biscaldi, M", 
+                            "preferred": "M Biscaldi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bolton, PF", 
+                            "preferred": "PF Bolton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brownfeld, JM", 
+                            "preferred": "JM Brownfeld"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cai, J", 
+                            "preferred": "J Cai"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Campbell, NG", 
+                            "preferred": "NG Campbell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Carracedo, A", 
+                            "preferred": "A Carracedo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chahrour, MH", 
+                            "preferred": "MH Chahrour"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chiocchetti, AG", 
+                            "preferred": "AG Chiocchetti"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Coon, H", 
+                            "preferred": "H Coon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Crawford, EL", 
+                            "preferred": "EL Crawford"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Curran, SR", 
+                            "preferred": "SR Curran"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dawson, G", 
+                            "preferred": "G Dawson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Duketis, E", 
+                            "preferred": "E Duketis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fernandez, BA", 
+                            "preferred": "BA Fernandez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gallagher, L", 
+                            "preferred": "L Gallagher"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Geller, E", 
+                            "preferred": "E Geller"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Guter, SJ", 
+                            "preferred": "SJ Guter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hill, RS", 
+                            "preferred": "RS Hill"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ionita-Laza, J", 
+                            "preferred": "J Ionita-Laza"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jimenz Gonzalez, P", 
+                            "preferred": "P Jimenz Gonzalez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kilpinen, H", 
+                            "preferred": "H Kilpinen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Klauck, SM", 
+                            "preferred": "SM Klauck"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kolevzon, A", 
+                            "preferred": "A Kolevzon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lee, I", 
+                            "preferred": "I Lee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lei, I", 
+                            "preferred": "I Lei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lei, J", 
+                            "preferred": "J Lei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lehtim\u00e4ki, T", 
+                            "preferred": "T Lehtim\u00e4ki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lin, CF", 
+                            "preferred": "CF Lin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ma'ayan, A", 
+                            "preferred": "A Ma'ayan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marshall, CR", 
+                            "preferred": "CR Marshall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McInnes, AL", 
+                            "preferred": "AL McInnes"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Neale, B", 
+                            "preferred": "B Neale"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Owen, MJ", 
+                            "preferred": "MJ Owen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ozaki, N", 
+                            "preferred": "N Ozaki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Parellada, M", 
+                            "preferred": "M Parellada"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Parr, JR", 
+                            "preferred": "JR Parr"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Purcell, S", 
+                            "preferred": "S Purcell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Puura, K", 
+                            "preferred": "K Puura"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rajagopalan, D", 
+                            "preferred": "D Rajagopalan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rehnstr\u00f6m, K", 
+                            "preferred": "K Rehnstr\u00f6m"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Reichenberg, A", 
+                            "preferred": "A Reichenberg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sabo, A", 
+                            "preferred": "A Sabo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sachse, M", 
+                            "preferred": "M Sachse"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanders, SJ", 
+                            "preferred": "SJ Sanders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schafer, C", 
+                            "preferred": "C Schafer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schulte-R\u00fcther, M", 
+                            "preferred": "M Schulte-R\u00fcther"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Skuse, D", 
+                            "preferred": "D Skuse"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stevens, C", 
+                            "preferred": "C Stevens"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Szatmari, P", 
+                            "preferred": "P Szatmari"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tammimies, K", 
+                            "preferred": "K Tammimies"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Valladares, O", 
+                            "preferred": "O Valladares"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Voran, A", 
+                            "preferred": "A Voran"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Li-San, W", 
+                            "preferred": "W Li-San"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Weiss, LA", 
+                            "preferred": "LA Weiss"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Willsey, AJ", 
+                            "preferred": "AJ Willsey"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yu, TW", 
+                            "preferred": "TW Yu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yuen, RK", 
+                            "preferred": "RK Yuen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cook, EH", 
+                            "preferred": "EH Cook"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Freitag, CM", 
+                            "preferred": "CM Freitag"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gill, M", 
+                            "preferred": "M Gill"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hultman, CM", 
+                            "preferred": "CM Hultman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lehner, T", 
+                            "preferred": "T Lehner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Palotie, A", 
+                            "preferred": "A Palotie"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schellenberg, GD", 
+                            "preferred": "GD Schellenberg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sklar, P", 
+                            "preferred": "P Sklar"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "State, MW", 
+                            "preferred": "MW State"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sutcliffe, JS", 
+                            "preferred": "JS Sutcliffe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Walsh, CA", 
+                            "preferred": "CA Walsh"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Scherer, SW", 
+                            "preferred": "SW Scherer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zwick, ME", 
+                            "preferred": "ME Zwick"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Barett, JC", 
+                            "preferred": "JC Barett"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cutler, DJ", 
+                            "preferred": "DJ Cutler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roeder, K", 
+                            "preferred": "K Roeder"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Devlin, B", 
+                            "preferred": "B Devlin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Daly, MJ", 
+                            "preferred": "MJ Daly"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Buxbaum, JD", 
+                            "preferred": "JD Buxbaum"
+                        }
+                    }, 
+                    {
+                        "type": "group", 
+                        "name": "DDD Study"
+                    }, 
+                    {
+                        "type": "group", 
+                        "name": "Homozygosity Mapping Collaborative for Autism"
+                    }, 
+                    {
+                        "type": "group", 
+                        "name": "UK10K Consortium"
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib5"
+            }, 
+            {
+                "doi": "10.1093/hmg/ddu733", 
+                "journal": {
+                    "name": [
+                        "Human Molecular Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "2125\u20132137", 
+                    "last": "2137", 
+                    "first": "2125"
+                }, 
+                "volume": "24", 
+                "articleTitle": "Comparison and integration of deleteriousness prediction methods for nonsynonymous SNVs in whole exome sequencing studies", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dong, C", 
+                            "preferred": "C Dong"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wei, P", 
+                            "preferred": "P Wei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jian, X", 
+                            "preferred": "X Jian"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gibbs, R", 
+                            "preferred": "R Gibbs"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boerwinkle, E", 
+                            "preferred": "E Boerwinkle"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, K", 
+                            "preferred": "K Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Liu, X", 
+                            "preferred": "X Liu"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib6"
+            }, 
+            {
+                "doi": "10.1038/ng.2421", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1249\u20131254", 
+                    "last": "1254", 
+                    "first": "1249"
+                }, 
+                "volume": "44", 
+                "articleTitle": "Mutations in the TGF-\u03b2 repressor SKI cause Shprintzen-Goldberg syndrome with aortic aneurysm", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Doyle, AJ", 
+                            "preferred": "AJ Doyle"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Doyle, JJ", 
+                            "preferred": "JJ Doyle"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bessling, SL", 
+                            "preferred": "SL Bessling"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Maragh, S", 
+                            "preferred": "S Maragh"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lindsay, ME", 
+                            "preferred": "ME Lindsay"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schepers, D", 
+                            "preferred": "D Schepers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gillis, E", 
+                            "preferred": "E Gillis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mortier, G", 
+                            "preferred": "G Mortier"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Homfray, T", 
+                            "preferred": "T Homfray"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sauls, K", 
+                            "preferred": "K Sauls"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Norris, RA", 
+                            "preferred": "RA Norris"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Huso, ND", 
+                            "preferred": "ND Huso"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leahy, D", 
+                            "preferred": "D Leahy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mohr, DW", 
+                            "preferred": "DW Mohr"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Caulfield, MJ", 
+                            "preferred": "MJ Caulfield"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Scott, AF", 
+                            "preferred": "AF Scott"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Destr\u00e9e, A", 
+                            "preferred": "A Destr\u00e9e"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hennekam, RC", 
+                            "preferred": "RC Hennekam"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Arn, PH", 
+                            "preferred": "PH Arn"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Curry, CJ", 
+                            "preferred": "CJ Curry"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Van Laer, L", 
+                            "preferred": "L Van Laer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McCallion, AS", 
+                            "preferred": "AS McCallion"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Loeys, BL", 
+                            "preferred": "BL Loeys"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dietz, HC", 
+                            "preferred": "HC Dietz"
+                        }
+                    }
+                ], 
+                "date": "2012", 
+                "type": "journal", 
+                "id": "bib7"
+            }, 
+            {
+                "doi": "10.1002/jbmr.443", 
+                "journal": {
+                    "name": [
+                        "Journal of Bone and Mineral Research"
+                    ]
+                }, 
+                "pages": {
+                    "range": "2498\u20132510", 
+                    "last": "2510", 
+                    "first": "2498"
+                }, 
+                "volume": "26", 
+                "articleTitle": "Smad6 is essential to limit BMP signaling during cartilage development", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Estrada, KD", 
+                            "preferred": "KD Estrada"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Retting, KN", 
+                            "preferred": "KN Retting"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chin, AM", 
+                            "preferred": "AM Chin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lyons, KM", 
+                            "preferred": "KM Lyons"
+                        }
+                    }
+                ], 
+                "date": "2011", 
+                "type": "journal", 
+                "id": "bib8"
+            }, 
+            {
+                "doi": "10.1007/s00381-014-2474-8", 
+                "journal": {
+                    "name": [
+                        "Child's Nervous System"
+                    ]
+                }, 
+                "pages": {
+                    "range": "2157\u20132161", 
+                    "last": "2161", 
+                    "first": "2157"
+                }, 
+                "volume": "30", 
+                "articleTitle": "Craniosynostosis, psychomotor retardation, and facial dysmorphic features in a Spanish patient with a 4q27q28.3 deletion", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fern\u00e1ndez-Ja\u00e9n, A", 
+                            "preferred": "A Fern\u00e1ndez-Ja\u00e9n"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fern\u00e1ndez-Perrone, AL", 
+                            "preferred": "AL Fern\u00e1ndez-Perrone"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fern\u00e1ndez-Mayoralas, DM", 
+                            "preferred": "DM Fern\u00e1ndez-Mayoralas"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Calleja-P\u00e9rez, B", 
+                            "preferred": "B Calleja-P\u00e9rez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "S\u00e1nchez-Hombre, MC", 
+                            "preferred": "MC S\u00e1nchez-Hombre"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fern\u00e1ndez, EC", 
+                            "preferred": "EC Fern\u00e1ndez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "L\u00f3pez-Mart\u00edn, S", 
+                            "preferred": "S L\u00f3pez-Mart\u00edn"
+                        }
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib9"
+            }, 
+            {
+                "doi": "10.1002/wdev.227", 
+                "journal": {
+                    "name": [
+                        "Wiley Interdisciplinary Reviews: Developmental Biology"
+                    ]
+                }, 
+                "pages": {
+                    "range": "429\u2013459", 
+                    "last": "459", 
+                    "first": "429"
+                }, 
+                "volume": "5", 
+                "articleTitle": "Understanding craniosynostosis as a growth disorder", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Flaherty, K", 
+                            "preferred": "K Flaherty"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Singh, N", 
+                            "preferred": "N Singh"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Richtsmeier, JT", 
+                            "preferred": "JT Richtsmeier"
+                        }
+                    }
+                ], 
+                "date": "2016", 
+                "type": "journal", 
+                "id": "bib10"
+            }, 
+            {
+                "doi": "10.1038/nature06258", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
+                "pages": {
+                    "range": "851\u2013861", 
+                    "last": "861", 
+                    "first": "851"
+                }, 
+                "volume": "449", 
+                "articleTitle": "A second generation human haplotype map of over 3.1 million SNPs", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Frazer, KA", 
+                            "preferred": "KA Frazer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ballinger, DG", 
+                            "preferred": "DG Ballinger"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cox, DR", 
+                            "preferred": "DR Cox"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hinds, DA", 
+                            "preferred": "DA Hinds"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stuve, LL", 
+                            "preferred": "LL Stuve"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gibbs, RA", 
+                            "preferred": "RA Gibbs"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Belmont, JW", 
+                            "preferred": "JW Belmont"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boudreau, A", 
+                            "preferred": "A Boudreau"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hardenbol, P", 
+                            "preferred": "P Hardenbol"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leal, SM", 
+                            "preferred": "SM Leal"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pasternak, S", 
+                            "preferred": "S Pasternak"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wheeler, DA", 
+                            "preferred": "DA Wheeler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Willis, TD", 
+                            "preferred": "TD Willis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yu, F", 
+                            "preferred": "F Yu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yang, H", 
+                            "preferred": "H Yang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zeng, C", 
+                            "preferred": "C Zeng"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gao, Y", 
+                            "preferred": "Y Gao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hu, H", 
+                            "preferred": "H Hu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hu, W", 
+                            "preferred": "W Hu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Li, C", 
+                            "preferred": "C Li"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lin, W", 
+                            "preferred": "W Lin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Liu, S", 
+                            "preferred": "S Liu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pan, H", 
+                            "preferred": "H Pan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tang, X", 
+                            "preferred": "X Tang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, J", 
+                            "preferred": "J Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, W", 
+                            "preferred": "W Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yu, J", 
+                            "preferred": "J Yu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhang, B", 
+                            "preferred": "B Zhang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhang, Q", 
+                            "preferred": "Q Zhang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhao, H", 
+                            "preferred": "H Zhao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhao, H", 
+                            "preferred": "H Zhao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhou, J", 
+                            "preferred": "J Zhou"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gabriel, SB", 
+                            "preferred": "SB Gabriel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Barry, R", 
+                            "preferred": "R Barry"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Blumenstiel, B", 
+                            "preferred": "B Blumenstiel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Camargo, A", 
+                            "preferred": "A Camargo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Defelice, M", 
+                            "preferred": "M Defelice"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Faggart, M", 
+                            "preferred": "M Faggart"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Goyette, M", 
+                            "preferred": "M Goyette"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gupta, S", 
+                            "preferred": "S Gupta"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Moore, J", 
+                            "preferred": "J Moore"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nguyen, H", 
+                            "preferred": "H Nguyen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Onofrio, RC", 
+                            "preferred": "RC Onofrio"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Parkin, M", 
+                            "preferred": "M Parkin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roy, J", 
+                            "preferred": "J Roy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stahl, E", 
+                            "preferred": "E Stahl"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Winchester, E", 
+                            "preferred": "E Winchester"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ziaugra, L", 
+                            "preferred": "L Ziaugra"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Altshuler, D", 
+                            "preferred": "D Altshuler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shen, Y", 
+                            "preferred": "Y Shen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yao, Z", 
+                            "preferred": "Z Yao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Huang, W", 
+                            "preferred": "W Huang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chu, X", 
+                            "preferred": "X Chu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "He, Y", 
+                            "preferred": "Y He"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jin, L", 
+                            "preferred": "L Jin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Liu, Y", 
+                            "preferred": "Y Liu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shen, Y", 
+                            "preferred": "Y Shen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sun, W", 
+                            "preferred": "W Sun"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, H", 
+                            "preferred": "H Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, Y", 
+                            "preferred": "Y Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, Y", 
+                            "preferred": "Y Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Xiong, X", 
+                            "preferred": "X Xiong"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Xu, L", 
+                            "preferred": "L Xu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Waye, MM", 
+                            "preferred": "MM Waye"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tsui, SK", 
+                            "preferred": "SK Tsui"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Xue, H", 
+                            "preferred": "H Xue"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wong, JT", 
+                            "preferred": "JT Wong"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Galver, LM", 
+                            "preferred": "LM Galver"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fan, JB", 
+                            "preferred": "JB Fan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gunderson, K", 
+                            "preferred": "K Gunderson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Murray, SS", 
+                            "preferred": "SS Murray"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Oliphant, AR", 
+                            "preferred": "AR Oliphant"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chee, MS", 
+                            "preferred": "MS Chee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Montpetit, A", 
+                            "preferred": "A Montpetit"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chagnon, F", 
+                            "preferred": "F Chagnon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ferretti, V", 
+                            "preferred": "V Ferretti"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leboeuf, M", 
+                            "preferred": "M Leboeuf"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Olivier, JF", 
+                            "preferred": "JF Olivier"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Phillips, MS", 
+                            "preferred": "MS Phillips"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roumy, S", 
+                            "preferred": "S Roumy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sall\u00e9e, C", 
+                            "preferred": "C Sall\u00e9e"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Verner, A", 
+                            "preferred": "A Verner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hudson, TJ", 
+                            "preferred": "TJ Hudson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kwok, PY", 
+                            "preferred": "PY Kwok"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cai, D", 
+                            "preferred": "D Cai"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Koboldt, DC", 
+                            "preferred": "DC Koboldt"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Miller, RD", 
+                            "preferred": "RD Miller"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pawlikowska, L", 
+                            "preferred": "L Pawlikowska"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Taillon-Miller, P", 
+                            "preferred": "P Taillon-Miller"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Xiao, M", 
+                            "preferred": "M Xiao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tsui, LC", 
+                            "preferred": "LC Tsui"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mak, W", 
+                            "preferred": "W Mak"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Song, YQ", 
+                            "preferred": "YQ Song"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tam, PK", 
+                            "preferred": "PK Tam"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nakamura, Y", 
+                            "preferred": "Y Nakamura"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kawaguchi, T", 
+                            "preferred": "T Kawaguchi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kitamoto, T", 
+                            "preferred": "T Kitamoto"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Morizono, T", 
+                            "preferred": "T Morizono"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nagashima, A", 
+                            "preferred": "A Nagashima"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ohnishi, Y", 
+                            "preferred": "Y Ohnishi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sekine, A", 
+                            "preferred": "A Sekine"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tanaka, T", 
+                            "preferred": "T Tanaka"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tsunoda, T", 
+                            "preferred": "T Tsunoda"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Deloukas, P", 
+                            "preferred": "P Deloukas"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bird, CP", 
+                            "preferred": "CP Bird"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Delgado, M", 
+                            "preferred": "M Delgado"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dermitzakis, ET", 
+                            "preferred": "ET Dermitzakis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gwilliam, R", 
+                            "preferred": "R Gwilliam"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hunt, S", 
+                            "preferred": "S Hunt"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Morrison, J", 
+                            "preferred": "J Morrison"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Powell, D", 
+                            "preferred": "D Powell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stranger, BE", 
+                            "preferred": "BE Stranger"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Whittaker, P", 
+                            "preferred": "P Whittaker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bentley, DR", 
+                            "preferred": "DR Bentley"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Daly, MJ", 
+                            "preferred": "MJ Daly"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "de Bakker, PI", 
+                            "preferred": "PI de Bakker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Barrett, J", 
+                            "preferred": "J Barrett"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chretien, YR", 
+                            "preferred": "YR Chretien"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Maller, J", 
+                            "preferred": "J Maller"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McCarroll, S", 
+                            "preferred": "S McCarroll"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Patterson, N", 
+                            "preferred": "N Patterson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pe'er, I", 
+                            "preferred": "I Pe'er"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Price, A", 
+                            "preferred": "A Price"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Purcell, S", 
+                            "preferred": "S Purcell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Richter, DJ", 
+                            "preferred": "DJ Richter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sabeti, P", 
+                            "preferred": "P Sabeti"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Saxena, R", 
+                            "preferred": "R Saxena"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schaffner, SF", 
+                            "preferred": "SF Schaffner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sham, PC", 
+                            "preferred": "PC Sham"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Varilly, P", 
+                            "preferred": "P Varilly"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Altshuler, D", 
+                            "preferred": "D Altshuler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stein, LD", 
+                            "preferred": "LD Stein"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Krishnan, L", 
+                            "preferred": "L Krishnan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Smith, AV", 
+                            "preferred": "AV Smith"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tello-Ruiz, MK", 
+                            "preferred": "MK Tello-Ruiz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Thorisson, GA", 
+                            "preferred": "GA Thorisson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chakravarti, A", 
+                            "preferred": "A Chakravarti"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chen, PE", 
+                            "preferred": "PE Chen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cutler, DJ", 
+                            "preferred": "DJ Cutler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kashuk, CS", 
+                            "preferred": "CS Kashuk"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lin, S", 
+                            "preferred": "S Lin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Abecasis, GR", 
+                            "preferred": "GR Abecasis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Guan, W", 
+                            "preferred": "W Guan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Li, Y", 
+                            "preferred": "Y Li"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Munro, HM", 
+                            "preferred": "HM Munro"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Qin, ZS", 
+                            "preferred": "ZS Qin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Thomas, DJ", 
+                            "preferred": "DJ Thomas"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McVean, G", 
+                            "preferred": "G McVean"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Auton, A", 
+                            "preferred": "A Auton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bottolo, L", 
+                            "preferred": "L Bottolo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cardin, N", 
+                            "preferred": "N Cardin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Eyheramendy, S", 
+                            "preferred": "S Eyheramendy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Freeman, C", 
+                            "preferred": "C Freeman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marchini, J", 
+                            "preferred": "J Marchini"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Myers, S", 
+                            "preferred": "S Myers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Spencer, C", 
+                            "preferred": "C Spencer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stephens, M", 
+                            "preferred": "M Stephens"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Donnelly, P", 
+                            "preferred": "P Donnelly"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cardon, LR", 
+                            "preferred": "LR Cardon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Clarke, G", 
+                            "preferred": "G Clarke"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Evans, DM", 
+                            "preferred": "DM Evans"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Morris, AP", 
+                            "preferred": "AP Morris"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Weir, BS", 
+                            "preferred": "BS Weir"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tsunoda, T", 
+                            "preferred": "T Tsunoda"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mullikin, JC", 
+                            "preferred": "JC Mullikin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sherry, ST", 
+                            "preferred": "ST Sherry"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Feolo, M", 
+                            "preferred": "M Feolo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Skol, A", 
+                            "preferred": "A Skol"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhang, H", 
+                            "preferred": "H Zhang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zeng, C", 
+                            "preferred": "C Zeng"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhao, H", 
+                            "preferred": "H Zhao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Matsuda, I", 
+                            "preferred": "I Matsuda"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fukushima, Y", 
+                            "preferred": "Y Fukushima"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Macer, DR", 
+                            "preferred": "DR Macer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Suda, E", 
+                            "preferred": "E Suda"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rotimi, CN", 
+                            "preferred": "CN Rotimi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Adebamowo, CA", 
+                            "preferred": "CA Adebamowo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ajayi, I", 
+                            "preferred": "I Ajayi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Aniagwu, T", 
+                            "preferred": "T Aniagwu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marshall, PA", 
+                            "preferred": "PA Marshall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nkwodimmah, C", 
+                            "preferred": "C Nkwodimmah"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Royal, CD", 
+                            "preferred": "CD Royal"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leppert, MF", 
+                            "preferred": "MF Leppert"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dixon, M", 
+                            "preferred": "M Dixon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Peiffer, A", 
+                            "preferred": "A Peiffer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Qiu, R", 
+                            "preferred": "R Qiu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kent, A", 
+                            "preferred": "A Kent"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kato, K", 
+                            "preferred": "K Kato"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Niikawa, N", 
+                            "preferred": "N Niikawa"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Adewole, IF", 
+                            "preferred": "IF Adewole"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Knoppers, BM", 
+                            "preferred": "BM Knoppers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Foster, MW", 
+                            "preferred": "MW Foster"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Clayton, EW", 
+                            "preferred": "EW Clayton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Watkin, J", 
+                            "preferred": "J Watkin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gibbs, RA", 
+                            "preferred": "RA Gibbs"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Belmont, JW", 
+                            "preferred": "JW Belmont"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Muzny, D", 
+                            "preferred": "D Muzny"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nazareth, L", 
+                            "preferred": "L Nazareth"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sodergren, E", 
+                            "preferred": "E Sodergren"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Weinstock, GM", 
+                            "preferred": "GM Weinstock"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wheeler, DA", 
+                            "preferred": "DA Wheeler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yakub, I", 
+                            "preferred": "I Yakub"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gabriel, SB", 
+                            "preferred": "SB Gabriel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Onofrio, RC", 
+                            "preferred": "RC Onofrio"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Richter, DJ", 
+                            "preferred": "DJ Richter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ziaugra, L", 
+                            "preferred": "L Ziaugra"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Birren, BW", 
+                            "preferred": "BW Birren"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Daly, MJ", 
+                            "preferred": "MJ Daly"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Altshuler, D", 
+                            "preferred": "D Altshuler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilson, RK", 
+                            "preferred": "RK Wilson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fulton, LL", 
+                            "preferred": "LL Fulton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rogers, J", 
+                            "preferred": "J Rogers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Burton, J", 
+                            "preferred": "J Burton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Carter, NP", 
+                            "preferred": "NP Carter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Clee, CM", 
+                            "preferred": "CM Clee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Griffiths, M", 
+                            "preferred": "M Griffiths"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jones, MC", 
+                            "preferred": "MC Jones"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McLay, K", 
+                            "preferred": "K McLay"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Plumb, RW", 
+                            "preferred": "RW Plumb"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ross, MT", 
+                            "preferred": "MT Ross"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sims, SK", 
+                            "preferred": "SK Sims"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Willey, DL", 
+                            "preferred": "DL Willey"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chen, Z", 
+                            "preferred": "Z Chen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Han, H", 
+                            "preferred": "H Han"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kang, L", 
+                            "preferred": "L Kang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Godbout, M", 
+                            "preferred": "M Godbout"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wallenburg, JC", 
+                            "preferred": "JC Wallenburg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "L'Archev\u00eaque, P", 
+                            "preferred": "P L'Archev\u00eaque"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bellemare, G", 
+                            "preferred": "G Bellemare"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Saeki, K", 
+                            "preferred": "K Saeki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, H", 
+                            "preferred": "H Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "An, D", 
+                            "preferred": "D An"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fu, H", 
+                            "preferred": "H Fu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Li, Q", 
+                            "preferred": "Q Li"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, Z", 
+                            "preferred": "Z Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, R", 
+                            "preferred": "R Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Holden, AL", 
+                            "preferred": "AL Holden"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brooks, LD", 
+                            "preferred": "LD Brooks"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McEwen, JE", 
+                            "preferred": "JE McEwen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Guyer, MS", 
+                            "preferred": "MS Guyer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, VO", 
+                            "preferred": "VO Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Peterson, JL", 
+                            "preferred": "JL Peterson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shi, M", 
+                            "preferred": "M Shi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Spiegel, J", 
+                            "preferred": "J Spiegel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sung, LM", 
+                            "preferred": "LM Sung"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zacharia, LF", 
+                            "preferred": "LF Zacharia"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Collins, FS", 
+                            "preferred": "FS Collins"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kennedy, K", 
+                            "preferred": "K Kennedy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jamieson, R", 
+                            "preferred": "R Jamieson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stewart, J", 
+                            "preferred": "J Stewart"
+                        }
+                    }, 
+                    {
+                        "type": "group", 
+                        "name": "International HapMap Consortium"
+                    }
+                ], 
+                "date": "2007", 
+                "type": "journal", 
+                "id": "bib11"
+            }, 
+            {
+                "doi": "10.1038/gim.2013.134", 
+                "journal": {
+                    "name": [
+                        "Genetics in Medicine"
+                    ]
+                }, 
+                "pages": {
+                    "range": "302\u2013310", 
+                    "last": "310", 
+                    "first": "302"
+                }, 
+                "volume": "16", 
+                "articleTitle": "Familial incidence and associated symptoms in a population of individuals with nonsyndromic craniosynostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Greenwood, J", 
+                            "preferred": "J Greenwood"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Flodman, P", 
+                            "preferred": "P Flodman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Osann, K", 
+                            "preferred": "K Osann"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boyadjiev, SA", 
+                            "preferred": "SA Boyadjiev"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kimonis, V", 
+                            "preferred": "V Kimonis"
+                        }
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib12"
+            }, 
+            {
+                "doi": "10.1101/gad.12.2.186", 
+                "journal": {
+                    "name": [
+                        "Genes & Development"
+                    ]
+                }, 
+                "pages": {
+                    "range": "186\u2013197", 
+                    "last": "197", 
+                    "first": "186"
+                }, 
+                "volume": "12", 
+                "articleTitle": "Smad6 inhibits BMP/Smad1 signaling by specifically competing with the Smad4 tumor suppressor", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hata, A", 
+                            "preferred": "A Hata"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lagna, G", 
+                            "preferred": "G Lagna"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Massagu\u00e9, J", 
+                            "preferred": "J Massagu\u00e9"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hemmati-Brivanlou, A", 
+                            "preferred": "A Hemmati-Brivanlou"
+                        }
+                    }
+                ], 
+                "date": "1998", 
+                "type": "journal", 
+                "id": "bib13"
+            }, 
+            {
+                "doi": "10.1126/science.aac9396", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1262\u20131266", 
+                    "last": "1266", 
+                    "first": "1262"
+                }, 
+                "volume": "350", 
+                "articleTitle": "De novo mutations in congenital heart disease with neurodevelopmental and other congenital anomalies", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Homsy, J", 
+                            "preferred": "J Homsy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zaidi, S", 
+                            "preferred": "S Zaidi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shen, Y", 
+                            "preferred": "Y Shen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ware, JS", 
+                            "preferred": "JS Ware"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Samocha, KE", 
+                            "preferred": "KE Samocha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Karczewski, KJ", 
+                            "preferred": "KJ Karczewski"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "DePalma, SR", 
+                            "preferred": "SR DePalma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McKean, D", 
+                            "preferred": "D McKean"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wakimoto, H", 
+                            "preferred": "H Wakimoto"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gorham, J", 
+                            "preferred": "J Gorham"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jin, SC", 
+                            "preferred": "SC Jin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Deanfield, J", 
+                            "preferred": "J Deanfield"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Giardini, A", 
+                            "preferred": "A Giardini"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Porter, GA", 
+                            "preferred": "GA Porter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kim, R", 
+                            "preferred": "R Kim"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bilguvar, K", 
+                            "preferred": "K Bilguvar"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "L\u00f3pez-Gir\u00e1ldez, F", 
+                            "preferred": "F L\u00f3pez-Gir\u00e1ldez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tikhonova, I", 
+                            "preferred": "I Tikhonova"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mane, S", 
+                            "preferred": "S Mane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Romano-Adesman, A", 
+                            "preferred": "A Romano-Adesman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Qi, H", 
+                            "preferred": "H Qi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Vardarajan, B", 
+                            "preferred": "B Vardarajan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ma, L", 
+                            "preferred": "L Ma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Daly, M", 
+                            "preferred": "M Daly"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roberts, AE", 
+                            "preferred": "AE Roberts"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Russell, MW", 
+                            "preferred": "MW Russell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mital, S", 
+                            "preferred": "S Mital"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Newburger, JW", 
+                            "preferred": "JW Newburger"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gaynor, JW", 
+                            "preferred": "JW Gaynor"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Breitbart, RE", 
+                            "preferred": "RE Breitbart"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Iossifov, I", 
+                            "preferred": "I Iossifov"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ronemus, M", 
+                            "preferred": "M Ronemus"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanders, SJ", 
+                            "preferred": "SJ Sanders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kaltman, JR", 
+                            "preferred": "JR Kaltman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Seidman, JG", 
+                            "preferred": "JG Seidman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brueckner, M", 
+                            "preferred": "M Brueckner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gelb, BD", 
+                            "preferred": "BD Gelb"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Goldmuntz, E", 
+                            "preferred": "E Goldmuntz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lifton, RP", 
+                            "preferred": "RP Lifton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Seidman, CE", 
+                            "preferred": "CE Seidman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chung, WK", 
+                            "preferred": "WK Chung"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib14"
+            }, 
+            {
+                "doi": "10.1038/nature13908", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
+                "pages": {
+                    "range": "216\u2013221", 
+                    "last": "221", 
+                    "first": "216"
+                }, 
+                "volume": "515", 
+                "articleTitle": "The contribution of de novo coding mutations to autism spectrum disorder", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Iossifov, I", 
+                            "preferred": "I Iossifov"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "O'Roak, BJ", 
+                            "preferred": "BJ O'Roak"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanders, SJ", 
+                            "preferred": "SJ Sanders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ronemus, M", 
+                            "preferred": "M Ronemus"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Krumm, N", 
+                            "preferred": "N Krumm"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Levy, D", 
+                            "preferred": "D Levy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stessman, HA", 
+                            "preferred": "HA Stessman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Witherspoon, KT", 
+                            "preferred": "KT Witherspoon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Vives, L", 
+                            "preferred": "L Vives"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Patterson, KE", 
+                            "preferred": "KE Patterson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Smith, JD", 
+                            "preferred": "JD Smith"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Paeper, B", 
+                            "preferred": "B Paeper"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nickerson, DA", 
+                            "preferred": "DA Nickerson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dea, J", 
+                            "preferred": "J Dea"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dong, S", 
+                            "preferred": "S Dong"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gonzalez, LE", 
+                            "preferred": "LE Gonzalez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mandell, JD", 
+                            "preferred": "JD Mandell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mane, SM", 
+                            "preferred": "SM Mane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Murtha, MT", 
+                            "preferred": "MT Murtha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sullivan, CA", 
+                            "preferred": "CA Sullivan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Walker, MF", 
+                            "preferred": "MF Walker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Waqar, Z", 
+                            "preferred": "Z Waqar"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wei, L", 
+                            "preferred": "L Wei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Willsey, AJ", 
+                            "preferred": "AJ Willsey"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yamrom, B", 
+                            "preferred": "B Yamrom"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lee, YH", 
+                            "preferred": "YH Lee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Grabowska, E", 
+                            "preferred": "E Grabowska"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dalkic, E", 
+                            "preferred": "E Dalkic"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, Z", 
+                            "preferred": "Z Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marks, S", 
+                            "preferred": "S Marks"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Andrews, P", 
+                            "preferred": "P Andrews"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leotta, A", 
+                            "preferred": "A Leotta"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kendall, J", 
+                            "preferred": "J Kendall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hakker, I", 
+                            "preferred": "I Hakker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rosenbaum, J", 
+                            "preferred": "J Rosenbaum"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ma, B", 
+                            "preferred": "B Ma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rodgers, L", 
+                            "preferred": "L Rodgers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Troge, J", 
+                            "preferred": "J Troge"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Narzisi, G", 
+                            "preferred": "G Narzisi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yoon, S", 
+                            "preferred": "S Yoon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schatz, MC", 
+                            "preferred": "MC Schatz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ye, K", 
+                            "preferred": "K Ye"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McCombie, WR", 
+                            "preferred": "WR McCombie"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shendure, J", 
+                            "preferred": "J Shendure"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Eichler, EE", 
+                            "preferred": "EE Eichler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "State, MW", 
+                            "preferred": "MW State"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wigler, M", 
+                            "preferred": "M Wigler"
+                        }
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib15"
+            }, 
+            {
+                "doi": "10.1016/j.neuron.2012.04.009", 
+                "journal": {
+                    "name": [
+                        "Neuron"
+                    ]
+                }, 
+                "pages": {
+                    "range": "285\u2013299", 
+                    "last": "299", 
+                    "first": "285"
+                }, 
+                "volume": "74", 
+                "articleTitle": "De novo gene disruptions in children on the autistic spectrum", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Iossifov, I", 
+                            "preferred": "I Iossifov"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ronemus, M", 
+                            "preferred": "M Ronemus"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Levy, D", 
+                            "preferred": "D Levy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, Z", 
+                            "preferred": "Z Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hakker, I", 
+                            "preferred": "I Hakker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rosenbaum, J", 
+                            "preferred": "J Rosenbaum"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yamrom, B", 
+                            "preferred": "B Yamrom"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lee, YH", 
+                            "preferred": "YH Lee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Narzisi, G", 
+                            "preferred": "G Narzisi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leotta, A", 
+                            "preferred": "A Leotta"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kendall, J", 
+                            "preferred": "J Kendall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Grabowska, E", 
+                            "preferred": "E Grabowska"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ma, B", 
+                            "preferred": "B Ma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marks, S", 
+                            "preferred": "S Marks"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rodgers, L", 
+                            "preferred": "L Rodgers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stepansky, A", 
+                            "preferred": "A Stepansky"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Troge, J", 
+                            "preferred": "J Troge"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Andrews, P", 
+                            "preferred": "P Andrews"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bekritsky, M", 
+                            "preferred": "M Bekritsky"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pradhan, K", 
+                            "preferred": "K Pradhan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ghiban, E", 
+                            "preferred": "E Ghiban"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kramer, M", 
+                            "preferred": "M Kramer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Parla, J", 
+                            "preferred": "J Parla"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Demeter, R", 
+                            "preferred": "R Demeter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fulton, LL", 
+                            "preferred": "LL Fulton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fulton, RS", 
+                            "preferred": "RS Fulton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Magrini, VJ", 
+                            "preferred": "VJ Magrini"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ye, K", 
+                            "preferred": "K Ye"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Darnell, JC", 
+                            "preferred": "JC Darnell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Darnell, RB", 
+                            "preferred": "RB Darnell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mardis, ER", 
+                            "preferred": "ER Mardis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilson, RK", 
+                            "preferred": "RK Wilson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schatz, MC", 
+                            "preferred": "MC Schatz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McCombie, WR", 
+                            "preferred": "WR McCombie"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wigler, M", 
+                            "preferred": "M Wigler"
+                        }
+                    }
+                ], 
+                "date": "2012", 
+                "type": "journal", 
+                "id": "bib16"
+            }, 
+            {
+                "doi": "10.1074/jbc.M705578200", 
+                "journal": {
+                    "name": [
+                        "Journal of Biological Chemistry"
+                    ]
+                }, 
+                "pages": {
+                    "range": "8412\u20138422", 
+                    "last": "8422", 
+                    "first": "8412"
+                }, 
+                "volume": "283", 
+                "articleTitle": "Structural coupling of Smad and Runx2 for execution of the BMP2 osteogenic signal", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Javed, A", 
+                            "preferred": "A Javed"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bae, JS", 
+                            "preferred": "JS Bae"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Afzal, F", 
+                            "preferred": "F Afzal"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gutierrez, S", 
+                            "preferred": "S Gutierrez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pratap, J", 
+                            "preferred": "J Pratap"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zaidi, SK", 
+                            "preferred": "SK Zaidi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lou, Y", 
+                            "preferred": "Y Lou"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "van Wijnen, AJ", 
+                            "preferred": "AJ van Wijnen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stein, JL", 
+                            "preferred": "JL Stein"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stein, GS", 
+                            "preferred": "GS Stein"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lian, JB", 
+                            "preferred": "JB Lian"
+                        }
+                    }
+                ], 
+                "date": "2008", 
+                "type": "journal", 
+                "id": "bib17"
+            }, 
+            {
+                "doi": "10.1038/ng.2463", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1360\u20131364", 
+                    "last": "1364", 
+                    "first": "1360"
+                }, 
+                "volume": "44", 
+                "articleTitle": "A genome-wide association study identifies susceptibility loci for nonsyndromic sagittal craniosynostosis near BMP2 and within BBS9", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Justice, CM", 
+                            "preferred": "CM Justice"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yagnik, G", 
+                            "preferred": "G Yagnik"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kim, Y", 
+                            "preferred": "Y Kim"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Peter, I", 
+                            "preferred": "I Peter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jabs, EW", 
+                            "preferred": "EW Jabs"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Erazo, M", 
+                            "preferred": "M Erazo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ye, X", 
+                            "preferred": "X Ye"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ainehsazan, E", 
+                            "preferred": "E Ainehsazan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shi, L", 
+                            "preferred": "L Shi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cunningham, ML", 
+                            "preferred": "ML Cunningham"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kimonis, V", 
+                            "preferred": "V Kimonis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roscioli, T", 
+                            "preferred": "T Roscioli"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wall, SA", 
+                            "preferred": "SA Wall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilkie, AO", 
+                            "preferred": "AO Wilkie"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stoler, J", 
+                            "preferred": "J Stoler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Richtsmeier, JT", 
+                            "preferred": "JT Richtsmeier"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Heuz\u00e9, Y", 
+                            "preferred": "Y Heuz\u00e9"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanchez-Lara, PA", 
+                            "preferred": "PA Sanchez-Lara"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Buckley, MF", 
+                            "preferred": "MF Buckley"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Druschel, CM", 
+                            "preferred": "CM Druschel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mills, JL", 
+                            "preferred": "JL Mills"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Caggana, M", 
+                            "preferred": "M Caggana"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Romitti, PA", 
+                            "preferred": "PA Romitti"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kay, DM", 
+                            "preferred": "DM Kay"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Senders, C", 
+                            "preferred": "C Senders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Taub, PJ", 
+                            "preferred": "PJ Taub"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Klein, OD", 
+                            "preferred": "OD Klein"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boggan, J", 
+                            "preferred": "J Boggan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zwienenberg-Lee, M", 
+                            "preferred": "M Zwienenberg-Lee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Naydenov, C", 
+                            "preferred": "C Naydenov"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kim, J", 
+                            "preferred": "J Kim"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilson, AF", 
+                            "preferred": "AF Wilson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boyadjiev, SA", 
+                            "preferred": "SA Boyadjiev"
+                        }
+                    }
+                ], 
+                "date": "2012", 
+                "type": "journal", 
+                "id": "bib18"
+            }, 
+            {
+                "doi": "10.1002/jbmr.1857", 
+                "journal": {
+                    "name": [
+                        "Journal of Bone and Mineral Research"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1422\u20131433", 
+                    "last": "1433", 
+                    "first": "1422"
+                }, 
+                "volume": "28", 
+                "articleTitle": "Augmentation of Smad-dependent BMP signaling in neural crest cells causes craniosynostosis in mice", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Komatsu, Y", 
+                            "preferred": "Y Komatsu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yu, PB", 
+                            "preferred": "PB Yu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kamiya, N", 
+                            "preferred": "N Kamiya"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pan, H", 
+                            "preferred": "H Pan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fukuda, T", 
+                            "preferred": "T Fukuda"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Scott, GJ", 
+                            "preferred": "GJ Scott"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ray, MK", 
+                            "preferred": "MK Ray"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yamamura, K", 
+                            "preferred": "K Yamamura"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mishina, Y", 
+                            "preferred": "Y Mishina"
+                        }
+                    }
+                ], 
+                "date": "2013", 
+                "type": "journal", 
+                "id": "bib19"
+            }, 
+            {
+                "doi": "10.1038/ng.3303", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "582\u2013588", 
+                    "last": "588", 
+                    "first": "582"
+                }, 
+                "volume": "47", 
+                "articleTitle": "Excess of rare, inherited truncating mutations in autism", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Krumm, N", 
+                            "preferred": "N Krumm"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Turner, TN", 
+                            "preferred": "TN Turner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Baker, C", 
+                            "preferred": "C Baker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Vives, L", 
+                            "preferred": "L Vives"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mohajeri, K", 
+                            "preferred": "K Mohajeri"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Witherspoon, K", 
+                            "preferred": "K Witherspoon"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Raja, A", 
+                            "preferred": "A Raja"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Coe, BP", 
+                            "preferred": "BP Coe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stessman, HA", 
+                            "preferred": "HA Stessman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "He, ZX", 
+                            "preferred": "ZX He"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leal, SM", 
+                            "preferred": "SM Leal"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bernier, R", 
+                            "preferred": "R Bernier"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Eichler, EE", 
+                            "preferred": "EE Eichler"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib20"
+            }, 
+            {
+                "doi": "10.1038/ng1511", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "275\u2013281", 
+                    "last": "281", 
+                    "first": "275"
+                }, 
+                "volume": "37", 
+                "articleTitle": "A syndrome of altered cardiovascular, craniofacial, neurocognitive and skeletal development caused by mutations in TGFBR1 or TGFBR2", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Loeys, BL", 
+                            "preferred": "BL Loeys"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chen, J", 
+                            "preferred": "J Chen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Neptune, ER", 
+                            "preferred": "ER Neptune"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Judge, DP", 
+                            "preferred": "DP Judge"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Podowski, M", 
+                            "preferred": "M Podowski"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Holm, T", 
+                            "preferred": "T Holm"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Meyers, J", 
+                            "preferred": "J Meyers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leitch, CC", 
+                            "preferred": "CC Leitch"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Katsanis, N", 
+                            "preferred": "N Katsanis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sharifi, N", 
+                            "preferred": "N Sharifi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Xu, FL", 
+                            "preferred": "FL Xu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Myers, LA", 
+                            "preferred": "LA Myers"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Spevak, PJ", 
+                            "preferred": "PJ Spevak"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cameron, DE", 
+                            "preferred": "DE Cameron"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "De Backer, J", 
+                            "preferred": "J De Backer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hellemans, J", 
+                            "preferred": "J Hellemans"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chen, Y", 
+                            "preferred": "Y Chen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Davis, EC", 
+                            "preferred": "EC Davis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Webb, CL", 
+                            "preferred": "CL Webb"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kress, W", 
+                            "preferred": "W Kress"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Coucke, P", 
+                            "preferred": "P Coucke"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rifkin, DB", 
+                            "preferred": "DB Rifkin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "De Paepe, AM", 
+                            "preferred": "AM De Paepe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Dietz, HC", 
+                            "preferred": "HC Dietz"
+                        }
+                    }
+                ], 
+                "date": "2005", 
+                "type": "journal", 
+                "id": "bib21"
+            }, 
+            {
+                "doi": "10.1038/ng.2479", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1291\u20131292", 
+                    "last": "1292", 
+                    "first": "1291"
+                }, 
+                "volume": "44", 
+                "articleTitle": "Digenic inheritance and mendelian disease", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lupski, JR", 
+                            "preferred": "JR Lupski"
+                        }
+                    }
+                ], 
+                "date": "2012", 
+                "type": "journal", 
+                "id": "bib22"
+            }, 
+            {
+                "doi": "10.1097/00001665-200201000-00023", 
+                "journal": {
+                    "name": [
+                        "Journal of Craniofacial Surgery"
+                    ]
+                }, 
+                "pages": {
+                    "range": "99\u2013104", 
+                    "last": "104", 
+                    "first": "99"
+                }, 
+                "volume": "13", 
+                "articleTitle": "Long-term neuropsychological effects of sagittal craniosynostosis on child development", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Magge, SN", 
+                            "preferred": "SN Magge"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Westerveld, M", 
+                            "preferred": "M Westerveld"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pruzinsky, T", 
+                            "preferred": "T Pruzinsky"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Persing, JA", 
+                            "preferred": "JA Persing"
+                        }
+                    }
+                ], 
+                "date": "2002", 
+                "type": "journal", 
+                "id": "bib23"
+            }, 
+            {
+                "doi": "10.1002/ajmg.a.33557", 
+                "journal": {
+                    "name": [
+                        "American Journal of Medical Genetics Part A"
+                    ]
+                }, 
+                "pages": {
+                    "range": "2203\u20132210", 
+                    "last": "2210", 
+                    "first": "2203"
+                }, 
+                "volume": "152A", 
+                "articleTitle": "Copy number variation analysis in single-suture craniosynostosis: multiple rare variants including RUNX2 duplication in two cousins with metopic craniosynostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mefford, HC", 
+                            "preferred": "HC Mefford"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shafer, N", 
+                            "preferred": "N Shafer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Antonacci, F", 
+                            "preferred": "F Antonacci"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tsai, JM", 
+                            "preferred": "JM Tsai"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Park, SS", 
+                            "preferred": "SS Park"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hing, AV", 
+                            "preferred": "AV Hing"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rieder, MJ", 
+                            "preferred": "MJ Rieder"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Smyth, MD", 
+                            "preferred": "MD Smyth"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Speltz, ML", 
+                            "preferred": "ML Speltz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Eichler, EE", 
+                            "preferred": "EE Eichler"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cunningham, ML", 
+                            "preferred": "ML Cunningham"
+                        }
+                    }
+                ], 
+                "date": "2010", 
+                "type": "journal", 
+                "id": "bib24"
+            }, 
+            {
+                "doi": "10.1016/j.yexcr.2014.01.019", 
+                "journal": {
+                    "name": [
+                        "Experimental Cell Research"
+                    ]
+                }, 
+                "pages": {
+                    "range": "138\u2013147", 
+                    "last": "147", 
+                    "first": "138"
+                }, 
+                "volume": "325", 
+                "articleTitle": "Neural crest cell signaling pathways critical to cranial bone development and pathology", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mishina, Y", 
+                            "preferred": "Y Mishina"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Snider, TN", 
+                            "preferred": "TN Snider"
+                        }
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib25"
+            }, 
+            {
+                "doi": "10.1091/mbc.E02-07-0441", 
+                "journal": {
+                    "name": [
+                        "Molecular Biology of the Cell"
+                    ]
+                }, 
+                "pages": {
+                    "range": "2809\u20132817", 
+                    "last": "2817", 
+                    "first": "2809"
+                }, 
+                "volume": "14", 
+                "articleTitle": "Cooperative inhibition of bone morphogenetic protein signaling by Smurf1 and inhibitory Smads", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Murakami, G", 
+                            "preferred": "G Murakami"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Watabe, T", 
+                            "preferred": "T Watabe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Takaoka, K", 
+                            "preferred": "K Takaoka"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Miyazono, K", 
+                            "preferred": "K Miyazono"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Imamura, T", 
+                            "preferred": "T Imamura"
+                        }
+                    }
+                ], 
+                "date": "2003", 
+                "type": "journal", 
+                "id": "bib26"
+            }, 
+            {
+                "doi": "10.1038/ng.835", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "585\u2013589", 
+                    "last": "589", 
+                    "first": "585"
+                }, 
+                "volume": "43", 
+                "articleTitle": "Exome sequencing in sporadic autism spectrum disorders identifies severe de novo mutations", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "O'Roak, BJ", 
+                            "preferred": "BJ O'Roak"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Deriziotis, P", 
+                            "preferred": "P Deriziotis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lee, C", 
+                            "preferred": "C Lee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Vives, L", 
+                            "preferred": "L Vives"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schwartz, JJ", 
+                            "preferred": "JJ Schwartz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Girirajan, S", 
+                            "preferred": "S Girirajan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Karakoc, E", 
+                            "preferred": "E Karakoc"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mackenzie, AP", 
+                            "preferred": "AP Mackenzie"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ng, SB", 
+                            "preferred": "SB Ng"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Baker, C", 
+                            "preferred": "C Baker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rieder, MJ", 
+                            "preferred": "MJ Rieder"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Nickerson, DA", 
+                            "preferred": "DA Nickerson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bernier, R", 
+                            "preferred": "R Bernier"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fisher, SE", 
+                            "preferred": "SE Fisher"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shendure, J", 
+                            "preferred": "J Shendure"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Eichler, EE", 
+                            "preferred": "EE Eichler"
+                        }
+                    }
+                ], 
+                "date": "2011", 
+                "type": "journal", 
+                "id": "bib27"
+            }, 
+            {
+                "doi": "10.1097/PRS.0000000000000511", 
+                "journal": {
+                    "name": [
+                        "Plastic and Reconstructive Surgery"
+                    ]
+                }, 
+                "pages": {
+                    "range": "608e\u2013617e", 
+                    "last": "617e", 
+                    "first": "608e"
+                }, 
+                "volume": "134", 
+                "articleTitle": "The impact of age at surgery on long-term neuropsychological outcomes in sagittal craniosynostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Patel, A", 
+                            "preferred": "A Patel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Yang, JF", 
+                            "preferred": "JF Yang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hashim, PW", 
+                            "preferred": "PW Hashim"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Travieso, R", 
+                            "preferred": "R Travieso"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Terner, J", 
+                            "preferred": "J Terner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mayes, LC", 
+                            "preferred": "LC Mayes"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kanev, P", 
+                            "preferred": "P Kanev"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Duncan, C", 
+                            "preferred": "C Duncan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jane, J", 
+                            "preferred": "J Jane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jane, J", 
+                            "preferred": "J Jane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pollack, I", 
+                            "preferred": "I Pollack"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Losee, JE", 
+                            "preferred": "JE Losee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bridgett, DJ", 
+                            "preferred": "DJ Bridgett"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Persing, JA", 
+                            "preferred": "JA Persing"
+                        }
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib28"
+            }, 
+            {
+                "title": "Scientific Foundations and Surgical Treatment of Craniosynostosis", 
+                "details": "117\u2013238, Surgical treatment of craniosynostosis, Scientific Foundations and Surgical Treatment of Craniosynostosis, Baltimore, Williams and Wilkins", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Persing, JA", 
+                            "preferred": "JA Persing"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jane, JA", 
+                            "preferred": "JA Jane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Edgerton, MT", 
+                            "preferred": "MT Edgerton"
+                        }
+                    }
+                ], 
+                "date": "1989", 
+                "type": "unknown", 
+                "id": "bib29"
+            }, 
+            {
+                "title": "Smad Proteins and the Regulation of Endochondral Bone Formation. PhD Thesis", 
+                "uri": "http://search.proquest.com/docview/304651496", 
+                "details": "Smad Proteins and the Regulation of Endochondral Bone Formation. PhD Thesis, University of California,\u00a0Los Angeles., http://search.proquest.com/docview/304651496", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Retting, KN", 
+                            "preferred": "KN Retting"
+                        }
+                    }
+                ], 
+                "date": "2008", 
+                "type": "unknown", 
+                "id": "bib30"
+            }, 
+            {
+                "doi": "10.1038/nrendo.2016.12", 
+                "journal": {
+                    "name": [
+                        "Nature Reviews Endocrinology"
+                    ]
+                }, 
+                "pages": {
+                    "range": "203\u2013221", 
+                    "last": "221", 
+                    "first": "203"
+                }, 
+                "volume": "12", 
+                "articleTitle": "BMP signalling in skeletal development, disease and repair", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Salazar, VS", 
+                            "preferred": "VS Salazar"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gamer, LW", 
+                            "preferred": "LW Gamer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rosen, V", 
+                            "preferred": "V Rosen"
+                        }
+                    }
+                ], 
+                "date": "2016", 
+                "type": "journal", 
+                "id": "bib31"
+            }, 
+            {
+                "doi": "10.1038/ng.3050", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "944\u2013950", 
+                    "last": "950", 
+                    "first": "944"
+                }, 
+                "volume": "46", 
+                "articleTitle": "A framework for the interpretation of de novo mutation in human disease", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Samocha, KE", 
+                            "preferred": "KE Samocha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Robinson, EB", 
+                            "preferred": "EB Robinson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanders, SJ", 
+                            "preferred": "SJ Sanders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stevens, C", 
+                            "preferred": "C Stevens"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sabo, A", 
+                            "preferred": "A Sabo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McGrath, LM", 
+                            "preferred": "LM McGrath"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kosmicki, JA", 
+                            "preferred": "JA Kosmicki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Rehnstr\u00f6m, K", 
+                            "preferred": "K Rehnstr\u00f6m"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mallick, S", 
+                            "preferred": "S Mallick"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kirby, A", 
+                            "preferred": "A Kirby"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wall, DP", 
+                            "preferred": "DP Wall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "MacArthur, DG", 
+                            "preferred": "DG MacArthur"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gabriel, SB", 
+                            "preferred": "SB Gabriel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "DePristo, M", 
+                            "preferred": "M DePristo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Purcell, SM", 
+                            "preferred": "SM Purcell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Palotie, A", 
+                            "preferred": "A Palotie"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Boerwinkle, E", 
+                            "preferred": "E Boerwinkle"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Buxbaum, JD", 
+                            "preferred": "JD Buxbaum"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cook, EH", 
+                            "preferred": "EH Cook"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gibbs, RA", 
+                            "preferred": "RA Gibbs"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Schellenberg, GD", 
+                            "preferred": "GD Schellenberg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sutcliffe, JS", 
+                            "preferred": "JS Sutcliffe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Devlin, B", 
+                            "preferred": "B Devlin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roeder, K", 
+                            "preferred": "K Roeder"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Neale, BM", 
+                            "preferred": "BM Neale"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Daly, MJ", 
+                            "preferred": "MJ Daly"
+                        }
+                    }
+                ], 
+                "date": "2014", 
+                "type": "journal", 
+                "id": "bib32"
+            }, 
+            {
+                "doi": "10.1038/nature10945", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
+                "pages": {
+                    "range": "237\u2013241", 
+                    "last": "241", 
+                    "first": "237"
+                }, 
+                "volume": "485", 
+                "articleTitle": "De novo mutations revealed by whole-exome sequencing are strongly associated with autism", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanders, SJ", 
+                            "preferred": "SJ Sanders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Murtha, MT", 
+                            "preferred": "MT Murtha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gupta, AR", 
+                            "preferred": "AR Gupta"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Murdoch, JD", 
+                            "preferred": "JD Murdoch"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Raubeson, MJ", 
+                            "preferred": "MJ Raubeson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Willsey, AJ", 
+                            "preferred": "AJ Willsey"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ercan-Sencicek, AG", 
+                            "preferred": "AG Ercan-Sencicek"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "DiLullo, NM", 
+                            "preferred": "NM DiLullo"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Parikshak, NN", 
+                            "preferred": "NN Parikshak"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stein, JL", 
+                            "preferred": "JL Stein"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Walker, MF", 
+                            "preferred": "MF Walker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ober, GT", 
+                            "preferred": "GT Ober"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Teran, NA", 
+                            "preferred": "NA Teran"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Song, Y", 
+                            "preferred": "Y Song"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "El-Fishawy, P", 
+                            "preferred": "P El-Fishawy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Murtha, RC", 
+                            "preferred": "RC Murtha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Choi, M", 
+                            "preferred": "M Choi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Overton, JD", 
+                            "preferred": "JD Overton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bjornson, RD", 
+                            "preferred": "RD Bjornson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Carriero, NJ", 
+                            "preferred": "NJ Carriero"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Meyer, KA", 
+                            "preferred": "KA Meyer"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bilguvar, K", 
+                            "preferred": "K Bilguvar"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mane, SM", 
+                            "preferred": "SM Mane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sestan, N", 
+                            "preferred": "N Sestan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lifton, RP", 
+                            "preferred": "RP Lifton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "G\u00fcnel, M", 
+                            "preferred": "M G\u00fcnel"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roeder, K", 
+                            "preferred": "K Roeder"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Geschwind, DH", 
+                            "preferred": "DH Geschwind"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Devlin, B", 
+                            "preferred": "B Devlin"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "State, MW", 
+                            "preferred": "MW State"
+                        }
+                    }
+                ], 
+                "date": "2012", 
+                "type": "journal", 
+                "id": "bib33"
+            }, 
+            {
+                "doi": "10.1016/j.celrep.2016.03.003", 
+                "journal": {
+                    "name": [
+                        "Cell Reports"
+                    ]
+                }, 
+                "pages": {
+                    "range": "27\u201335", 
+                    "last": "35", 
+                    "first": "27"
+                }, 
+                "volume": "15", 
+                "articleTitle": "Smurf1 inhibits osteoblast differentiation, bone formation, and glucose homeostasis through serine 148", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shimazu, J", 
+                            "preferred": "J Shimazu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wei, J", 
+                            "preferred": "J Wei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Karsenty, G", 
+                            "preferred": "G Karsenty"
+                        }
+                    }
+                ], 
+                "date": "2016", 
+                "type": "journal", 
+                "id": "bib34"
+            }, 
+            {
+                "doi": "10.1111/j.1469-8749.2003.tb00857.x", 
+                "journal": {
+                    "name": [
+                        "Developmental Medicine & Child Neurology"
+                    ]
+                }, 
+                "pages": {
+                    "range": "34\u201343", 
+                    "last": "43", 
+                    "first": "34"
+                }, 
+                "volume": "45", 
+                "articleTitle": "Speech, language, and cognitive development in children with isolated sagittal synostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shipster, C", 
+                            "preferred": "C Shipster"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hearst, D", 
+                            "preferred": "D Hearst"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Somerville, A", 
+                            "preferred": "A Somerville"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stackhouse, J", 
+                            "preferred": "J Stackhouse"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hayward, R", 
+                            "preferred": "R Hayward"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wade, A", 
+                            "preferred": "A Wade"
+                        }
+                    }
+                ], 
+                "date": "2003", 
+                "type": "journal", 
+                "id": "bib35"
+            }, 
+            {
+                "doi": "10.1038/ng2096", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1145\u20131150", 
+                    "last": "1150", 
+                    "first": "1145"
+                }, 
+                "volume": "39", 
+                "articleTitle": "RNA interference and inhibition of MEK-ERK signaling prevent abnormal skeletal phenotypes in a mouse model of craniosynostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Shukla, V", 
+                            "preferred": "V Shukla"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Coumoul, X", 
+                            "preferred": "X Coumoul"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, RH", 
+                            "preferred": "RH Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kim, HS", 
+                            "preferred": "HS Kim"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Deng, CX", 
+                            "preferred": "CX Deng"
+                        }
+                    }
+                ], 
+                "date": "2007", 
+                "type": "journal", 
+                "id": "bib36"
+            }, 
+            {
+                "doi": "10.1097/00006534-199602000-00002", 
+                "journal": {
+                    "name": [
+                        "Plastic & Reconstructive Surgery"
+                    ]
+                }, 
+                "pages": {
+                    "range": "276\u2013281", 
+                    "last": "281", 
+                    "first": "276"
+                }, 
+                "volume": "97", 
+                "articleTitle": "Long-term studies of metopic synostosis: frequency of cognitive impairment and behavioral disturbances", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sidoti, EJ", 
+                            "preferred": "EJ Sidoti"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marsh, JL", 
+                            "preferred": "JL Marsh"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Marty-Grames, L", 
+                            "preferred": "L Marty-Grames"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Noetzel, MJ", 
+                            "preferred": "MJ Noetzel"
+                        }
+                    }
+                ], 
+                "date": "1996", 
+                "type": "journal", 
+                "id": "bib37"
+            }, 
+            {
+                "doi": "10.1097/01.prs.0000304441.99483.97", 
+                "journal": {
+                    "name": [
+                        "Plastic and Reconstructive Surgery"
+                    ]
+                }, 
+                "pages": {
+                    "range": "170e\u2013178e", 
+                    "last": "178e", 
+                    "first": "170e"
+                }, 
+                "volume": "121", 
+                "articleTitle": "Cranial sutures: a brief review", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Slater, BJ", 
+                            "preferred": "BJ Slater"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lenton, KA", 
+                            "preferred": "KA Lenton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kwan, MD", 
+                            "preferred": "MD Kwan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gupta, DM", 
+                            "preferred": "DM Gupta"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wan, DC", 
+                            "preferred": "DC Wan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Longaker, MT", 
+                            "preferred": "MT Longaker"
+                        }
+                    }
+                ], 
+                "date": "2008", 
+                "type": "journal", 
+                "id": "bib38"
+            }, 
+            {
+                "doi": "10.1038/ng.2539", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "308\u2013313", 
+                    "last": "313", 
+                    "first": "308"
+                }, 
+                "volume": "45", 
+                "articleTitle": "Reduced dosage of ERF causes complex craniosynostosis in humans and mice and links ERK1/2 signaling to regulation of osteogenesis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Twigg, SR", 
+                            "preferred": "SR Twigg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Vorgia, E", 
+                            "preferred": "E Vorgia"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "McGowan, SJ", 
+                            "preferred": "SJ McGowan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Peraki, I", 
+                            "preferred": "I Peraki"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fenwick, AL", 
+                            "preferred": "AL Fenwick"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sharma, VP", 
+                            "preferred": "VP Sharma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Allegra, M", 
+                            "preferred": "M Allegra"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zaragkoulias, A", 
+                            "preferred": "A Zaragkoulias"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sadighi Akha, E", 
+                            "preferred": "E Sadighi Akha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Knight, SJ", 
+                            "preferred": "SJ Knight"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lord, H", 
+                            "preferred": "H Lord"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lester, T", 
+                            "preferred": "T Lester"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Izatt, L", 
+                            "preferred": "L Izatt"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lampe, AK", 
+                            "preferred": "AK Lampe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mohammed, SN", 
+                            "preferred": "SN Mohammed"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Stewart, FJ", 
+                            "preferred": "FJ Stewart"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Verloes, A", 
+                            "preferred": "A Verloes"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilson, LC", 
+                            "preferred": "LC Wilson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Healy, C", 
+                            "preferred": "C Healy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sharpe, PT", 
+                            "preferred": "PT Sharpe"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hammond, P", 
+                            "preferred": "P Hammond"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hughes, J", 
+                            "preferred": "J Hughes"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Taylor, S", 
+                            "preferred": "S Taylor"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Johnson, D", 
+                            "preferred": "D Johnson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wall, SA", 
+                            "preferred": "SA Wall"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mavrothalassitis, G", 
+                            "preferred": "G Mavrothalassitis"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilkie, AO", 
+                            "preferred": "AO Wilkie"
+                        }
+                    }
+                ], 
+                "date": "2013", 
+                "type": "journal", 
+                "id": "bib39"
+            }, 
+            {
+                "doi": "10.1016/j.ajhg.2015.07.006", 
+                "journal": {
+                    "name": [
+                        "The American Journal of Human Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "359\u2013377", 
+                    "last": "377", 
+                    "first": "359"
+                }, 
+                "volume": "97", 
+                "articleTitle": "A genetic-pathophysiological framework for craniosynostosis", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Twigg, SR", 
+                            "preferred": "SR Twigg"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wilkie, AO", 
+                            "preferred": "AO Wilkie"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib40"
+            }, 
+            {
+                "doi": "10.1093/nar/gkq603", 
+                "journal": {
+                    "name": [
+                        "Nucleic Acids Research"
+                    ]
+                }, 
+                "pages": "e164", 
+                "volume": "38", 
+                "articleTitle": "ANNOVAR: functional annotation of genetic variants from high-throughput sequencing data", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, K", 
+                            "preferred": "K Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Li, M", 
+                            "preferred": "M Li"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hakonarson, H", 
+                            "preferred": "H Hakonarson"
+                        }
+                    }
+                ], 
+                "date": "2010", 
+                "type": "journal", 
+                "id": "bib41"
+            }, 
+            {
+                "doi": "10.1002/0471142905.hg0725s87", 
+                "journal": {
+                    "name": [
+                        "Current Protocols in Human Genetics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "7.25.1\u20137.25.15", 
+                    "last": "7.25.15", 
+                    "first": "7.25.1"
+                }, 
+                "volume": "87", 
+                "articleTitle": "Interpreting de novo variation in human disease using denovolyzeR", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ware, JS", 
+                            "preferred": "JS Ware"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Samocha, KE", 
+                            "preferred": "KE Samocha"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Homsy, J", 
+                            "preferred": "J Homsy"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Daly, MJ", 
+                            "preferred": "MJ Daly"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib42"
+            }, 
+            {
+                "doi": "10.1093/bioinformatics/btu839", 
+                "journal": {
+                    "name": [
+                        "Bioinformatics"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1375\u20131381", 
+                    "last": "1381", 
+                    "first": "1375"
+                }, 
+                "volume": "31", 
+                "articleTitle": "A Bayesian framework for de novo mutation calling in parents-offspring trios", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wei, Q", 
+                            "preferred": "Q Wei"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhan, X", 
+                            "preferred": "X Zhan"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhong, X", 
+                            "preferred": "X Zhong"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Liu, Y", 
+                            "preferred": "Y Liu"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Han, Y", 
+                            "preferred": "Y Han"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chen, W", 
+                            "preferred": "W Chen"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Li, B", 
+                            "preferred": "B Li"
+                        }
+                    }
+                ], 
+                "date": "2015", 
+                "type": "journal", 
+                "id": "bib43"
+            }, 
+            {
+                "doi": "10.1097/01.PRS.0000080729.28749.A3", 
+                "journal": {
+                    "name": [
+                        "Plastic and Reconstructive Surgery"
+                    ]
+                }, 
+                "pages": {
+                    "range": "1211\u20131218", 
+                    "last": "1218", 
+                    "first": "1211"
+                }, 
+                "volume": "112", 
+                "articleTitle": "Metopic synostosis: Defining the temporal sequence of normal suture fusion and differentiating it from synostosis on the basis of computed tomography images", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Weinzweig, J", 
+                            "preferred": "J Weinzweig"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kirschner, RE", 
+                            "preferred": "RE Kirschner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Farley, A", 
+                            "preferred": "A Farley"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Reiss, P", 
+                            "preferred": "P Reiss"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hunter, J", 
+                            "preferred": "J Hunter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Whitaker, LA", 
+                            "preferred": "LA Whitaker"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bartlett, SP", 
+                            "preferred": "SP Bartlett"
+                        }
+                    }
+                ], 
+                "date": "2003", 
+                "type": "journal", 
+                "id": "bib44"
+            }, 
+            {
+                "doi": "10.1038/nature12141", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
+                "pages": {
+                    "range": "220\u2013223", 
+                    "last": "223", 
+                    "first": "220"
+                }, 
+                "volume": "498", 
+                "articleTitle": "De novo mutations in histone-modifying genes in congenital heart disease", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zaidi, S", 
+                            "preferred": "S Zaidi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Choi, M", 
+                            "preferred": "M Choi"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wakimoto, H", 
+                            "preferred": "H Wakimoto"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Ma, L", 
+                            "preferred": "L Ma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Jiang, J", 
+                            "preferred": "J Jiang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Overton, JD", 
+                            "preferred": "JD Overton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Romano-Adesman, A", 
+                            "preferred": "A Romano-Adesman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Bjornson, RD", 
+                            "preferred": "RD Bjornson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Breitbart, RE", 
+                            "preferred": "RE Breitbart"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brown, KK", 
+                            "preferred": "KK Brown"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Carriero, NJ", 
+                            "preferred": "NJ Carriero"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Cheung, YH", 
+                            "preferred": "YH Cheung"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Deanfield, J", 
+                            "preferred": "J Deanfield"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "DePalma, S", 
+                            "preferred": "S DePalma"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Fakhro, KA", 
+                            "preferred": "KA Fakhro"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Glessner, J", 
+                            "preferred": "J Glessner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Hakonarson, H", 
+                            "preferred": "H Hakonarson"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Italia, MJ", 
+                            "preferred": "MJ Italia"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kaltman, JR", 
+                            "preferred": "JR Kaltman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kaski, J", 
+                            "preferred": "J Kaski"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kim, R", 
+                            "preferred": "R Kim"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Kline, JK", 
+                            "preferred": "JK Kline"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lee, T", 
+                            "preferred": "T Lee"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Leipzig, J", 
+                            "preferred": "J Leipzig"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lopez, A", 
+                            "preferred": "A Lopez"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mane, SM", 
+                            "preferred": "SM Mane"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Mitchell, LE", 
+                            "preferred": "LE Mitchell"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Newburger, JW", 
+                            "preferred": "JW Newburger"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Parfenov, M", 
+                            "preferred": "M Parfenov"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Pe'er, I", 
+                            "preferred": "I Pe'er"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Porter, G", 
+                            "preferred": "G Porter"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Roberts, AE", 
+                            "preferred": "AE Roberts"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sachidanandam, R", 
+                            "preferred": "R Sachidanandam"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Sanders, SJ", 
+                            "preferred": "SJ Sanders"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Seiden, HS", 
+                            "preferred": "HS Seiden"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "State, MW", 
+                            "preferred": "MW State"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Subramanian, S", 
+                            "preferred": "S Subramanian"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Tikhonova, IR", 
+                            "preferred": "IR Tikhonova"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Wang, W", 
+                            "preferred": "W Wang"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Warburton, D", 
+                            "preferred": "D Warburton"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "White, PS", 
+                            "preferred": "PS White"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Williams, IA", 
+                            "preferred": "IA Williams"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Zhao, H", 
+                            "preferred": "H Zhao"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Seidman, JG", 
+                            "preferred": "JG Seidman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Brueckner, M", 
+                            "preferred": "M Brueckner"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Chung, WK", 
+                            "preferred": "WK Chung"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Gelb, BD", 
+                            "preferred": "BD Gelb"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Goldmuntz, E", 
+                            "preferred": "E Goldmuntz"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Seidman, CE", 
+                            "preferred": "CE Seidman"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "index": "Lifton, RP", 
+                            "preferred": "RP Lifton"
+                        }
+                    }
+                ], 
+                "date": "2013", 
+                "type": "journal", 
+                "id": "bib45"
+            }
+        ], 
+        "keywords": [
+            "craniosynostosis", 
+            "craniofacial", 
+            "exome sequencing", 
+            "human genetics", 
+            "de novo mutation", 
+            "incomplete penetrance", 
+            "SMAD6", 
+            "BMP2", 
+            "SMURF1", 
+            "SPRY1", 
+            "SPRY4"
+        ], 
+        "subjects": [
+            {
+                "id": "genes-chromosomes", 
+                "name": "Genes and Chromosomes"
+            }, 
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "digest": {
+            "content": [
+                {
+                    "text": "The bones in the front, back and sides of the human skull are not fused to one another at birth in order to allow the brain to double in size during the first year of life and continue growing into adulthood. However, one in 2,000 infants is born with a condition called craniosynostosis in which some of these bones have already fused. This fusion prevents the skull from growing properly, and can lead to the brain becoming compressed. As such, surgeons routinely undo the fusion in these infants to allow the brain and skull to grow normally.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "Eighty-five percent of craniosynostosis cases occur in infants with no other abnormalities, (called non-syndromic cases) and most have no other affected family member. It has therefore been unclear whether these infants have craniosynostosis due to a genetic or non-genetic cause. If the cause is genetic, it is also not clear whether a mutation in a single gene, the combined effects of many genes, or something in between is responsible.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "Now, by focusing on a group of 191 infants with premature fusion of bones joined at the midline of the skull, Timberlake et al. asked if any of the approximately 20,000 genes in the human genome were altered more frequently in these infants than would be expected by chance. This search revealed that rare mutations that disable one copy of a gene called <i>SMAD6</i> in combination with a common DNA variant near another gene called <i>BMP2</i> account for about 7% of infants with midline forms of craniosynostosis. These genes are both known to regulate how bones form, which explains how the mutation of these genes could lead to craniosynostosis.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "In all cases, the parents of these children were unaffected. This was typically because one parent had only the <i>SMAD6</i> mutation while the other had only the common <i>BMP2</i> variant; the transmission of both to their offspring resulted in craniosynostosis. The finding that a rare mutation\u2019s effect is strongly modified by a common variant from another site in the genome is unprecedented. These findings will allow doctors to counsel families about the risk of having additional children with craniosynostosis.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "Timberlake et al. next plan to study more patients with craniosynostosis to identify additional genes that contribute to this disease. They will also look at other diseases to see whether the combination of rare mutation and common DNA variant could be behind other unexplained disorders.", 
+                    "type": "paragraph"
+                }
+            ], 
+            "doi": "10.7554/eLife.20125.002"
+        }, 
+        "decisionLetter": {
+            "content": [
+                {
+                    "text": "Congratulations: we are very pleased to inform you that your article, \"Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles\", has been accepted for publication in <i>eLife</i>. The Reviewing Editor for your submission was David Ginsburg. The additional reviewers, who have also agreed to reveal their identities were: Yuji Mishina and James Lupski.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "If you have selected our \"Publish on Acceptance\" option, your PDF will be published within a few days; if you have opted out of the \"Publish on Acceptance\" option, your work will be published in about four weeks' time.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "The reviewers concluded that: this manuscript reports very convincing data demonstrating epistatic interaction between rare loss of function mutations in SMAD6 and a common variant near the BMP2 locus as the genetic etiology of craniosynostosis in a subset of nonsyndromic patients. The data are of very high quality, the manuscript clearly written, and the conclusions convincingly supported by the data. The investigators performed whole exome sequencing (WES) of 132 parent-offspring trios and 59 additional probands. Seven percent of probands had damaging de novo or rare transmitted mutations in SMAD6; an inhibitor of BMP \u2013 induced osteoblast differentiation (P &lt;10-20). Interestingly, SMAD6 mutations showed striking incomplete penetrance for the craniosynostosis trait (&lt;60%). Genotypes of a common variant near BMP2, previously shown to be strongly associated with midline craniosynostosis, explained nearly all of the phenotypic variance in these kindred. Thus, these findings clearly documented digenic inheritance via epistatic interactions of rare and common variants as a defining feature of the most frequent cause of midline craniosynostosis. This work has very important implications for the genetic basis of other disease traits and reveals a potential mechanism for common variant genetic effects to markedly influence the manifestation of disease.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "None of the reviewers had any major suggestions for required revision/correction. However, a few minor points/questions were raised, as listed below, which the reviewers all agreed could be addressed by minor changes to the text (or none), as the authors see fit.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "Minor points:", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "1) Subsection \"Exome sequencing of non-syndromic midline craniosynostosis\": the authors \"infer that these de novo mutations contribute to ~15% of non-syndromic midline craniosynostosis\". How was this figure calculated?", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "2) The authors note that SMAD6 knockout mice exhibit skull abnormalities reminiscent of craniosynostosis (Estrada et al., 2011 and Retting, 2008). Is there a heterozygous phenotype in the mice? Though clearly beyond the scope of the current manuscript, it will be interesting to see whether genetic interaction between BMP2 gain-of-function and SMAD6 haploinsufficiency can be demonstrated in the mouse.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "3) Though 2 previously identified GWAS hits for nonsyndromic craniosynostosis, one (BMP2) modifies SMAD6 haploinsufficiency, whereas the other (BBS9) does not, despite similar large effect sizes for both variants. Could the authors speculate about a potential similar epistatic interaction of BBS9 with rare variant in another gene(s) in a different subset of craniosynostosis patients?", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "4) Though most of the identified SMAD6 mutations would generate clear loss-of-function, two of them are located near the C-terminus (i.e. R465C and I490T). Have any specific functions been ascribed to this region of the molecule?", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "5) SMAD7 is another inhibitory Smad that affects both BMP and TGF-\u03b2 pathways. Although a craniofacial phenotype is not appreciated in Smad7 mutant mice, they show similar skeletal phenotypes to Smad6 knockouts. One would think mutations in SMAD7 might also interact with the BMP2 risk allele. Does the lack of SMAD7 mutations in their patient cohort, suggest a particularly unique role for SMAD6 in midline craniosynostosis?", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "6) Discussion, paragraph 5: \"The only other clinical finding found[\u2026]\" could be reworded as \"finding present\" or \"observed\".", 
+                    "type": "paragraph"
+                }
+            ], 
+            "doi": "10.7554/eLife.20125.028", 
+            "description": [
+                {
+                    "text": "In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.", 
+                    "type": "paragraph"
+                }
+            ]
+        }, 
+        "copyright": {
+            "holder": "Timberlake et al", 
+            "statement": "This article is distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use and redistribution provided that the original author and source are credited.", 
+            "license": "CC-BY-4.0"
+        }, 
+        "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare SMAD6 and common BMP2 alleles", 
+        "authorLine": "Andrew T Timberlake et al", 
+        "id": "20125", 
+        "version": 3, 
+        "statusDate": "2016-01-01T00:00:00Z", 
+        "type": "research-article", 
+        "status": "vor", 
+        "impactStatement": "Epistatic interactions of rare loss of function mutations in <italic>SMAD6</italic> and a common variant modifier near <italic>BMP2</italic> are the most common cause of midline craniosynostosis in humans.", 
+        "volume": 5, 
+        "researchOrganisms": [
+            "Human"
+        ], 
+        "authors": [
+            {
+                "name": {
+                    "index": "Timberlake, Andrew T", 
+                    "preferred": "Andrew T Timberlake"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "orcid": "0000-0002-8926-9692", 
+                "contribution": "ATT, Recruited and enrolled patients, collected genetic specimens, performed SNP genotyping and Sanger sequencing, performed genetic analyses, wrote the manuscript", 
+                "type": "person"
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JC, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Choi, Jungmin", 
+                    "preferred": "Jungmin Choi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SZ, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Zaidi, Samir", 
+                    "preferred": "Samir Zaidi"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "QL, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Lu, Qiongshi", 
+                    "preferred": "Qiongshi Lu"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CN-W, Performed SNP genotyping and Sanger sequencing, performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Nelson-Williams, Carol", 
+                    "preferred": "Carol Nelson-Williams"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EDB, Recruited and enrolled patients, collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Brooks, Eric D", 
+                    "preferred": "Eric D Brooks"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "KB, Directed exome sequence production", 
+                "type": "person", 
+                "name": {
+                    "index": "Bilguvar, Kaya", 
+                    "preferred": "Kaya Bilguvar"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "IT, Directed exome sequence production", 
+                "type": "person", 
+                "name": {
+                    "index": "Tikhonova, Irina", 
+                    "preferred": "Irina Tikhonova"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SM, Directed exome sequence production", 
+                "type": "person", 
+                "name": {
+                    "index": "Mane, Shrikant", 
+                    "preferred": "Shrikant Mane"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JFY, Recruited and enrolled patients, collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Yang, Jenny F", 
+                    "preferred": "Jenny F Yang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "RS-M, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Sawh-Martinez, Rajendra", 
+                    "preferred": "Rajendra Sawh-Martinez"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SP, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, Sarah", 
+                    "preferred": "Sarah Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EGZ, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Zellner, Elizabeth G", 
+                    "preferred": "Elizabeth G Zellner"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EL, Recruited and enrolled patients", 
+                "type": "person", 
+                "name": {
+                    "index": "Loring, Erin", 
+                    "preferred": "Erin Loring"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CC, Collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Chuang, Carolyn", 
+                    "preferred": "Carolyn Chuang"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Craniosynostosis and Positional Plagiocephaly Support"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "AG, Recruited and enrolled patients", 
+                "type": "person", 
+                "name": {
+                    "index": "Galm, Amy", 
+                    "preferred": "Amy Galm"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "PWH, Collected genetic specimens", 
+                "type": "person", 
+                "name": {
+                    "index": "Hashim, Peter W", 
+                    "preferred": "Peter W Hashim"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DMS, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Steinbacher, Derek M", 
+                    "preferred": "Derek M Steinbacher"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MLD, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "DiLuna, Michael L", 
+                    "preferred": "Michael L DiLuna"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Neurosurgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CCD, Contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Duncan, Charles C", 
+                    "preferred": "Charles C Duncan"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Child Study Center", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "KAP, Recruited and enrolled patients", 
+                "type": "person", 
+                "name": {
+                    "index": "Pelphrey, Kevin A", 
+                    "preferred": "Kevin A Pelphrey"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Biostatistics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "HZ, Performed genetic analyses", 
+                "type": "person", 
+                "name": {
+                    "index": "Zhao, Hongyu", 
+                    "preferred": "Hongyu Zhao"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "affiliations": [
+                    {
+                        "name": [
+                            "Section of Plastic and Reconstructive Surgery, Department of Surgery", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JAP, Conceived, designed, and directed study, contributed clinical evaluations", 
+                "type": "person", 
+                "name": {
+                    "index": "Persing, John A", 
+                    "preferred": "John A Persing"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "name": {
+                    "index": "Lifton, Richard P", 
+                    "preferred": "Richard P Lifton"
+                }, 
+                "competingInterests": "The authors declare that no competing interests exist.", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Genetics", 
+                            "Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Howard Hughes Medical Institute, Yale University School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Yale Center for Genome Analysis"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Haven", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New Haven"
+                                ]
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "The Rockefeller University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "country": "United States", 
+                                "locality": [
+                                    "New York"
+                                ]
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "richard.lifton@yale.edu"
+                ], 
+                "type": "person", 
+                "contribution": "RPL, Conceived, designed, and directed the study, performed genetic analyses, wrote the manuscript"
+            }
+        ], 
+        "acknowledgements": [
+            {
+                "text": "We are enormously grateful to the study participants and their families for their invaluable role in this study, to the Cranio Kids- Craniosynostosis Support Group and the Craniosynostosis-Positional Plagiocephaly Support Group for posting our invitations to participate on their Facebook pages, to the staff of the Yale Center for Genome Analysis for expert performance of exome sequencing, and to Lynn Boyden for helpful discussions. Supported by the Yale Center for Mendelian Genomics (NIH M#UM1HG006504-05), the Maxillofacial Surgeons Foundation/ASMS (M#M156301), the NIH Medical Scientist Training Program (NIH/NIGMS T32GM007205), and the Howard Hughes Medical Institute.", 
+                "type": "paragraph"
+            }
+        ], 
+        "elocationId": "e20125", 
+        "authorResponse": {
+            "content": [
+                {
+                    "text": "<i>1) Subsection \"Exome sequencing of non-syndromic midline craniosynostosis\": the authors \"infer that these de novo mutations contribute to ~15% of non-syndromic midline craniosynostosis\". How was this figure calculated?</i> ", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "As discussed in the Methods section, among 132 probands, 123 had protein-altering <i>de novo</i> mutations, compared to an expected number of 102.4. Thus ~20 more probands (~15% of all probands) had protein-altering de novo mutations than expected by chance, suggesting that at least this fraction of probands has disease owing to <i>de novo</i> mutation.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "<i>2) The authors note that SMAD6 knockout mice exhibit skull abnormalities reminiscent of craniosynostosis (Estrada et al., 2011 and Retting, 2008). Is there a heterozygous phenotype in the mice? Though clearly beyond the scope of the current manuscript, it will be interesting to see whether genetic interaction between BMP2 gain-of-function and SMAD6 haploinsufficiency can be demonstrated in the mouse.</i> ", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "There is no heterozygous phenotype described for <i>SMAD6</i> loss of function in mice. We agree that it will be interesting to determine the consequence in mice of combined <i>BMP2</i> gain of function with <i>SMAD6</i> loss of function.Titration of dosing of BMP2 will likely be important in such an experiment.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "<i>3) Though 2 previously identified GWAS hits for nonsyndromic craniosynostosis, one (BMP2) modifies SMAD6 haploinsufficiency, whereas the other (BBS9) does not, despite similar large effect sizes for both variants. Could the authors speculate about a potential similar epistatic interaction of BBS9 with rare variant in another gene(s) in a different subset of craniosynostosis patients?</i>", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "This is an interesting point. We speculated in the manuscript that other common variants, particularly those with relatively large effects, may show similar epistatic interactions with rare variants. The common BBS9 risk variant, which clearly falls into this class, would be an excellent candidate for modifying risk of rare variants in another gene or genes.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "<i>4) Though most of the identified SMAD6 mutations would generate clear loss-of-function, two of them are located near the C-terminus (i.e. R465C and I490T). Have any specific functions been ascribed to this region of the molecule?</i>", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "The C-terminus, which is part of the MH2 domain, is responsible for protein-protein interactions, including SMAD6\u2019s interaction with receptor-SMADs and BMP receptors themselves. It is possible that these variants impair SMAD6 binding to these signaling molecules, impairing inhibition of BMP/SMAD signaling.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "<i>5) SMAD7 is another inhibitory Smad that affects both BMP and TGF-beta pathways. Although a craniofacial phenotype is not appreciated in Smad7 mutant mice, they show similar skeletal phenotypes to Smad6 knockouts. One would think mutations in SMAD7 might also interact with the BMP2 risk allele. Does the lack of SMAD7 mutations in their patient cohort, suggest a particularly unique role for SMAD6 in midline craniosynostosis?</i> ", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "Yes, the data would support this inference. It has been suggested that <i>SMAD6</i> is more specific to regulation of BMP signaling, whereas <i>SMAD7</i> is more specific for inhibition of TGFB-receptor - mediated SMAD signaling. Mutations in TGFBR1/2, and its downstream inhibitor SKI, have been shown to cause syndromic forms of craniosynostosis that also involve the cardiovascular system and are markedly more severe than the non-syndromic craniosynostosis phenotype resulting from SMAD6/BMP2 variants. It is thus possible that heterozygous loss of function mutations in <i>SMAD7</i> have a more extreme, potentially early lethal, phenotype than <i>SMAD6</i> mutations, accounting for why we have not seen these mutations in our cohort. Consistent with this possibility, zero heterozygous loss of function variants in <i>SMAD7</i> have been reported in the ExAC database.", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "<i>6) Line 315: \"The only other clinical finding found[\u2026]\" could be reworded as \"finding present\" or \"observed\u201d.</i>", 
+                    "type": "paragraph"
+                }, 
+                {
+                    "text": "We agree, thanks. We have changed the sentence to, 'The only other clinical finding observed[\u2026]'", 
+                    "type": "paragraph"
+                }
+            ], 
+            "doi": "10.7554/eLife.20125.029"
+        }, 
+        "doi": "10.7554/eLife.20125", 
+        "published": "2016-09-08T00:00:00", 
+        "pdf": "https://cdn.elifesciences.org/elife-articles/20125/pdf/elife-20125.pdf"
+    }, 
+    "journal": {
+        "issn": "2050-084X", 
+        "id": "eLife", 
+        "title": "eLife"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/elife-01968-v1.xml.json
+++ b/src/publisher/tests/fixtures/ajson/elife-01968-v1.xml.json
@@ -207,3998 +207,5471 @@
         ], 
         "references": [
             {
-                "article_title": "Deletion of ultraconserved elements yields viable mice", 
-                "doi": "10.1371/journal.pbio.0050234", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib1", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Ahituv", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Ahituv", 
+                            "index": "Ahituv, N"
+                        }
                     }, 
                     {
-                        "surname": "Zhu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Zhu", 
+                            "index": "Zhu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Visel", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Visel", 
+                            "index": "Visel, A"
+                        }
                     }, 
                     {
-                        "surname": "Holt", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Holt", 
+                            "index": "Holt, A"
+                        }
                     }, 
                     {
-                        "surname": "Afzal", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Afzal", 
+                            "index": "Afzal, V"
+                        }
                     }, 
                     {
-                        "surname": "Pennacchio", 
-                        "given-names": "LA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LA Pennacchio", 
+                            "index": "Pennacchio, LA"
+                        }
                     }, 
                     {
-                        "surname": "Rubin", 
-                        "given-names": "EM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Rubin", 
+                            "index": "Rubin, EM"
+                        }
                     }
                 ], 
-                "full_article_title": "Deletion of ultraconserved elements yields viable mice", 
-                "publication-type": "journal", 
+                "articleTitle": "Deletion of ultraconserved elements yields viable mice", 
+                "journal": {
+                    "name": [
+                        "PLOS Biology"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "PLOS Biology", 
-                "reference_id": "10.1371/journal.pbio.0050234", 
-                "fpage": "e234", 
-                "year": "2007", 
-                "position": 1, 
-                "ref": "AhituvNZhuYViselAHoltAAfzalVPennacchioLARubinEM2007Deletion of ultraconserved elements yields viable micePLOS Biology5e23410.1371/journal.pbio.0050234", 
-                "id": "bib1"
+                "pages": "e234", 
+                "doi": "10.1371/journal.pbio.0050234"
             }, 
             {
-                "article_title": "Identification and analysis of functional elements in 1% of the human genome by the ENCODE pilot project", 
-                "lpage": "816", 
-                "doi": "10.1038/nature05874", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib2", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Birney", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Birney", 
+                            "index": "Birney, E"
+                        }
                     }, 
                     {
-                        "surname": "Stamatoyannopoulos", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Stamatoyannopoulos", 
+                            "index": "Stamatoyannopoulos, JA"
+                        }
                     }, 
                     {
-                        "surname": "Dutta", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Dutta", 
+                            "index": "Dutta, A"
+                        }
                     }, 
                     {
-                        "surname": "Guigo", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Guigo", 
+                            "index": "Guigo, R"
+                        }
                     }, 
                     {
-                        "surname": "Gingeras", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Gingeras", 
+                            "index": "Gingeras, TR"
+                        }
                     }, 
                     {
-                        "surname": "Margulies", 
-                        "given-names": "EH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EH Margulies", 
+                            "index": "Margulies, EH"
+                        }
                     }, 
                     {
-                        "surname": "Birney", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Birney", 
+                            "index": "Birney, E"
+                        }
                     }, 
                     {
-                        "surname": "Stamatoyannopoulos", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Stamatoyannopoulos", 
+                            "index": "Stamatoyannopoulos, JA"
+                        }
                     }, 
                     {
-                        "surname": "Dutta", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Dutta", 
+                            "index": "Dutta, A"
+                        }
                     }, 
                     {
-                        "surname": "Guig\u00f3", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Guig\u00f3", 
+                            "index": "Guig\u00f3, R"
+                        }
                     }, 
                     {
-                        "surname": "Gingeras", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Gingeras", 
+                            "index": "Gingeras, TR"
+                        }
                     }, 
                     {
-                        "surname": "Margulies", 
-                        "given-names": "EH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EH Margulies", 
+                            "index": "Margulies, EH"
+                        }
                     }, 
                     {
-                        "surname": "Weng", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Weng", 
+                            "index": "Weng, Z"
+                        }
                     }, 
                     {
-                        "surname": "Snyder", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Snyder", 
+                            "index": "Snyder, M"
+                        }
                     }, 
                     {
-                        "surname": "Dermitzakis", 
-                        "given-names": "ET", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ET Dermitzakis", 
+                            "index": "Dermitzakis, ET"
+                        }
                     }, 
                     {
-                        "surname": "Thurman", 
-                        "given-names": "RE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RE Thurman", 
+                            "index": "Thurman, RE"
+                        }
                     }, 
                     {
-                        "surname": "Kuehn", 
-                        "given-names": "MS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS Kuehn", 
+                            "index": "Kuehn, MS"
+                        }
                     }, 
                     {
-                        "surname": "Taylor", 
-                        "given-names": "CM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Taylor", 
+                            "index": "Taylor, CM"
+                        }
                     }, 
                     {
-                        "surname": "Neph", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Neph", 
+                            "index": "Neph, S"
+                        }
                     }, 
                     {
-                        "surname": "Koch", 
-                        "given-names": "CM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Koch", 
+                            "index": "Koch, CM"
+                        }
                     }, 
                     {
-                        "surname": "Asthana", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Asthana", 
+                            "index": "Asthana, S"
+                        }
                     }, 
                     {
-                        "surname": "Malhotra", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Malhotra", 
+                            "index": "Malhotra, A"
+                        }
                     }, 
                     {
-                        "surname": "Adzhubei", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Adzhubei", 
+                            "index": "Adzhubei, I"
+                        }
                     }, 
                     {
-                        "surname": "Greenbaum", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Greenbaum", 
+                            "index": "Greenbaum, JA"
+                        }
                     }, 
                     {
-                        "surname": "Andrews", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Andrews", 
+                            "index": "Andrews, RM"
+                        }
                     }, 
                     {
-                        "surname": "Flicek", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Flicek", 
+                            "index": "Flicek, P"
+                        }
                     }, 
                     {
-                        "surname": "Boyle", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Boyle", 
+                            "index": "Boyle, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Cao", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Cao", 
+                            "index": "Cao, H"
+                        }
                     }, 
                     {
-                        "surname": "Carter", 
-                        "given-names": "NP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NP Carter", 
+                            "index": "Carter, NP"
+                        }
                     }, 
                     {
-                        "surname": "Clelland", 
-                        "given-names": "GK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GK Clelland", 
+                            "index": "Clelland, GK"
+                        }
                     }, 
                     {
-                        "surname": "Davis", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Davis", 
+                            "index": "Davis, S"
+                        }
                     }, 
                     {
-                        "surname": "Day", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Day", 
+                            "index": "Day, N"
+                        }
                     }, 
                     {
-                        "surname": "Dhami", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Dhami", 
+                            "index": "Dhami, P"
+                        }
                     }, 
                     {
-                        "surname": "Dillon", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Dillon", 
+                            "index": "Dillon, SC"
+                        }
                     }, 
                     {
-                        "surname": "Dorschner", 
-                        "given-names": "MO", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MO Dorschner", 
+                            "index": "Dorschner, MO"
+                        }
                     }, 
                     {
-                        "surname": "Fiegler", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Fiegler", 
+                            "index": "Fiegler, H"
+                        }
                     }, 
                     {
-                        "surname": "Giresi", 
-                        "given-names": "PG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PG Giresi", 
+                            "index": "Giresi, PG"
+                        }
                     }, 
                     {
-                        "surname": "Goldy", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Goldy", 
+                            "index": "Goldy, J"
+                        }
                     }, 
                     {
-                        "surname": "Hawrylycz", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Hawrylycz", 
+                            "index": "Hawrylycz, M"
+                        }
                     }, 
                     {
-                        "surname": "Haydock", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Haydock", 
+                            "index": "Haydock, A"
+                        }
                     }, 
                     {
-                        "surname": "Humbert", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Humbert", 
+                            "index": "Humbert, R"
+                        }
                     }, 
                     {
-                        "surname": "James", 
-                        "given-names": "KD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KD James", 
+                            "index": "James, KD"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "BE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BE Johnson", 
+                            "index": "Johnson, BE"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "EM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Johnson", 
+                            "index": "Johnson, EM"
+                        }
                     }, 
                     {
-                        "surname": "Frum", 
-                        "given-names": "TT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TT Frum", 
+                            "index": "Frum, TT"
+                        }
                     }, 
                     {
-                        "surname": "Rosenzweig", 
-                        "given-names": "ER", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ER Rosenzweig", 
+                            "index": "Rosenzweig, ER"
+                        }
                     }, 
                     {
-                        "surname": "Karnani", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Karnani", 
+                            "index": "Karnani, N"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Lee", 
+                            "index": "Lee, K"
+                        }
                     }, 
                     {
-                        "surname": "Lefebvre", 
-                        "given-names": "GC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GC Lefebvre", 
+                            "index": "Lefebvre, GC"
+                        }
                     }, 
                     {
-                        "surname": "Navas", 
-                        "given-names": "PA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PA Navas", 
+                            "index": "Navas, PA"
+                        }
                     }, 
                     {
-                        "surname": "Neri", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Neri", 
+                            "index": "Neri, F"
+                        }
                     }, 
                     {
-                        "surname": "Parker", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Parker", 
+                            "index": "Parker, SC"
+                        }
                     }, 
                     {
-                        "surname": "Sabo", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Sabo", 
+                            "index": "Sabo, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Sandstrom", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Sandstrom", 
+                            "index": "Sandstrom, R"
+                        }
                     }, 
                     {
-                        "surname": "Shafer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Shafer", 
+                            "index": "Shafer, A"
+                        }
                     }, 
                     {
-                        "surname": "Vetrie", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Vetrie", 
+                            "index": "Vetrie, D"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Weaver", 
+                            "index": "Weaver, M"
+                        }
                     }, 
                     {
-                        "surname": "Wilcox", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Wilcox", 
+                            "index": "Wilcox, S"
+                        }
                     }, 
                     {
-                        "surname": "Yu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Yu", 
+                            "index": "Yu, M"
+                        }
                     }, 
                     {
-                        "surname": "Collins", 
-                        "given-names": "FS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FS Collins", 
+                            "index": "Collins, FS"
+                        }
                     }, 
                     {
-                        "surname": "Dekker", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Dekker", 
+                            "index": "Dekker, J"
+                        }
                     }, 
                     {
-                        "surname": "Lieb", 
-                        "given-names": "JD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JD Lieb", 
+                            "index": "Lieb, JD"
+                        }
                     }, 
                     {
-                        "surname": "Tullius", 
-                        "given-names": "TD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD Tullius", 
+                            "index": "Tullius, TD"
+                        }
                     }, 
                     {
-                        "surname": "Crawford", 
-                        "given-names": "GE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GE Crawford", 
+                            "index": "Crawford, GE"
+                        }
                     }, 
                     {
-                        "surname": "Sunyaev", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sunyaev", 
+                            "index": "Sunyaev, S"
+                        }
                     }, 
                     {
-                        "surname": "Noble", 
-                        "given-names": "WS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WS Noble", 
+                            "index": "Noble, WS"
+                        }
                     }, 
                     {
-                        "surname": "Dunham", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Dunham", 
+                            "index": "Dunham, I"
+                        }
                     }, 
                     {
-                        "surname": "Denoeud", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Denoeud", 
+                            "index": "Denoeud, F"
+                        }
                     }, 
                     {
-                        "surname": "Reymond", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Reymond", 
+                            "index": "Reymond, A"
+                        }
                     }, 
                     {
-                        "surname": "Kapranov", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Kapranov", 
+                            "index": "Kapranov, P"
+                        }
                     }, 
                     {
-                        "surname": "Rozowsky", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Rozowsky", 
+                            "index": "Rozowsky, J"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Zheng", 
+                            "index": "Zheng, D"
+                        }
                     }, 
                     {
-                        "surname": "Castelo", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Castelo", 
+                            "index": "Castelo, R"
+                        }
                     }, 
                     {
-                        "surname": "Frankish", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Frankish", 
+                            "index": "Frankish, A"
+                        }
                     }, 
                     {
-                        "surname": "Harrow", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Harrow", 
+                            "index": "Harrow, J"
+                        }
                     }, 
                     {
-                        "surname": "Ghosh", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Ghosh", 
+                            "index": "Ghosh, S"
+                        }
                     }, 
                     {
-                        "surname": "Sandelin", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sandelin", 
+                            "index": "Sandelin, A"
+                        }
                     }, 
                     {
-                        "surname": "Hofacker", 
-                        "given-names": "IL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IL Hofacker", 
+                            "index": "Hofacker, IL"
+                        }
                     }, 
                     {
-                        "surname": "Baertsch", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Baertsch", 
+                            "index": "Baertsch, R"
+                        }
                     }, 
                     {
-                        "surname": "Keefe", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Keefe", 
+                            "index": "Keefe, D"
+                        }
                     }, 
                     {
-                        "surname": "Dike", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Dike", 
+                            "index": "Dike, S"
+                        }
                     }, 
                     {
-                        "surname": "Cheng", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Cheng", 
+                            "index": "Cheng, J"
+                        }
                     }, 
                     {
-                        "surname": "Hirsch", 
-                        "given-names": "HA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HA Hirsch", 
+                            "index": "Hirsch, HA"
+                        }
                     }, 
                     {
-                        "surname": "Sekinger", 
-                        "given-names": "EA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EA Sekinger", 
+                            "index": "Sekinger, EA"
+                        }
                     }, 
                     {
-                        "surname": "Lagarde", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Lagarde", 
+                            "index": "Lagarde, J"
+                        }
                     }, 
                     {
-                        "surname": "Abril", 
-                        "given-names": "JF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JF Abril", 
+                            "index": "Abril, JF"
+                        }
                     }, 
                     {
-                        "surname": "Shahab", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Shahab", 
+                            "index": "Shahab, A"
+                        }
                     }, 
                     {
-                        "surname": "Flamm", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Flamm", 
+                            "index": "Flamm, C"
+                        }
                     }, 
                     {
-                        "surname": "Fried", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Fried", 
+                            "index": "Fried, C"
+                        }
                     }, 
                     {
-                        "surname": "Hackerm\u00fcller", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hackerm\u00fcller", 
+                            "index": "Hackerm\u00fcller, J"
+                        }
                     }, 
                     {
-                        "surname": "Hertel", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hertel", 
+                            "index": "Hertel, J"
+                        }
                     }, 
                     {
-                        "surname": "Lindemeyer", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Lindemeyer", 
+                            "index": "Lindemeyer, M"
+                        }
                     }, 
                     {
-                        "surname": "Missal", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Missal", 
+                            "index": "Missal, K"
+                        }
                     }, 
                     {
-                        "surname": "Tanzer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Tanzer", 
+                            "index": "Tanzer, A"
+                        }
                     }, 
                     {
-                        "surname": "Washietl", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Washietl", 
+                            "index": "Washietl, S"
+                        }
                     }, 
                     {
-                        "surname": "Korbel", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Korbel", 
+                            "index": "Korbel, J"
+                        }
                     }, 
                     {
-                        "surname": "Emanuelsson", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Emanuelsson", 
+                            "index": "Emanuelsson, O"
+                        }
                     }, 
                     {
-                        "surname": "Pedersen", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Pedersen", 
+                            "index": "Pedersen, JS"
+                        }
                     }, 
                     {
-                        "surname": "Holroyd", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Holroyd", 
+                            "index": "Holroyd, N"
+                        }
                     }, 
                     {
-                        "surname": "Taylor", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Taylor", 
+                            "index": "Taylor, R"
+                        }
                     }, 
                     {
-                        "surname": "Swarbreck", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Swarbreck", 
+                            "index": "Swarbreck, D"
+                        }
                     }, 
                     {
-                        "surname": "Matthews", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Matthews", 
+                            "index": "Matthews, N"
+                        }
                     }, 
                     {
-                        "surname": "Dickson", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Dickson", 
+                            "index": "Dickson, MC"
+                        }
                     }, 
                     {
-                        "surname": "Thomas", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ Thomas", 
+                            "index": "Thomas, DJ"
+                        }
                     }, 
                     {
-                        "surname": "Weirauch", 
-                        "given-names": "MT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MT Weirauch", 
+                            "index": "Weirauch, MT"
+                        }
                     }, 
                     {
-                        "surname": "Gilbert", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Gilbert", 
+                            "index": "Gilbert, J"
+                        }
                     }, 
                     {
-                        "surname": "Drenkow", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Drenkow", 
+                            "index": "Drenkow, J"
+                        }
                     }, 
                     {
-                        "surname": "Bell", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Bell", 
+                            "index": "Bell, I"
+                        }
                     }, 
                     {
-                        "surname": "Zhao", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Zhao", 
+                            "index": "Zhao, X"
+                        }
                     }, 
                     {
-                        "surname": "Srinivasan", 
-                        "given-names": "KG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KG Srinivasan", 
+                            "index": "Srinivasan, KG"
+                        }
                     }, 
                     {
-                        "surname": "Sung", 
-                        "given-names": "WK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WK Sung", 
+                            "index": "Sung, WK"
+                        }
                     }, 
                     {
-                        "surname": "Ooi", 
-                        "given-names": "HS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HS Ooi", 
+                            "index": "Ooi, HS"
+                        }
                     }, 
                     {
-                        "surname": "Chiu", 
-                        "given-names": "KP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KP Chiu", 
+                            "index": "Chiu, KP"
+                        }
                     }, 
                     {
-                        "surname": "Foissac", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Foissac", 
+                            "index": "Foissac, S"
+                        }
                     }, 
                     {
-                        "surname": "Alioto", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Alioto", 
+                            "index": "Alioto, T"
+                        }
                     }, 
                     {
-                        "surname": "Brent", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Brent", 
+                            "index": "Brent, M"
+                        }
                     }, 
                     {
-                        "surname": "Pachter", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Pachter", 
+                            "index": "Pachter, L"
+                        }
                     }, 
                     {
-                        "surname": "Tress", 
-                        "given-names": "ML", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ML Tress", 
+                            "index": "Tress, ML"
+                        }
                     }, 
                     {
-                        "surname": "Valencia", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Valencia", 
+                            "index": "Valencia, A"
+                        }
                     }, 
                     {
-                        "surname": "Choo", 
-                        "given-names": "SW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SW Choo", 
+                            "index": "Choo, SW"
+                        }
                     }, 
                     {
-                        "surname": "Choo", 
-                        "given-names": "CY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CY Choo", 
+                            "index": "Choo, CY"
+                        }
                     }, 
                     {
-                        "surname": "Ucla", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Ucla", 
+                            "index": "Ucla, C"
+                        }
                     }, 
                     {
-                        "surname": "Manzano", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Manzano", 
+                            "index": "Manzano, C"
+                        }
                     }, 
                     {
-                        "surname": "Wyss", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Wyss", 
+                            "index": "Wyss, C"
+                        }
                     }, 
                     {
-                        "surname": "Cheung", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Cheung", 
+                            "index": "Cheung, E"
+                        }
                     }, 
                     {
-                        "surname": "Clark", 
-                        "given-names": "TG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TG Clark", 
+                            "index": "Clark, TG"
+                        }
                     }, 
                     {
-                        "surname": "Brown", 
-                        "given-names": "JB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JB Brown", 
+                            "index": "Brown, JB"
+                        }
                     }, 
                     {
-                        "surname": "Ganesh", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Ganesh", 
+                            "index": "Ganesh, M"
+                        }
                     }, 
                     {
-                        "surname": "Patel", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Patel", 
+                            "index": "Patel, S"
+                        }
                     }, 
                     {
-                        "surname": "Tammana", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Tammana", 
+                            "index": "Tammana, H"
+                        }
                     }, 
                     {
-                        "surname": "Chrast", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Chrast", 
+                            "index": "Chrast, J"
+                        }
                     }, 
                     {
-                        "surname": "Henrichsen", 
-                        "given-names": "CN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CN Henrichsen", 
+                            "index": "Henrichsen, CN"
+                        }
                     }, 
                     {
-                        "surname": "Kai", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Kai", 
+                            "index": "Kai, C"
+                        }
                     }, 
                     {
-                        "surname": "Kawai", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kawai", 
+                            "index": "Kawai, J"
+                        }
                     }, 
                     {
-                        "surname": "Nagalakshmi", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Nagalakshmi", 
+                            "index": "Nagalakshmi, U"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Wu", 
+                            "index": "Wu, J"
+                        }
                     }, 
                     {
-                        "surname": "Lian", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Lian", 
+                            "index": "Lian, Z"
+                        }
                     }, 
                     {
-                        "surname": "Lian", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Lian", 
+                            "index": "Lian, J"
+                        }
                     }, 
                     {
-                        "surname": "Newburger", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Newburger", 
+                            "index": "Newburger, P"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Zhang", 
+                            "index": "Zhang, X"
+                        }
                     }, 
                     {
-                        "surname": "Bickel", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Bickel", 
+                            "index": "Bickel, P"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }, 
                     {
-                        "surname": "Carninci", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Carninci", 
+                            "index": "Carninci, P"
+                        }
                     }, 
                     {
-                        "surname": "Hayashizaki", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Hayashizaki", 
+                            "index": "Hayashizaki, Y"
+                        }
                     }, 
                     {
-                        "surname": "Weissman", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Weissman", 
+                            "index": "Weissman, S"
+                        }
                     }, 
                     {
-                        "surname": "Hubbard", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hubbard", 
+                            "index": "Hubbard, T"
+                        }
                     }, 
                     {
-                        "surname": "Myers", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Myers", 
+                            "index": "Myers, RM"
+                        }
                     }, 
                     {
-                        "surname": "Rogers", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Rogers", 
+                            "index": "Rogers, J"
+                        }
                     }, 
                     {
-                        "surname": "Stadler", 
-                        "given-names": "PF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PF Stadler", 
+                            "index": "Stadler, PF"
+                        }
                     }, 
                     {
-                        "surname": "Lowe", 
-                        "given-names": "TM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TM Lowe", 
+                            "index": "Lowe, TM"
+                        }
                     }, 
                     {
-                        "surname": "Wei", 
-                        "given-names": "CL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CL Wei", 
+                            "index": "Wei, CL"
+                        }
                     }, 
                     {
-                        "surname": "Ruan", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ruan", 
+                            "index": "Ruan, Y"
+                        }
                     }, 
                     {
-                        "surname": "Struhl", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Struhl", 
+                            "index": "Struhl, K"
+                        }
                     }, 
                     {
-                        "surname": "Gerstein", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Gerstein", 
+                            "index": "Gerstein, M"
+                        }
                     }, 
                     {
-                        "surname": "Antonarakis", 
-                        "given-names": "SE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Antonarakis", 
+                            "index": "Antonarakis, SE"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fu", 
+                            "index": "Fu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Green", 
-                        "given-names": "ED", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ED Green", 
+                            "index": "Green, ED"
+                        }
                     }, 
                     {
-                        "surname": "Kara\u00f6z", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Kara\u00f6z", 
+                            "index": "Kara\u00f6z, U"
+                        }
                     }, 
                     {
-                        "surname": "Siepel", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Siepel", 
+                            "index": "Siepel, A"
+                        }
                     }, 
                     {
-                        "surname": "Taylor", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Taylor", 
+                            "index": "Taylor, J"
+                        }
                     }, 
                     {
-                        "surname": "Liefer", 
-                        "given-names": "LA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LA Liefer", 
+                            "index": "Liefer, LA"
+                        }
                     }, 
                     {
-                        "surname": "Wetterstrand", 
-                        "given-names": "KA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KA Wetterstrand", 
+                            "index": "Wetterstrand, KA"
+                        }
                     }, 
                     {
-                        "surname": "Good", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Good", 
+                            "index": "Good, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Feingold", 
-                        "given-names": "EA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EA Feingold", 
+                            "index": "Feingold, EA"
+                        }
                     }, 
                     {
-                        "surname": "Guyer", 
-                        "given-names": "MS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS Guyer", 
+                            "index": "Guyer, MS"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "GM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GM Cooper", 
+                            "index": "Cooper, GM"
+                        }
                     }, 
                     {
-                        "surname": "Asimenos", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Asimenos", 
+                            "index": "Asimenos, G"
+                        }
                     }, 
                     {
-                        "surname": "Dewey", 
-                        "given-names": "CN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CN Dewey", 
+                            "index": "Dewey, CN"
+                        }
                     }, 
                     {
-                        "surname": "Hou", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Hou", 
+                            "index": "Hou, M"
+                        }
                     }, 
                     {
-                        "surname": "Nikolaev", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nikolaev", 
+                            "index": "Nikolaev, S"
+                        }
                     }, 
                     {
-                        "surname": "Montoya-Burgos", 
-                        "given-names": "JI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JI Montoya-Burgos", 
+                            "index": "Montoya-Burgos, JI"
+                        }
                     }, 
                     {
-                        "surname": "L\u00f6ytynoja", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A L\u00f6ytynoja", 
+                            "index": "L\u00f6ytynoja, A"
+                        }
                     }, 
                     {
-                        "surname": "Whelan", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Whelan", 
+                            "index": "Whelan, S"
+                        }
                     }, 
                     {
-                        "surname": "Pardi", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Pardi", 
+                            "index": "Pardi, F"
+                        }
                     }, 
                     {
-                        "surname": "Massingham", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Massingham", 
+                            "index": "Massingham, T"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Huang", 
+                            "index": "Huang, H"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "NR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NR Zhang", 
+                            "index": "Zhang, NR"
+                        }
                     }, 
                     {
-                        "surname": "Holmes", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Holmes", 
+                            "index": "Holmes, I"
+                        }
                     }, 
                     {
-                        "surname": "Mullikin", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Mullikin", 
+                            "index": "Mullikin, JC"
+                        }
                     }, 
                     {
-                        "surname": "Ureta-Vidal", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Ureta-Vidal", 
+                            "index": "Ureta-Vidal, A"
+                        }
                     }, 
                     {
-                        "surname": "Paten", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Paten", 
+                            "index": "Paten, B"
+                        }
                     }, 
                     {
-                        "surname": "Seringhaus", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Seringhaus", 
+                            "index": "Seringhaus, M"
+                        }
                     }, 
                     {
-                        "surname": "Church", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Church", 
+                            "index": "Church, D"
+                        }
                     }, 
                     {
-                        "surname": "Rosenbloom", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Rosenbloom", 
+                            "index": "Rosenbloom, K"
+                        }
                     }, 
                     {
-                        "surname": "Kent", 
-                        "given-names": "WJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WJ Kent", 
+                            "index": "Kent, WJ"
+                        }
                     }, 
                     {
-                        "surname": "Stone", 
-                        "given-names": "EA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EA Stone", 
+                            "index": "Stone, EA"
+                        }
                     }, 
                     {
-                        "surname": "Batzoglou", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Batzoglou", 
+                            "index": "Batzoglou, S"
+                        }
                     }, 
                     {
-                        "surname": "Goldman", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Goldman", 
+                            "index": "Goldman, N"
+                        }
                     }, 
                     {
-                        "surname": "Hardison", 
-                        "given-names": "RC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RC Hardison", 
+                            "index": "Hardison, RC"
+                        }
                     }, 
                     {
-                        "surname": "Haussler", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Haussler", 
+                            "index": "Haussler, D"
+                        }
                     }, 
                     {
-                        "surname": "Miller", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Miller", 
+                            "index": "Miller, W"
+                        }
                     }, 
                     {
-                        "surname": "Sidow", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sidow", 
+                            "index": "Sidow, A"
+                        }
                     }, 
                     {
-                        "surname": "Trinklein", 
-                        "given-names": "ND", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ND Trinklein", 
+                            "index": "Trinklein, ND"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "ZD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ZD Zhang", 
+                            "index": "Zhang, ZD"
+                        }
                     }, 
                     {
-                        "surname": "Barrera", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Barrera", 
+                            "index": "Barrera, L"
+                        }
                     }, 
                     {
-                        "surname": "Stuart", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Stuart", 
+                            "index": "Stuart, R"
+                        }
                     }, 
                     {
-                        "surname": "King", 
-                        "given-names": "DC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC King", 
+                            "index": "King, DC"
+                        }
                     }, 
                     {
-                        "surname": "Ameur", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Ameur", 
+                            "index": "Ameur, A"
+                        }
                     }, 
                     {
-                        "surname": "Enroth", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Enroth", 
+                            "index": "Enroth, S"
+                        }
                     }, 
                     {
-                        "surname": "Bieda", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Bieda", 
+                            "index": "Bieda, MC"
+                        }
                     }, 
                     {
-                        "surname": "Kim", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kim", 
+                            "index": "Kim, J"
+                        }
                     }, 
                     {
-                        "surname": "Bhinge", 
-                        "given-names": "AA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AA Bhinge", 
+                            "index": "Bhinge, AA"
+                        }
                     }, 
                     {
-                        "surname": "Jiang", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Jiang", 
+                            "index": "Jiang, N"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Liu", 
+                            "index": "Liu, J"
+                        }
                     }, 
                     {
-                        "surname": "Yao", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Yao", 
+                            "index": "Yao, F"
+                        }
                     }, 
                     {
-                        "surname": "Vega", 
-                        "given-names": "VB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "VB Vega", 
+                            "index": "Vega, VB"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "CW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CW Lee", 
+                            "index": "Lee, CW"
+                        }
                     }, 
                     {
-                        "surname": "Ng", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Ng", 
+                            "index": "Ng, P"
+                        }
                     }, 
                     {
-                        "surname": "Shahab", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Shahab", 
+                            "index": "Shahab, A"
+                        }
                     }, 
                     {
-                        "surname": "Yang", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Yang", 
+                            "index": "Yang, A"
+                        }
                     }, 
                     {
-                        "surname": "Moqtaderi", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Moqtaderi", 
+                            "index": "Moqtaderi, Z"
+                        }
                     }, 
                     {
-                        "surname": "Zhu", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Zhu", 
+                            "index": "Zhu, Z"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Xu", 
+                            "index": "Xu, X"
+                        }
                     }, 
                     {
-                        "surname": "Squazzo", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Squazzo", 
+                            "index": "Squazzo, S"
+                        }
                     }, 
                     {
-                        "surname": "Oberley", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Oberley", 
+                            "index": "Oberley, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Inman", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Inman", 
+                            "index": "Inman, D"
+                        }
                     }, 
                     {
-                        "surname": "Singer", 
-                        "given-names": "MA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Singer", 
+                            "index": "Singer, MA"
+                        }
                     }, 
                     {
-                        "surname": "Richmond", 
-                        "given-names": "TA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TA Richmond", 
+                            "index": "Richmond, TA"
+                        }
                     }, 
                     {
-                        "surname": "Munn", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Munn", 
+                            "index": "Munn, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Rada-Iglesias", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Rada-Iglesias", 
+                            "index": "Rada-Iglesias, A"
+                        }
                     }, 
                     {
-                        "surname": "Wallerman", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Wallerman", 
+                            "index": "Wallerman, O"
+                        }
                     }, 
                     {
-                        "surname": "Komorowski", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Komorowski", 
+                            "index": "Komorowski, J"
+                        }
                     }, 
                     {
-                        "surname": "Fowler", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Fowler", 
+                            "index": "Fowler, JC"
+                        }
                     }, 
                     {
-                        "surname": "Couttet", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Couttet", 
+                            "index": "Couttet, P"
+                        }
                     }, 
                     {
-                        "surname": "Bruce", 
-                        "given-names": "AW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AW Bruce", 
+                            "index": "Bruce, AW"
+                        }
                     }, 
                     {
-                        "surname": "Dovey", 
-                        "given-names": "OM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "OM Dovey", 
+                            "index": "Dovey, OM"
+                        }
                     }, 
                     {
-                        "surname": "Ellis", 
-                        "given-names": "PD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PD Ellis", 
+                            "index": "Ellis, PD"
+                        }
                     }, 
                     {
-                        "surname": "Langford", 
-                        "given-names": "CF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CF Langford", 
+                            "index": "Langford, CF"
+                        }
                     }, 
                     {
-                        "surname": "Nix", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Nix", 
+                            "index": "Nix, DA"
+                        }
                     }, 
                     {
-                        "surname": "Euskirchen", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Euskirchen", 
+                            "index": "Euskirchen, G"
+                        }
                     }, 
                     {
-                        "surname": "Hartman", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Hartman", 
+                            "index": "Hartman, S"
+                        }
                     }, 
                     {
-                        "surname": "Urban", 
-                        "given-names": "AE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AE Urban", 
+                            "index": "Urban, AE"
+                        }
                     }, 
                     {
-                        "surname": "Kraus", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Kraus", 
+                            "index": "Kraus, P"
+                        }
                     }, 
                     {
-                        "surname": "Van Calcar", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Van Calcar", 
+                            "index": "Van Calcar, S"
+                        }
                     }, 
                     {
-                        "surname": "Heintzman", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Heintzman", 
+                            "index": "Heintzman, N"
+                        }
                     }, 
                     {
-                        "surname": "Kim", 
-                        "given-names": "TH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TH Kim", 
+                            "index": "Kim, TH"
+                        }
                     }, 
                     {
-                        "surname": "Wang", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Wang", 
+                            "index": "Wang, K"
+                        }
                     }, 
                     {
-                        "surname": "Qu", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Qu", 
+                            "index": "Qu, C"
+                        }
                     }, 
                     {
-                        "surname": "Hon", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Hon", 
+                            "index": "Hon, G"
+                        }
                     }, 
                     {
-                        "surname": "Luna", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Luna", 
+                            "index": "Luna, R"
+                        }
                     }, 
                     {
-                        "surname": "Glass", 
-                        "given-names": "CK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CK Glass", 
+                            "index": "Glass, CK"
+                        }
                     }, 
                     {
-                        "surname": "Rosenfeld", 
-                        "given-names": "MG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MG Rosenfeld", 
+                            "index": "Rosenfeld, MG"
+                        }
                     }, 
                     {
-                        "surname": "Aldred", 
-                        "given-names": "SF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SF Aldred", 
+                            "index": "Aldred, SF"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "SJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SJ Cooper", 
+                            "index": "Cooper, SJ"
+                        }
                     }, 
                     {
-                        "surname": "Halees", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Halees", 
+                            "index": "Halees, A"
+                        }
                     }, 
                     {
-                        "surname": "Lin", 
-                        "given-names": "JM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Lin", 
+                            "index": "Lin, JM"
+                        }
                     }, 
                     {
-                        "surname": "Shulha", 
-                        "given-names": "HP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HP Shulha", 
+                            "index": "Shulha, HP"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Zhang", 
+                            "index": "Zhang, X"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Xu", 
+                            "index": "Xu, M"
+                        }
                     }, 
                     {
-                        "surname": "Haidar", 
-                        "given-names": "JN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JN Haidar", 
+                            "index": "Haidar, JN"
+                        }
                     }, 
                     {
-                        "surname": "Yu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Yu", 
+                            "index": "Yu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Ruan", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ruan", 
+                            "index": "Ruan, Y"
+                        }
                     }, 
                     {
-                        "surname": "Iyer", 
-                        "given-names": "VR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "VR Iyer", 
+                            "index": "Iyer, VR"
+                        }
                     }, 
                     {
-                        "surname": "Green", 
-                        "given-names": "RD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RD Green", 
+                            "index": "Green, RD"
+                        }
                     }, 
                     {
-                        "surname": "Wadelius", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Wadelius", 
+                            "index": "Wadelius, C"
+                        }
                     }, 
                     {
-                        "surname": "Farnham", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Farnham", 
+                            "index": "Farnham, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Ren", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Ren", 
+                            "index": "Ren, B"
+                        }
                     }, 
                     {
-                        "surname": "Harte", 
-                        "given-names": "RA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Harte", 
+                            "index": "Harte, RA"
+                        }
                     }, 
                     {
-                        "surname": "Hinrichs", 
-                        "given-names": "AS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Hinrichs", 
+                            "index": "Hinrichs, AS"
+                        }
                     }, 
                     {
-                        "surname": "Trumbower", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Trumbower", 
+                            "index": "Trumbower, H"
+                        }
                     }, 
                     {
-                        "surname": "Clawson", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Clawson", 
+                            "index": "Clawson, H"
+                        }
                     }, 
                     {
-                        "surname": "Hillman-Jackson", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hillman-Jackson", 
+                            "index": "Hillman-Jackson, J"
+                        }
                     }, 
                     {
-                        "surname": "Zweig", 
-                        "given-names": "AS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Zweig", 
+                            "index": "Zweig, AS"
+                        }
                     }, 
                     {
-                        "surname": "Smith", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Smith", 
+                            "index": "Smith, K"
+                        }
                     }, 
                     {
-                        "surname": "Thakkapallayil", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Thakkapallayil", 
+                            "index": "Thakkapallayil, A"
+                        }
                     }, 
                     {
-                        "surname": "Barber", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Barber", 
+                            "index": "Barber, G"
+                        }
                     }, 
                     {
-                        "surname": "Kuhn", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Kuhn", 
+                            "index": "Kuhn, RM"
+                        }
                     }, 
                     {
-                        "surname": "Karolchik", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Karolchik", 
+                            "index": "Karolchik, D"
+                        }
                     }, 
                     {
-                        "surname": "Armengol", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Armengol", 
+                            "index": "Armengol, L"
+                        }
                     }, 
                     {
-                        "surname": "Bird", 
-                        "given-names": "CP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CP Bird", 
+                            "index": "Bird, CP"
+                        }
                     }, 
                     {
-                        "surname": "de Bakker", 
-                        "given-names": "PI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PI de Bakker", 
+                            "index": "de Bakker, PI"
+                        }
                     }, 
                     {
-                        "surname": "Kern", 
-                        "given-names": "AD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AD Kern", 
+                            "index": "Kern, AD"
+                        }
                     }, 
                     {
-                        "surname": "Lopez-Bigas", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Lopez-Bigas", 
+                            "index": "Lopez-Bigas, N"
+                        }
                     }, 
                     {
-                        "surname": "Martin", 
-                        "given-names": "JD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JD Martin", 
+                            "index": "Martin, JD"
+                        }
                     }, 
                     {
-                        "surname": "Stranger", 
-                        "given-names": "BE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BE Stranger", 
+                            "index": "Stranger, BE"
+                        }
                     }, 
                     {
-                        "surname": "Woodroffe", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Woodroffe", 
+                            "index": "Woodroffe, A"
+                        }
                     }, 
                     {
-                        "surname": "Davydov", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Davydov", 
+                            "index": "Davydov, E"
+                        }
                     }, 
                     {
-                        "surname": "Dimas", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Dimas", 
+                            "index": "Dimas, A"
+                        }
                     }, 
                     {
-                        "surname": "Eyras", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Eyras", 
+                            "index": "Eyras, E"
+                        }
                     }, 
                     {
-                        "surname": "Hallgr\u00edmsd\u00f3ttir", 
-                        "given-names": "IB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IB Hallgr\u00edmsd\u00f3ttir", 
+                            "index": "Hallgr\u00edmsd\u00f3ttir, IB"
+                        }
                     }, 
                     {
-                        "surname": "Huppert", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Huppert", 
+                            "index": "Huppert, J"
+                        }
                     }, 
                     {
-                        "surname": "Zody", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Zody", 
+                            "index": "Zody, MC"
+                        }
                     }, 
                     {
-                        "surname": "Abecasis", 
-                        "given-names": "GR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GR Abecasis", 
+                            "index": "Abecasis, GR"
+                        }
                     }, 
                     {
-                        "surname": "Estivill", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Estivill", 
+                            "index": "Estivill, X"
+                        }
                     }, 
                     {
-                        "surname": "Bouffard", 
-                        "given-names": "GG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GG Bouffard", 
+                            "index": "Bouffard, GG"
+                        }
                     }, 
                     {
-                        "surname": "Guan", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Guan", 
+                            "index": "Guan, X"
+                        }
                     }, 
                     {
-                        "surname": "Hansen", 
-                        "given-names": "NF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NF Hansen", 
+                            "index": "Hansen, NF"
+                        }
                     }, 
                     {
-                        "surname": "Idol", 
-                        "given-names": "JR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JR Idol", 
+                            "index": "Idol, JR"
+                        }
                     }, 
                     {
-                        "surname": "Maduro", 
-                        "given-names": "VV", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "VV Maduro", 
+                            "index": "Maduro, VV"
+                        }
                     }, 
                     {
-                        "surname": "Maskeri", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Maskeri", 
+                            "index": "Maskeri, B"
+                        }
                     }, 
                     {
-                        "surname": "McDowell", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC McDowell", 
+                            "index": "McDowell, JC"
+                        }
                     }, 
                     {
-                        "surname": "Park", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Park", 
+                            "index": "Park, M"
+                        }
                     }, 
                     {
-                        "surname": "Thomas", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Thomas", 
+                            "index": "Thomas, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Young", 
-                        "given-names": "AC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AC Young", 
+                            "index": "Young, AC"
+                        }
                     }, 
                     {
-                        "surname": "Blakesley", 
-                        "given-names": "RW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RW Blakesley", 
+                            "index": "Blakesley, RW"
+                        }
                     }, 
                     {
-                        "surname": "Muzny", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Muzny", 
+                            "index": "Muzny, DM"
+                        }
                     }, 
                     {
-                        "surname": "Sodergren", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Sodergren", 
+                            "index": "Sodergren, E"
+                        }
                     }, 
                     {
-                        "surname": "Wheeler", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Wheeler", 
+                            "index": "Wheeler, DA"
+                        }
                     }, 
                     {
-                        "surname": "Worley", 
-                        "given-names": "KC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KC Worley", 
+                            "index": "Worley, KC"
+                        }
                     }, 
                     {
-                        "surname": "Jiang", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Jiang", 
+                            "index": "Jiang, H"
+                        }
                     }, 
                     {
-                        "surname": "Weinstock", 
-                        "given-names": "GM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GM Weinstock", 
+                            "index": "Weinstock, GM"
+                        }
                     }, 
                     {
-                        "surname": "Gibbs", 
-                        "given-names": "RA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Gibbs", 
+                            "index": "Gibbs, RA"
+                        }
                     }, 
                     {
-                        "surname": "Graves", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Graves", 
+                            "index": "Graves, T"
+                        }
                     }, 
                     {
-                        "surname": "Fulton", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Fulton", 
+                            "index": "Fulton, R"
+                        }
                     }, 
                     {
-                        "surname": "Mardis", 
-                        "given-names": "ER", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ER Mardis", 
+                            "index": "Mardis, ER"
+                        }
                     }, 
                     {
-                        "surname": "Wilson", 
-                        "given-names": "RK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RK Wilson", 
+                            "index": "Wilson, RK"
+                        }
                     }, 
                     {
-                        "surname": "Clamp", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Clamp", 
+                            "index": "Clamp, M"
+                        }
                     }, 
                     {
-                        "surname": "Cuff", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Cuff", 
+                            "index": "Cuff, J"
+                        }
                     }, 
                     {
-                        "surname": "Gnerre", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Gnerre", 
+                            "index": "Gnerre, S"
+                        }
                     }, 
                     {
-                        "surname": "Jaffe", 
-                        "given-names": "DB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DB Jaffe", 
+                            "index": "Jaffe, DB"
+                        }
                     }, 
                     {
-                        "surname": "Chang", 
-                        "given-names": "JL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Chang", 
+                            "index": "Chang, JL"
+                        }
                     }, 
                     {
-                        "surname": "Lindblad-Toh", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Lindblad-Toh", 
+                            "index": "Lindblad-Toh, K"
+                        }
                     }, 
                     {
-                        "surname": "Lander", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Lander", 
+                            "index": "Lander, ES"
+                        }
                     }, 
                     {
-                        "surname": "Koriabine", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Koriabine", 
+                            "index": "Koriabine, M"
+                        }
                     }, 
                     {
-                        "surname": "Nefedov", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Nefedov", 
+                            "index": "Nefedov, M"
+                        }
                     }, 
                     {
-                        "surname": "Osoegawa", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Osoegawa", 
+                            "index": "Osoegawa, K"
+                        }
                     }, 
                     {
-                        "surname": "Yoshinaga", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Yoshinaga", 
+                            "index": "Yoshinaga, Y"
+                        }
                     }, 
                     {
-                        "surname": "Zhu", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zhu", 
+                            "index": "Zhu, B"
+                        }
                     }, 
                     {
-                        "surname": "de Jong", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ de Jong", 
+                            "index": "de Jong, PJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Identification and analysis of functional elements in 1% of the human genome by the ENCODE pilot project", 
-                "publication-type": "journal", 
+                "articleTitle": "Identification and analysis of functional elements in 1% of the human genome by the ENCODE pilot project", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "447", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature05874", 
-                "fpage": "799", 
-                "year": "2007", 
-                "position": 2, 
-                "ref": "BirneyEStamatoyannopoulosJADuttaAGuigoRGingerasTRMarguliesEHBirneyEStamatoyannopoulosJADuttaAGuig\u00f3RGingerasTRMarguliesEHWengZSnyderMDermitzakisETThurmanREKuehnMSTaylorCMNephSKochCMAsthanaSMalhotraAAdzhubeiIGreenbaumJAAndrewsRMFlicekPBoylePJCaoHCarterNPClellandGKDavisSDayNDhamiPDillonSCDorschnerMOFieglerHGiresiPGGoldyJHawrylyczMHaydockAHumbertRJamesKDJohnsonBEJohnsonEMFrumTTRosenzweigERKarnaniNLeeKLefebvreGCNavasPANeriFParkerSCSaboPJSandstromRShaferAVetrieDWeaverMWilcoxSYuMCollinsFSDekkerJLiebJDTulliusTDCrawfordGESunyaevSNobleWSDunhamIDenoeudFReymondAKapranovPRozowskyJZhengDCasteloRFrankishAHarrowJGhoshSSandelinAHofackerILBaertschRKeefeDDikeSChengJHirschHASekingerEALagardeJAbrilJFShahabAFlammCFriedCHackerm\u00fcllerJHertelJLindemeyerMMissalKTanzerAWashietlSKorbelJEmanuelssonOPedersenJSHolroydNTaylorRSwarbreckDMatthewsNDicksonMCThomasDJWeirauchMTGilbertJDrenkowJBellIZhaoXSrinivasanKGSungWKOoiHSChiuKPFoissacSAliotoTBrentMPachterLTressMLValenciaAChooSWChooCYUclaCManzanoCWyssCCheungEClarkTGBrownJBGaneshMPatelSTammanaHChrastJHenrichsenCNKaiCKawaiJNagalakshmiUWuJLianZLianJNewburgerPZhangXBickelPMattickJSCarninciPHayashizakiYWeissmanSHubbardTMyersRMRogersJStadlerPFLoweTMWeiCLRuanYStruhlKGersteinMAntonarakisSEFuYGreenEDKara\u00f6zUSiepelATaylorJLieferLAWetterstrandKAGoodPJFeingoldEAGuyerMSCooperGMAsimenosGDeweyCNHouMNikolaevSMontoya-BurgosJIL\u00f6ytynojaAWhelanSPardiFMassinghamTHuangHZhangNRHolmesIMullikinJCUreta-VidalAPatenBSeringhausMChurchDRosenbloomKKentWJStoneEABatzoglouSGoldmanNHardisonRCHausslerDMillerWSidowATrinkleinNDZhangZDBarreraLStuartRKingDCAmeurAEnrothSBiedaMCKimJBhingeAAJiangNLiuJYaoFVegaVBLeeCWNgPShahabAYangAMoqtaderiZZhuZXuXSquazzoSOberleyMJInmanDSingerMARichmondTAMunnKJRada-IglesiasAWallermanOKomorowskiJFowlerJCCouttetPBruceAWDoveyOMEllisPDLangfordCFNixDAEuskirchenGHartmanSUrbanAEKrausPVan CalcarSHeintzmanNKimTHWangKQuCHonGLunaRGlassCKRosenfeldMGAldredSFCooperSJHaleesALinJMShulhaHPZhangXXuMHaidarJNYuYRuanYIyerVRGreenRDWadeliusCFarnhamPJRenBHarteRAHinrichsASTrumbowerHClawsonHHillman-JacksonJZweigASSmithKThakkapallayilABarberGKuhnRMKarolchikDArmengolLBirdCPde BakkerPIKernADLopez-BigasNMartinJDStrangerBEWoodroffeADavydovEDimasAEyrasEHallgr\u00edmsd\u00f3ttirIBHuppertJZodyMCAbecasisGREstivillXBouffardGGGuanXHansenNFIdolJRMaduroVVMaskeriBMcDowellJCParkMThomasPJYoungACBlakesleyRWMuznyDMSodergrenEWheelerDAWorleyKCJiangHWeinstockGMGibbsRAGravesTFultonRMardisERWilsonRKClampMCuffJGnerreSJaffeDBChangJLLindblad-TohKLanderESKoriabineMNefedovMOsoegawaKYoshinagaYZhuBde JongPJ2007Identification and analysis of functional elements in 1% of the human genome by the ENCODE pilot projectNature44779981610.1038/nature05874", 
-                "id": "bib2"
+                "pages": {
+                    "first": "799", 
+                    "last": "816", 
+                    "range": "799\u2013816"
+                }, 
+                "doi": "10.1038/nature05874"
             }, 
             {
-                "article_title": "The transcriptional landscape of the mammalian genome", 
-                "lpage": "1563", 
-                "doi": "10.1126/science.1112014", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib3", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Carninci", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Carninci", 
+                            "index": "Carninci, P"
+                        }
                     }, 
                     {
-                        "surname": "Kasukawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Kasukawa", 
+                            "index": "Kasukawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Katayama", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Katayama", 
+                            "index": "Katayama, S"
+                        }
                     }, 
                     {
-                        "surname": "Gough", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Gough", 
+                            "index": "Gough, J"
+                        }
                     }, 
                     {
-                        "surname": "Frith", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Frith", 
+                            "index": "Frith, MC"
+                        }
                     }, 
                     {
-                        "surname": "Maeda", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Maeda", 
+                            "index": "Maeda, N"
+                        }
                     }, 
                     {
-                        "surname": "Carninci", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Carninci", 
+                            "index": "Carninci, P"
+                        }
                     }, 
                     {
-                        "surname": "Kasukawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Kasukawa", 
+                            "index": "Kasukawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Katayama", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Katayama", 
+                            "index": "Katayama, S"
+                        }
                     }, 
                     {
-                        "surname": "Gough", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Gough", 
+                            "index": "Gough, J"
+                        }
                     }, 
                     {
-                        "surname": "Frith", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Frith", 
+                            "index": "Frith, MC"
+                        }
                     }, 
                     {
-                        "surname": "Maeda", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Maeda", 
+                            "index": "Maeda, N"
+                        }
                     }, 
                     {
-                        "surname": "Oyama", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Oyama", 
+                            "index": "Oyama, R"
+                        }
                     }, 
                     {
-                        "surname": "Ravasi", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Ravasi", 
+                            "index": "Ravasi, T"
+                        }
                     }, 
                     {
-                        "surname": "Lenhard", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Lenhard", 
+                            "index": "Lenhard, B"
+                        }
                     }, 
                     {
-                        "surname": "Wells", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Wells", 
+                            "index": "Wells, C"
+                        }
                     }, 
                     {
-                        "surname": "Kodzius", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Kodzius", 
+                            "index": "Kodzius, R"
+                        }
                     }, 
                     {
-                        "surname": "Shimokawa", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shimokawa", 
+                            "index": "Shimokawa, K"
+                        }
                     }, 
                     {
-                        "surname": "Bajic", 
-                        "given-names": "VB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "VB Bajic", 
+                            "index": "Bajic, VB"
+                        }
                     }, 
                     {
-                        "surname": "Brenner", 
-                        "given-names": "SE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Brenner", 
+                            "index": "Brenner, SE"
+                        }
                     }, 
                     {
-                        "surname": "Batalov", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Batalov", 
+                            "index": "Batalov, S"
+                        }
                     }, 
                     {
-                        "surname": "Forrest", 
-                        "given-names": "AR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AR Forrest", 
+                            "index": "Forrest, AR"
+                        }
                     }, 
                     {
-                        "surname": "Zavolan", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Zavolan", 
+                            "index": "Zavolan, M"
+                        }
                     }, 
                     {
-                        "surname": "Davis", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Davis", 
+                            "index": "Davis, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Wilming", 
-                        "given-names": "LG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LG Wilming", 
+                            "index": "Wilming, LG"
+                        }
                     }, 
                     {
-                        "surname": "Aidinis", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Aidinis", 
+                            "index": "Aidinis, V"
+                        }
                     }, 
                     {
-                        "surname": "Allen", 
-                        "given-names": "JE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JE Allen", 
+                            "index": "Allen, JE"
+                        }
                     }, 
                     {
-                        "surname": "Ambesi-Impiombato", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Ambesi-Impiombato", 
+                            "index": "Ambesi-Impiombato, A"
+                        }
                     }, 
                     {
-                        "surname": "Apweiler", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Apweiler", 
+                            "index": "Apweiler, R"
+                        }
                     }, 
                     {
-                        "surname": "Aturaliya", 
-                        "given-names": "RN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RN Aturaliya", 
+                            "index": "Aturaliya, RN"
+                        }
                     }, 
                     {
-                        "surname": "Bailey", 
-                        "given-names": "TL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TL Bailey", 
+                            "index": "Bailey, TL"
+                        }
                     }, 
                     {
-                        "surname": "Bansal", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Bansal", 
+                            "index": "Bansal, M"
+                        }
                     }, 
                     {
-                        "surname": "Baxter", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Baxter", 
+                            "index": "Baxter, L"
+                        }
                     }, 
                     {
-                        "surname": "Beisel", 
-                        "given-names": "KW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KW Beisel", 
+                            "index": "Beisel, KW"
+                        }
                     }, 
                     {
-                        "surname": "Bersano", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Bersano", 
+                            "index": "Bersano, T"
+                        }
                     }, 
                     {
-                        "surname": "Bono", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Bono", 
+                            "index": "Bono, H"
+                        }
                     }, 
                     {
-                        "surname": "Chalk", 
-                        "given-names": "AM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AM Chalk", 
+                            "index": "Chalk, AM"
+                        }
                     }, 
                     {
-                        "surname": "Chiu", 
-                        "given-names": "KP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KP Chiu", 
+                            "index": "Chiu, KP"
+                        }
                     }, 
                     {
-                        "surname": "Choudhary", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Choudhary", 
+                            "index": "Choudhary, V"
+                        }
                     }, 
                     {
-                        "surname": "Christoffels", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Christoffels", 
+                            "index": "Christoffels, A"
+                        }
                     }, 
                     {
-                        "surname": "Clutterbuck", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Clutterbuck", 
+                            "index": "Clutterbuck, DR"
+                        }
                     }, 
                     {
-                        "surname": "Crowe", 
-                        "given-names": "ML", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ML Crowe", 
+                            "index": "Crowe, ML"
+                        }
                     }, 
                     {
-                        "surname": "Dalla", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Dalla", 
+                            "index": "Dalla, E"
+                        }
                     }, 
                     {
-                        "surname": "Dalrymple", 
-                        "given-names": "BP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BP Dalrymple", 
+                            "index": "Dalrymple, BP"
+                        }
                     }, 
                     {
-                        "surname": "de Bono", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B de Bono", 
+                            "index": "de Bono, B"
+                        }
                     }, 
                     {
-                        "surname": "Della Gatta", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Della Gatta", 
+                            "index": "Della Gatta, G"
+                        }
                     }, 
                     {
-                        "surname": "di Bernardo", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D di Bernardo", 
+                            "index": "di Bernardo, D"
+                        }
                     }, 
                     {
-                        "surname": "Down", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Down", 
+                            "index": "Down, T"
+                        }
                     }, 
                     {
-                        "surname": "Engstrom", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Engstrom", 
+                            "index": "Engstrom, P"
+                        }
                     }, 
                     {
-                        "surname": "Fagiolini", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Fagiolini", 
+                            "index": "Fagiolini, M"
+                        }
                     }, 
                     {
-                        "surname": "Faulkner", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Faulkner", 
+                            "index": "Faulkner, G"
+                        }
                     }, 
                     {
-                        "surname": "Fletcher", 
-                        "given-names": "CF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CF Fletcher", 
+                            "index": "Fletcher, CF"
+                        }
                     }, 
                     {
-                        "surname": "Fukushima", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Fukushima", 
+                            "index": "Fukushima, T"
+                        }
                     }, 
                     {
-                        "surname": "Furuno", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Furuno", 
+                            "index": "Furuno, M"
+                        }
                     }, 
                     {
-                        "surname": "Futaki", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Futaki", 
+                            "index": "Futaki, S"
+                        }
                     }, 
                     {
-                        "surname": "Gariboldi", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Gariboldi", 
+                            "index": "Gariboldi, M"
+                        }
                     }, 
                     {
-                        "surname": "Georgii-Hemming", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Georgii-Hemming", 
+                            "index": "Georgii-Hemming, P"
+                        }
                     }, 
                     {
-                        "surname": "Gingeras", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Gingeras", 
+                            "index": "Gingeras, TR"
+                        }
                     }, 
                     {
-                        "surname": "Gojobori", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Gojobori", 
+                            "index": "Gojobori, T"
+                        }
                     }, 
                     {
-                        "surname": "Green", 
-                        "given-names": "RE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RE Green", 
+                            "index": "Green, RE"
+                        }
                     }, 
                     {
-                        "surname": "Gustincich", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Gustincich", 
+                            "index": "Gustincich, S"
+                        }
                     }, 
                     {
-                        "surname": "Harbers", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Harbers", 
+                            "index": "Harbers, M"
+                        }
                     }, 
                     {
-                        "surname": "Hayashi", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Hayashi", 
+                            "index": "Hayashi, Y"
+                        }
                     }, 
                     {
-                        "surname": "Hensch", 
-                        "given-names": "TK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TK Hensch", 
+                            "index": "Hensch, TK"
+                        }
                     }, 
                     {
-                        "surname": "Hirokawa", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Hirokawa", 
+                            "index": "Hirokawa, N"
+                        }
                     }, 
                     {
-                        "surname": "Hill", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Hill", 
+                            "index": "Hill, D"
+                        }
                     }, 
                     {
-                        "surname": "Huminiecki", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Huminiecki", 
+                            "index": "Huminiecki, L"
+                        }
                     }, 
                     {
-                        "surname": "Iacono", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Iacono", 
+                            "index": "Iacono, M"
+                        }
                     }, 
                     {
-                        "surname": "Ikeo", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Ikeo", 
+                            "index": "Ikeo, K"
+                        }
                     }, 
                     {
-                        "surname": "Iwama", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Iwama", 
+                            "index": "Iwama, A"
+                        }
                     }, 
                     {
-                        "surname": "Ishikawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Ishikawa", 
+                            "index": "Ishikawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Jakt", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Jakt", 
+                            "index": "Jakt, M"
+                        }
                     }, 
                     {
-                        "surname": "Kanapin", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kanapin", 
+                            "index": "Kanapin, A"
+                        }
                     }, 
                     {
-                        "surname": "Katoh", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Katoh", 
+                            "index": "Katoh, M"
+                        }
                     }, 
                     {
-                        "surname": "Kawasawa", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Kawasawa", 
+                            "index": "Kawasawa, Y"
+                        }
                     }, 
                     {
-                        "surname": "Kelso", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kelso", 
+                            "index": "Kelso, J"
+                        }
                     }, 
                     {
-                        "surname": "Kitamura", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kitamura", 
+                            "index": "Kitamura, H"
+                        }
                     }, 
                     {
-                        "surname": "Kitano", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kitano", 
+                            "index": "Kitano, H"
+                        }
                     }, 
                     {
-                        "surname": "Kollias", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Kollias", 
+                            "index": "Kollias, G"
+                        }
                     }, 
                     {
-                        "surname": "Krishnan", 
-                        "given-names": "SP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SP Krishnan", 
+                            "index": "Krishnan, SP"
+                        }
                     }, 
                     {
-                        "surname": "Kruger", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kruger", 
+                            "index": "Kruger, A"
+                        }
                     }, 
                     {
-                        "surname": "Kummerfeld", 
-                        "given-names": "SK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SK Kummerfeld", 
+                            "index": "Kummerfeld, SK"
+                        }
                     }, 
                     {
-                        "surname": "Kurochkin", 
-                        "given-names": "IV", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IV Kurochkin", 
+                            "index": "Kurochkin, IV"
+                        }
                     }, 
                     {
-                        "surname": "Lareau", 
-                        "given-names": "LF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LF Lareau", 
+                            "index": "Lareau, LF"
+                        }
                     }, 
                     {
-                        "surname": "Lazarevic", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lazarevic", 
+                            "index": "Lazarevic, D"
+                        }
                     }, 
                     {
-                        "surname": "Lipovich", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Lipovich", 
+                            "index": "Lipovich, L"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Liu", 
+                            "index": "Liu, J"
+                        }
                     }, 
                     {
-                        "surname": "Liuni", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Liuni", 
+                            "index": "Liuni, S"
+                        }
                     }, 
                     {
-                        "surname": "McWilliam", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S McWilliam", 
+                            "index": "McWilliam, S"
+                        }
                     }, 
                     {
-                        "surname": "Madan Babu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Madan Babu", 
+                            "index": "Madan Babu, M"
+                        }
                     }, 
                     {
-                        "surname": "Madera", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Madera", 
+                            "index": "Madera, M"
+                        }
                     }, 
                     {
-                        "surname": "Marchionni", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Marchionni", 
+                            "index": "Marchionni, L"
+                        }
                     }, 
                     {
-                        "surname": "Matsuda", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Matsuda", 
+                            "index": "Matsuda, H"
+                        }
                     }, 
                     {
-                        "surname": "Matsuzawa", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Matsuzawa", 
+                            "index": "Matsuzawa, S"
+                        }
                     }, 
                     {
-                        "surname": "Miki", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Miki", 
+                            "index": "Miki, H"
+                        }
                     }, 
                     {
-                        "surname": "Mignone", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Mignone", 
+                            "index": "Mignone, F"
+                        }
                     }, 
                     {
-                        "surname": "Miyake", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Miyake", 
+                            "index": "Miyake, S"
+                        }
                     }, 
                     {
-                        "surname": "Morris", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Morris", 
+                            "index": "Morris, K"
+                        }
                     }, 
                     {
-                        "surname": "Mottagui-Tabar", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Mottagui-Tabar", 
+                            "index": "Mottagui-Tabar, S"
+                        }
                     }, 
                     {
-                        "surname": "Mulder", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Mulder", 
+                            "index": "Mulder, N"
+                        }
                     }, 
                     {
-                        "surname": "Nakano", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Nakano", 
+                            "index": "Nakano, N"
+                        }
                     }, 
                     {
-                        "surname": "Nakauchi", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Nakauchi", 
+                            "index": "Nakauchi, H"
+                        }
                     }, 
                     {
-                        "surname": "Ng", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Ng", 
+                            "index": "Ng, P"
+                        }
                     }, 
                     {
-                        "surname": "Nilsson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Nilsson", 
+                            "index": "Nilsson, R"
+                        }
                     }, 
                     {
-                        "surname": "Nishiguchi", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nishiguchi", 
+                            "index": "Nishiguchi, S"
+                        }
                     }, 
                     {
-                        "surname": "Nishikawa", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nishikawa", 
+                            "index": "Nishikawa, S"
+                        }
                     }, 
                     {
-                        "surname": "Nori", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Nori", 
+                            "index": "Nori, F"
+                        }
                     }, 
                     {
-                        "surname": "Ohara", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Ohara", 
+                            "index": "Ohara, O"
+                        }
                     }, 
                     {
-                        "surname": "Okazaki", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Okazaki", 
+                            "index": "Okazaki, Y"
+                        }
                     }, 
                     {
-                        "surname": "Orlando", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Orlando", 
+                            "index": "Orlando, V"
+                        }
                     }, 
                     {
-                        "surname": "Pang", 
-                        "given-names": "KC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KC Pang", 
+                            "index": "Pang, KC"
+                        }
                     }, 
                     {
-                        "surname": "Pavan", 
-                        "given-names": "WJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WJ Pavan", 
+                            "index": "Pavan, WJ"
+                        }
                     }, 
                     {
-                        "surname": "Pavesi", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Pavesi", 
+                            "index": "Pavesi, G"
+                        }
                     }, 
                     {
-                        "surname": "Pesole", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Pesole", 
+                            "index": "Pesole, G"
+                        }
                     }, 
                     {
-                        "surname": "Petrovsky", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Petrovsky", 
+                            "index": "Petrovsky, N"
+                        }
                     }, 
                     {
-                        "surname": "Piazza", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Piazza", 
+                            "index": "Piazza, S"
+                        }
                     }, 
                     {
-                        "surname": "Reed", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Reed", 
+                            "index": "Reed, J"
+                        }
                     }, 
                     {
-                        "surname": "Reid", 
-                        "given-names": "JF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JF Reid", 
+                            "index": "Reid, JF"
+                        }
                     }, 
                     {
-                        "surname": "Ring", 
-                        "given-names": "BZ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BZ Ring", 
+                            "index": "Ring, BZ"
+                        }
                     }, 
                     {
-                        "surname": "Ringwald", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Ringwald", 
+                            "index": "Ringwald, M"
+                        }
                     }, 
                     {
-                        "surname": "Rost", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Rost", 
+                            "index": "Rost, B"
+                        }
                     }, 
                     {
-                        "surname": "Ruan", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ruan", 
+                            "index": "Ruan, Y"
+                        }
                     }, 
                     {
-                        "surname": "Salzberg", 
-                        "given-names": "SL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SL Salzberg", 
+                            "index": "Salzberg, SL"
+                        }
                     }, 
                     {
-                        "surname": "Sandelin", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sandelin", 
+                            "index": "Sandelin, A"
+                        }
                     }, 
                     {
-                        "surname": "Schneider", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Schneider", 
+                            "index": "Schneider, C"
+                        }
                     }, 
                     {
-                        "surname": "Sch\u00f6nbach", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Sch\u00f6nbach", 
+                            "index": "Sch\u00f6nbach, C"
+                        }
                     }, 
                     {
-                        "surname": "Sekiguchi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Sekiguchi", 
+                            "index": "Sekiguchi, K"
+                        }
                     }, 
                     {
-                        "surname": "Semple", 
-                        "given-names": "CA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CA Semple", 
+                            "index": "Semple, CA"
+                        }
                     }, 
                     {
-                        "surname": "Seno", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Seno", 
+                            "index": "Seno, S"
+                        }
                     }, 
                     {
-                        "surname": "Sessa", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Sessa", 
+                            "index": "Sessa, L"
+                        }
                     }, 
                     {
-                        "surname": "Sheng", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Sheng", 
+                            "index": "Sheng, Y"
+                        }
                     }, 
                     {
-                        "surname": "Shibata", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Shibata", 
+                            "index": "Shibata, Y"
+                        }
                     }, 
                     {
-                        "surname": "Shimada", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Shimada", 
+                            "index": "Shimada, H"
+                        }
                     }, 
                     {
-                        "surname": "Shimada", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shimada", 
+                            "index": "Shimada, K"
+                        }
                     }, 
                     {
-                        "surname": "Silva", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Silva", 
+                            "index": "Silva, D"
+                        }
                     }, 
                     {
-                        "surname": "Sinclair", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Sinclair", 
+                            "index": "Sinclair, B"
+                        }
                     }, 
                     {
-                        "surname": "Sperling", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sperling", 
+                            "index": "Sperling, S"
+                        }
                     }, 
                     {
-                        "surname": "Stupka", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Stupka", 
+                            "index": "Stupka, E"
+                        }
                     }, 
                     {
-                        "surname": "Sugiura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Sugiura", 
+                            "index": "Sugiura, K"
+                        }
                     }, 
                     {
-                        "surname": "Sultana", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Sultana", 
+                            "index": "Sultana, R"
+                        }
                     }, 
                     {
-                        "surname": "Takenaka", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Takenaka", 
+                            "index": "Takenaka, Y"
+                        }
                     }, 
                     {
-                        "surname": "Taki", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Taki", 
+                            "index": "Taki, K"
+                        }
                     }, 
                     {
-                        "surname": "Tammoja", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Tammoja", 
+                            "index": "Tammoja, K"
+                        }
                     }, 
                     {
-                        "surname": "Tan", 
-                        "given-names": "SL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SL Tan", 
+                            "index": "Tan, SL"
+                        }
                     }, 
                     {
-                        "surname": "Tang", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Tang", 
+                            "index": "Tang, S"
+                        }
                     }, 
                     {
-                        "surname": "Taylor", 
-                        "given-names": "MS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS Taylor", 
+                            "index": "Taylor, MS"
+                        }
                     }, 
                     {
-                        "surname": "Tegner", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Tegner", 
+                            "index": "Tegner, J"
+                        }
                     }, 
                     {
-                        "surname": "Teichmann", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Teichmann", 
+                            "index": "Teichmann, SA"
+                        }
                     }, 
                     {
-                        "surname": "Ueda", 
-                        "given-names": "HR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HR Ueda", 
+                            "index": "Ueda, HR"
+                        }
                     }, 
                     {
-                        "surname": "van Nimwegen", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E van Nimwegen", 
+                            "index": "van Nimwegen, E"
+                        }
                     }, 
                     {
-                        "surname": "Verardo", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Verardo", 
+                            "index": "Verardo, R"
+                        }
                     }, 
                     {
-                        "surname": "Wei", 
-                        "given-names": "CL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CL Wei", 
+                            "index": "Wei, CL"
+                        }
                     }, 
                     {
-                        "surname": "Yagi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Yagi", 
+                            "index": "Yagi, K"
+                        }
                     }, 
                     {
-                        "surname": "Yamanishi", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Yamanishi", 
+                            "index": "Yamanishi, H"
+                        }
                     }, 
                     {
-                        "surname": "Zabarovsky", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Zabarovsky", 
+                            "index": "Zabarovsky, E"
+                        }
                     }, 
                     {
-                        "surname": "Zhu", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Zhu", 
+                            "index": "Zhu, S"
+                        }
                     }, 
                     {
-                        "surname": "Zimmer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Zimmer", 
+                            "index": "Zimmer, A"
+                        }
                     }, 
                     {
-                        "surname": "Hide", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Hide", 
+                            "index": "Hide, W"
+                        }
                     }, 
                     {
-                        "surname": "Bult", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Bult", 
+                            "index": "Bult, C"
+                        }
                     }, 
                     {
-                        "surname": "Grimmond", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Grimmond", 
+                            "index": "Grimmond, SM"
+                        }
                     }, 
                     {
-                        "surname": "Teasdale", 
-                        "given-names": "RD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RD Teasdale", 
+                            "index": "Teasdale, RD"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "ET", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ET Liu", 
+                            "index": "Liu, ET"
+                        }
                     }, 
                     {
-                        "surname": "Brusic", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Brusic", 
+                            "index": "Brusic, V"
+                        }
                     }, 
                     {
-                        "surname": "Quackenbush", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Quackenbush", 
+                            "index": "Quackenbush, J"
+                        }
                     }, 
                     {
-                        "surname": "Wahlestedt", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Wahlestedt", 
+                            "index": "Wahlestedt, C"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }, 
                     {
-                        "surname": "Hume", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Hume", 
+                            "index": "Hume, DA"
+                        }
                     }, 
                     {
-                        "surname": "Kai", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Kai", 
+                            "index": "Kai, C"
+                        }
                     }, 
                     {
-                        "surname": "Sasaki", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Sasaki", 
+                            "index": "Sasaki, D"
+                        }
                     }, 
                     {
-                        "surname": "Tomaru", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Tomaru", 
+                            "index": "Tomaru, Y"
+                        }
                     }, 
                     {
-                        "surname": "Fukuda", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Fukuda", 
+                            "index": "Fukuda, S"
+                        }
                     }, 
                     {
-                        "surname": "Kanamori-Katayama", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kanamori-Katayama", 
+                            "index": "Kanamori-Katayama, M"
+                        }
                     }, 
                     {
-                        "surname": "Suzuki", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Suzuki", 
+                            "index": "Suzuki, M"
+                        }
                     }, 
                     {
-                        "surname": "Aoki", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Aoki", 
+                            "index": "Aoki, J"
+                        }
                     }, 
                     {
-                        "surname": "Arakawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Arakawa", 
+                            "index": "Arakawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Iida", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Iida", 
+                            "index": "Iida, J"
+                        }
                     }, 
                     {
-                        "surname": "Imamura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Imamura", 
+                            "index": "Imamura, K"
+                        }
                     }, 
                     {
-                        "surname": "Itoh", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Itoh", 
+                            "index": "Itoh, M"
+                        }
                     }, 
                     {
-                        "surname": "Kato", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Kato", 
+                            "index": "Kato, T"
+                        }
                     }, 
                     {
-                        "surname": "Kawaji", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kawaji", 
+                            "index": "Kawaji, H"
+                        }
                     }, 
                     {
-                        "surname": "Kawagashira", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Kawagashira", 
+                            "index": "Kawagashira, N"
+                        }
                     }, 
                     {
-                        "surname": "Kawashima", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Kawashima", 
+                            "index": "Kawashima, T"
+                        }
                     }, 
                     {
-                        "surname": "Kojima", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kojima", 
+                            "index": "Kojima, M"
+                        }
                     }, 
                     {
-                        "surname": "Kondo", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kondo", 
+                            "index": "Kondo, S"
+                        }
                     }, 
                     {
-                        "surname": "Konno", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Konno", 
+                            "index": "Konno, H"
+                        }
                     }, 
                     {
-                        "surname": "Nakano", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Nakano", 
+                            "index": "Nakano, K"
+                        }
                     }, 
                     {
-                        "surname": "Ninomiya", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Ninomiya", 
+                            "index": "Ninomiya, N"
+                        }
                     }, 
                     {
-                        "surname": "Nishio", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Nishio", 
+                            "index": "Nishio, T"
+                        }
                     }, 
                     {
-                        "surname": "Okada", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Okada", 
+                            "index": "Okada, M"
+                        }
                     }, 
                     {
-                        "surname": "Plessy", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Plessy", 
+                            "index": "Plessy, C"
+                        }
                     }, 
                     {
-                        "surname": "Shibata", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shibata", 
+                            "index": "Shibata, K"
+                        }
                     }, 
                     {
-                        "surname": "Shiraki", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Shiraki", 
+                            "index": "Shiraki, T"
+                        }
                     }, 
                     {
-                        "surname": "Suzuki", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Suzuki", 
+                            "index": "Suzuki, S"
+                        }
                     }, 
                     {
-                        "surname": "Tagami", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Tagami", 
+                            "index": "Tagami, M"
+                        }
                     }, 
                     {
-                        "surname": "Waki", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Waki", 
+                            "index": "Waki, K"
+                        }
                     }, 
                     {
-                        "surname": "Watahiki", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Watahiki", 
+                            "index": "Watahiki, A"
+                        }
                     }, 
                     {
-                        "surname": "Okamura-Oho", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Okamura-Oho", 
+                            "index": "Okamura-Oho, Y"
+                        }
                     }, 
                     {
-                        "surname": "Suzuki", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Suzuki", 
+                            "index": "Suzuki, H"
+                        }
                     }, 
                     {
-                        "surname": "Kawai", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kawai", 
+                            "index": "Kawai, J"
+                        }
                     }, 
                     {
-                        "surname": "Hayashizaki", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Hayashizaki", 
+                            "index": "Hayashizaki, Y"
+                        }
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "FANTOM Consortium"
+                        "type": "group", 
+                        "name": "FANTOM Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "Genome Network Project Core Group"
+                        "type": "group", 
+                        "name": "Genome Network Project Core Group"
                     }
                 ], 
-                "full_article_title": "The transcriptional landscape of the mammalian genome", 
-                "publication-type": "journal", 
+                "articleTitle": "The transcriptional landscape of the mammalian genome", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "309", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1112014", 
-                "fpage": "1559", 
-                "year": "2005", 
-                "position": 3, 
-                "collab": "FANTOM Consortium", 
-                "ref": "CarninciPKasukawaTKatayamaSGoughJFrithMCMaedaNCarninciPKasukawaTKatayamaSGoughJFrithMCMaedaNOyamaRRavasiTLenhardBWellsCKodziusRShimokawaKBajicVBBrennerSEBatalovSForrestARZavolanMDavisMJWilmingLGAidinisVAllenJEAmbesi-ImpiombatoAApweilerRAturaliyaRNBaileyTLBansalMBaxterLBeiselKWBersanoTBonoHChalkAMChiuKPChoudharyVChristoffelsAClutterbuckDRCroweMLDallaEDalrympleBPde BonoBDella GattaGdi BernardoDDownTEngstromPFagioliniMFaulknerGFletcherCFFukushimaTFurunoMFutakiSGariboldiMGeorgii-HemmingPGingerasTRGojoboriTGreenREGustincichSHarbersMHayashiYHenschTKHirokawaNHillDHuminieckiLIaconoMIkeoKIwamaAIshikawaTJaktMKanapinAKatohMKawasawaYKelsoJKitamuraHKitanoHKolliasGKrishnanSPKrugerAKummerfeldSKKurochkinIVLareauLFLazarevicDLipovichLLiuJLiuniSMcWilliamSMadan BabuMMaderaMMarchionniLMatsudaHMatsuzawaSMikiHMignoneFMiyakeSMorrisKMottagui-TabarSMulderNNakanoNNakauchiHNgPNilssonRNishiguchiSNishikawaSNoriFOharaOOkazakiYOrlandoVPangKCPavanWJPavesiGPesoleGPetrovskyNPiazzaSReedJReidJFRingBZRingwaldMRostBRuanYSalzbergSLSandelinASchneiderCSch\u00f6nbachCSekiguchiKSempleCASenoSSessaLShengYShibataYShimadaHShimadaKSilvaDSinclairBSperlingSStupkaESugiuraKSultanaRTakenakaYTakiKTammojaKTanSLTangSTaylorMSTegnerJTeichmannSAUedaHRvan NimwegenEVerardoRWeiCLYagiKYamanishiHZabarovskyEZhuSZimmerAHideWBultCGrimmondSMTeasdaleRDLiuETBrusicVQuackenbushJWahlestedtCMattickJSHumeDAKaiCSasakiDTomaruYFukudaSKanamori-KatayamaMSuzukiMAokiJArakawaTIidaJImamuraKItohMKatoTKawajiHKawagashiraNKawashimaTKojimaMKondoSKonnoHNakanoKNinomiyaNNishioTOkadaMPlessyCShibataKShirakiTSuzukiSTagamiMWakiKWatahikiAOkamura-OhoYSuzukiHKawaiJHayashizakiYFANTOM ConsortiumGenome Network Project Core Group2005The transcriptional landscape of the mammalian genomeScience3091559156310.1126/science.1112014", 
-                "id": "bib3"
+                "pages": {
+                    "first": "1559", 
+                    "last": "1563", 
+                    "range": "1559\u20131563"
+                }, 
+                "doi": "10.1126/science.1112014"
             }, 
             {
-                "article_title": "Transcriptional maps of 10 human chromosomes at 5-nucleotide resolution", 
-                "lpage": "1154", 
-                "doi": "10.1126/science.1108625", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib4", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Cheng", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Cheng", 
+                            "index": "Cheng, J"
+                        }
                     }, 
                     {
-                        "surname": "Kapranov", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Kapranov", 
+                            "index": "Kapranov, P"
+                        }
                     }, 
                     {
-                        "surname": "Drenkow", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Drenkow", 
+                            "index": "Drenkow, J"
+                        }
                     }, 
                     {
-                        "surname": "Dike", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Dike", 
+                            "index": "Dike, S"
+                        }
                     }, 
                     {
-                        "surname": "Brubaker", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Brubaker", 
+                            "index": "Brubaker, S"
+                        }
                     }, 
                     {
-                        "surname": "Patel", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Patel", 
+                            "index": "Patel, S"
+                        }
                     }, 
                     {
-                        "surname": "Long", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Long", 
+                            "index": "Long, J"
+                        }
                     }, 
                     {
-                        "surname": "Stern", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Stern", 
+                            "index": "Stern, D"
+                        }
                     }, 
                     {
-                        "surname": "Tammana", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Tammana", 
+                            "index": "Tammana, H"
+                        }
                     }, 
                     {
-                        "surname": "Helt", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Helt", 
+                            "index": "Helt, G"
+                        }
                     }, 
                     {
-                        "surname": "Sementchenko", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Sementchenko", 
+                            "index": "Sementchenko, V"
+                        }
                     }, 
                     {
-                        "surname": "Piccolboni", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Piccolboni", 
+                            "index": "Piccolboni, A"
+                        }
                     }, 
                     {
-                        "surname": "Bekiranov", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Bekiranov", 
+                            "index": "Bekiranov, S"
+                        }
                     }, 
                     {
-                        "surname": "Bailey", 
-                        "given-names": "DK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DK Bailey", 
+                            "index": "Bailey, DK"
+                        }
                     }, 
                     {
-                        "surname": "Ganesh", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Ganesh", 
+                            "index": "Ganesh, M"
+                        }
                     }, 
                     {
-                        "surname": "Ghosh", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Ghosh", 
+                            "index": "Ghosh, S"
+                        }
                     }, 
                     {
-                        "surname": "Bell", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Bell", 
+                            "index": "Bell, I"
+                        }
                     }, 
                     {
-                        "surname": "Gerhard", 
-                        "given-names": "DS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DS Gerhard", 
+                            "index": "Gerhard, DS"
+                        }
                     }, 
                     {
-                        "surname": "Gingeras", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Gingeras", 
+                            "index": "Gingeras, TR"
+                        }
                     }
                 ], 
-                "full_article_title": "Transcriptional maps of 10 human chromosomes at 5-nucleotide resolution", 
-                "publication-type": "journal", 
+                "articleTitle": "Transcriptional maps of 10 human chromosomes at 5-nucleotide resolution", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "308", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1108625", 
-                "fpage": "1149", 
-                "year": "2005", 
-                "position": 4, 
-                "ref": "ChengJKapranovPDrenkowJDikeSBrubakerSPatelSLongJSternDTammanaHHeltGSementchenkoVPiccolboniABekiranovSBaileyDKGaneshMGhoshSBellIGerhardDSGingerasTR2005Transcriptional maps of 10 human chromosomes at 5-nucleotide resolutionScience3081149115410.1126/science.1108625", 
-                "id": "bib4"
+                "pages": {
+                    "first": "1149", 
+                    "last": "1154", 
+                    "range": "1149\u20131154"
+                }, 
+                "doi": "10.1126/science.1108625"
             }, 
             {
-                "article_title": "The GENCODE v7 catalog of human long noncoding RNAs: analysis of their gene structure, evolution, and expression", 
-                "lpage": "1789", 
-                "doi": "10.1101/gr.132159.111", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib5", 
+                "date": "2012", 
                 "authors": [
                     {
-                        "surname": "Derrien", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Derrien", 
+                            "index": "Derrien, T"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Johnson", 
+                            "index": "Johnson, R"
+                        }
                     }, 
                     {
-                        "surname": "Bussotti", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Bussotti", 
+                            "index": "Bussotti, G"
+                        }
                     }, 
                     {
-                        "surname": "Tanzer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Tanzer", 
+                            "index": "Tanzer, A"
+                        }
                     }, 
                     {
-                        "surname": "Djebali", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Djebali", 
+                            "index": "Djebali, S"
+                        }
                     }, 
                     {
-                        "surname": "Tilgner", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Tilgner", 
+                            "index": "Tilgner, H"
+                        }
                     }, 
                     {
-                        "surname": "Guernec", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Guernec", 
+                            "index": "Guernec, G"
+                        }
                     }, 
                     {
-                        "surname": "Martin", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Martin", 
+                            "index": "Martin, D"
+                        }
                     }, 
                     {
-                        "surname": "Merkel", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Merkel", 
+                            "index": "Merkel, A"
+                        }
                     }, 
                     {
-                        "surname": "Knowles", 
-                        "given-names": "DG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DG Knowles", 
+                            "index": "Knowles, DG"
+                        }
                     }, 
                     {
-                        "surname": "Lagarde", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Lagarde", 
+                            "index": "Lagarde, J"
+                        }
                     }, 
                     {
-                        "surname": "Veeravalli", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Veeravalli", 
+                            "index": "Veeravalli, L"
+                        }
                     }, 
                     {
-                        "surname": "Ruan", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Ruan", 
+                            "index": "Ruan, X"
+                        }
                     }, 
                     {
-                        "surname": "Ruan", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ruan", 
+                            "index": "Ruan, Y"
+                        }
                     }, 
                     {
-                        "surname": "Lassmann", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Lassmann", 
+                            "index": "Lassmann, T"
+                        }
                     }, 
                     {
-                        "surname": "Carninci", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Carninci", 
+                            "index": "Carninci, P"
+                        }
                     }, 
                     {
-                        "surname": "Brown", 
-                        "given-names": "JB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JB Brown", 
+                            "index": "Brown, JB"
+                        }
                     }, 
                     {
-                        "surname": "Lipovich", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Lipovich", 
+                            "index": "Lipovich, L"
+                        }
                     }, 
                     {
-                        "surname": "Gonzalez", 
-                        "given-names": "JM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Gonzalez", 
+                            "index": "Gonzalez, JM"
+                        }
                     }, 
                     {
-                        "surname": "Thomas", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Thomas", 
+                            "index": "Thomas, M"
+                        }
                     }, 
                     {
-                        "surname": "Davis", 
-                        "given-names": "CA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CA Davis", 
+                            "index": "Davis, CA"
+                        }
                     }, 
                     {
-                        "surname": "Shiekhattar", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Shiekhattar", 
+                            "index": "Shiekhattar, R"
+                        }
                     }, 
                     {
-                        "surname": "Gingeras", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Gingeras", 
+                            "index": "Gingeras, TR"
+                        }
                     }, 
                     {
-                        "surname": "Hubbard", 
-                        "given-names": "TJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TJ Hubbard", 
+                            "index": "Hubbard, TJ"
+                        }
                     }, 
                     {
-                        "surname": "Notredame", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Notredame", 
+                            "index": "Notredame, C"
+                        }
                     }, 
                     {
-                        "surname": "Harrow", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Harrow", 
+                            "index": "Harrow, J"
+                        }
                     }, 
                     {
-                        "surname": "Guig\u00f3", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Guig\u00f3", 
+                            "index": "Guig\u00f3, R"
+                        }
                     }
                 ], 
-                "full_article_title": "The GENCODE v7 catalog of human long noncoding RNAs: analysis of their gene structure, evolution, and expression", 
-                "publication-type": "journal", 
+                "articleTitle": "The GENCODE v7 catalog of human long noncoding RNAs: analysis of their gene structure, evolution, and expression", 
+                "journal": {
+                    "name": [
+                        "Genome Research"
+                    ]
+                }, 
                 "volume": "22", 
-                "source": "Genome Research", 
-                "reference_id": "10.1101/gr.132159.111", 
-                "fpage": "1775", 
-                "year": "2012", 
-                "position": 5, 
-                "ref": "DerrienTJohnsonRBussottiGTanzerADjebaliSTilgnerHGuernecGMartinDMerkelAKnowlesDGLagardeJVeeravalliLRuanXRuanYLassmannTCarninciPBrownJBLipovichLGonzalezJMThomasMDavisCAShiekhattarRGingerasTRHubbardTJNotredameCHarrowJGuig\u00f3R2012The GENCODE v7 catalog of human long noncoding RNAs: analysis of their gene structure, evolution, and expressionGenome Research221775178910.1101/gr.132159.111", 
-                "id": "bib5"
+                "pages": {
+                    "first": "1775", 
+                    "last": "1789", 
+                    "range": "1775\u20131789"
+                }, 
+                "doi": "10.1101/gr.132159.111"
             }, 
             {
-                "article_title": "Long noncoding RNAs in mouse embryonic stem cell pluripotency and differentiation", 
-                "lpage": "1445", 
-                "doi": "10.1101/gr.078378.108", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib6", 
+                "date": "2008", 
                 "authors": [
                     {
-                        "surname": "Dinger", 
-                        "given-names": "ME", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ME Dinger", 
+                            "index": "Dinger, ME"
+                        }
                     }, 
                     {
-                        "surname": "Amaral", 
-                        "given-names": "PP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PP Amaral", 
+                            "index": "Amaral, PP"
+                        }
                     }, 
                     {
-                        "surname": "Mercer", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Mercer", 
+                            "index": "Mercer, TR"
+                        }
                     }, 
                     {
-                        "surname": "Pang", 
-                        "given-names": "KC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KC Pang", 
+                            "index": "Pang, KC"
+                        }
                     }, 
                     {
-                        "surname": "Bruce", 
-                        "given-names": "SJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SJ Bruce", 
+                            "index": "Bruce, SJ"
+                        }
                     }, 
                     {
-                        "surname": "Gardiner", 
-                        "given-names": "BB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BB Gardiner", 
+                            "index": "Gardiner, BB"
+                        }
                     }, 
                     {
-                        "surname": "Askarian-Amiri", 
-                        "given-names": "ME", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ME Askarian-Amiri", 
+                            "index": "Askarian-Amiri, ME"
+                        }
                     }, 
                     {
-                        "surname": "Ru", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Ru", 
+                            "index": "Ru, K"
+                        }
                     }, 
                     {
-                        "surname": "Sold\u00e0", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Sold\u00e0", 
+                            "index": "Sold\u00e0, G"
+                        }
                     }, 
                     {
-                        "surname": "Simons", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Simons", 
+                            "index": "Simons, C"
+                        }
                     }, 
                     {
-                        "surname": "Sunkin", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Sunkin", 
+                            "index": "Sunkin, SM"
+                        }
                     }, 
                     {
-                        "surname": "Crowe", 
-                        "given-names": "ML", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ML Crowe", 
+                            "index": "Crowe, ML"
+                        }
                     }, 
                     {
-                        "surname": "Grimmond", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Grimmond", 
+                            "index": "Grimmond, SM"
+                        }
                     }, 
                     {
-                        "surname": "Perkins", 
-                        "given-names": "AC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AC Perkins", 
+                            "index": "Perkins, AC"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Long noncoding RNAs in mouse embryonic stem cell pluripotency and differentiation", 
-                "publication-type": "journal", 
+                "articleTitle": "Long noncoding RNAs in mouse embryonic stem cell pluripotency and differentiation", 
+                "journal": {
+                    "name": [
+                        "Genome Research"
+                    ]
+                }, 
                 "volume": "18", 
-                "source": "Genome Research", 
-                "reference_id": "10.1101/gr.078378.108", 
-                "fpage": "1433", 
-                "year": "2008", 
-                "position": 6, 
-                "ref": "DingerMEAmaralPPMercerTRPangKCBruceSJGardinerBBAskarian-AmiriMERuKSold\u00e0GSimonsCSunkinSMCroweMLGrimmondSMPerkinsACMattickJS2008Long noncoding RNAs in mouse embryonic stem cell pluripotency and differentiationGenome Research181433144510.1101/gr.078378.108", 
-                "id": "bib6"
+                "pages": {
+                    "first": "1433", 
+                    "last": "1445", 
+                    "range": "1433\u20131445"
+                }, 
+                "doi": "10.1101/gr.078378.108"
             }, 
             {
-                "article_title": "Principles for the post-GWAS functional characterization of cancer risk loci", 
-                "lpage": "518", 
-                "doi": "10.1038/ng.840", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib7", 
+                "date": "2011", 
                 "authors": [
                     {
-                        "surname": "Freedman", 
-                        "given-names": "ML", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ML Freedman", 
+                            "index": "Freedman, ML"
+                        }
                     }, 
                     {
-                        "surname": "Monteiro", 
-                        "given-names": "AN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AN Monteiro", 
+                            "index": "Monteiro, AN"
+                        }
                     }, 
                     {
-                        "surname": "Gayther", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Gayther", 
+                            "index": "Gayther, SA"
+                        }
                     }, 
                     {
-                        "surname": "Coetzee", 
-                        "given-names": "GA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GA Coetzee", 
+                            "index": "Coetzee, GA"
+                        }
                     }, 
                     {
-                        "surname": "Risch", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Risch", 
+                            "index": "Risch, A"
+                        }
                     }, 
                     {
-                        "surname": "Plass", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Plass", 
+                            "index": "Plass, C"
+                        }
                     }, 
                     {
-                        "surname": "Casey", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Casey", 
+                            "index": "Casey, G"
+                        }
                     }, 
                     {
-                        "surname": "De Biasi", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M De Biasi", 
+                            "index": "De Biasi, M"
+                        }
                     }, 
                     {
-                        "surname": "Carlson", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Carlson", 
+                            "index": "Carlson, C"
+                        }
                     }, 
                     {
-                        "surname": "Duggan", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Duggan", 
+                            "index": "Duggan, D"
+                        }
                     }, 
                     {
-                        "surname": "James", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M James", 
+                            "index": "James, M"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Liu", 
+                            "index": "Liu, P"
+                        }
                     }, 
                     {
-                        "surname": "Tichelaar", 
-                        "given-names": "JW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JW Tichelaar", 
+                            "index": "Tichelaar, JW"
+                        }
                     }, 
                     {
-                        "surname": "Vikis", 
-                        "given-names": "HG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HG Vikis", 
+                            "index": "Vikis, HG"
+                        }
                     }, 
                     {
-                        "surname": "You", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M You", 
+                            "index": "You, M"
+                        }
                     }, 
                     {
-                        "surname": "Mills", 
-                        "given-names": "IG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IG Mills", 
+                            "index": "Mills, IG"
+                        }
                     }
                 ], 
-                "full_article_title": "Principles for the post-GWAS functional characterization of cancer risk loci", 
-                "publication-type": "journal", 
+                "articleTitle": "Principles for the post-GWAS functional characterization of cancer risk loci", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
                 "volume": "43", 
-                "source": "Nature Genetics", 
-                "reference_id": "10.1038/ng.840", 
-                "fpage": "513", 
-                "year": "2011", 
-                "position": 7, 
-                "ref": "FreedmanMLMonteiroANGaytherSACoetzeeGARischAPlassCCaseyGDe BiasiMCarlsonCDugganDJamesMLiuPTichelaarJWVikisHGYouMMillsIG2011Principles for the post-GWAS functional characterization of cancer risk lociNature Genetics4351351810.1038/ng.840", 
-                "id": "bib7"
+                "pages": {
+                    "first": "513", 
+                    "last": "518", 
+                    "range": "513\u2013518"
+                }, 
+                "doi": "10.1038/ng.840"
             }, 
             {
-                "article_title": "The tissue-specific lncRNA Fendrr is an essential regulator of heart and body wall development in the mouse", 
-                "lpage": "214", 
-                "doi": "10.1016/j.devcel.2012.12.012", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib8", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Grote", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Grote", 
+                            "index": "Grote, P"
+                        }
                     }, 
                     {
-                        "surname": "Wittler", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Wittler", 
+                            "index": "Wittler, L"
+                        }
                     }, 
                     {
-                        "surname": "Hendrix", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Hendrix", 
+                            "index": "Hendrix, D"
+                        }
                     }, 
                     {
-                        "surname": "Koch", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Koch", 
+                            "index": "Koch, F"
+                        }
                     }, 
                     {
-                        "surname": "Wahrisch", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Wahrisch", 
+                            "index": "Wahrisch, S"
+                        }
                     }, 
                     {
-                        "surname": "Beisaw", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Beisaw", 
+                            "index": "Beisaw, A"
+                        }
                     }, 
                     {
-                        "surname": "Macura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Macura", 
+                            "index": "Macura, K"
+                        }
                     }, 
                     {
-                        "surname": "Blass", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Blass", 
+                            "index": "Blass, G"
+                        }
                     }, 
                     {
-                        "surname": "Kellis", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kellis", 
+                            "index": "Kellis, M"
+                        }
                     }, 
                     {
-                        "surname": "Werber", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Werber", 
+                            "index": "Werber, M"
+                        }
                     }, 
                     {
-                        "surname": "Herrmann", 
-                        "given-names": "BG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BG Herrmann", 
+                            "index": "Herrmann, BG"
+                        }
                     }
                 ], 
-                "full_article_title": "The tissue-specific lncRNA Fendrr is an essential regulator of heart and body wall development in the mouse", 
-                "publication-type": "journal", 
+                "articleTitle": "The tissue-specific lncRNA Fendrr is an essential regulator of heart and body wall development in the mouse", 
+                "journal": {
+                    "name": [
+                        "Developmental Cell"
+                    ]
+                }, 
                 "volume": "24", 
-                "source": "Developmental Cell", 
-                "reference_id": "10.1016/j.devcel.2012.12.012", 
-                "fpage": "206", 
-                "year": "2013", 
-                "position": 8, 
-                "ref": "GrotePWittlerLHendrixDKochFWahrischSBeisawAMacuraKBlassGKellisMWerberMHerrmannBG2013The tissue-specific lncRNA Fendrr is an essential regulator of heart and body wall development in the mouseDevelopmental Cell2420621410.1016/j.devcel.2012.12.012", 
-                "id": "bib8"
+                "pages": {
+                    "first": "206", 
+                    "last": "214", 
+                    "range": "206\u2013214"
+                }, 
+                "doi": "10.1016/j.devcel.2012.12.012"
             }, 
             {
-                "article_title": "The noncoding RNA MALAT1 is a critical regulator of the metastasis phenotype of lung cancer cells", 
-                "lpage": "1189", 
-                "doi": "10.1158/0008-5472.CAN-12-2850", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib9", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Gutschner", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Gutschner", 
+                            "index": "Gutschner, T"
+                        }
                     }, 
                     {
-                        "surname": "Hammerle", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Hammerle", 
+                            "index": "Hammerle, M"
+                        }
                     }, 
                     {
-                        "surname": "Eissmann", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Eissmann", 
+                            "index": "Eissmann, M"
+                        }
                     }, 
                     {
-                        "surname": "Hsu", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hsu", 
+                            "index": "Hsu, J"
+                        }
                     }, 
                     {
-                        "surname": "Kim", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Kim", 
+                            "index": "Kim, Y"
+                        }
                     }, 
                     {
-                        "surname": "Hung", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Hung", 
+                            "index": "Hung, G"
+                        }
                     }, 
                     {
-                        "surname": "Revenko", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Revenko", 
+                            "index": "Revenko, A"
+                        }
                     }, 
                     {
-                        "surname": "Arun", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Arun", 
+                            "index": "Arun, G"
+                        }
                     }, 
                     {
-                        "surname": "Stentrup", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Stentrup", 
+                            "index": "Stentrup, M"
+                        }
                     }, 
                     {
-                        "surname": "Gross", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Gross", 
+                            "index": "Gross, M"
+                        }
                     }, 
                     {
-                        "surname": "Z\u00f6rnig", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Z\u00f6rnig", 
+                            "index": "Z\u00f6rnig, M"
+                        }
                     }, 
                     {
-                        "surname": "MacLeod", 
-                        "given-names": "AR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AR MacLeod", 
+                            "index": "MacLeod, AR"
+                        }
                     }, 
                     {
-                        "surname": "Spector", 
-                        "given-names": "DL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DL Spector", 
+                            "index": "Spector, DL"
+                        }
                     }, 
                     {
-                        "surname": "Diederichs", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Diederichs", 
+                            "index": "Diederichs, S"
+                        }
                     }
                 ], 
-                "full_article_title": "The noncoding RNA MALAT1 is a critical regulator of the metastasis phenotype of lung cancer cells", 
-                "publication-type": "journal", 
+                "articleTitle": "The noncoding RNA MALAT1 is a critical regulator of the metastasis phenotype of lung cancer cells", 
+                "journal": {
+                    "name": [
+                        "Cancer Research"
+                    ]
+                }, 
                 "volume": "73", 
-                "source": "Cancer Research", 
-                "reference_id": "10.1158/0008-5472.CAN-12-2850", 
-                "fpage": "1180", 
-                "year": "2013", 
-                "position": 9, 
-                "ref": "GutschnerTHammerleMEissmannMHsuJKimYHungGRevenkoAArunGStentrupMGrossMZ\u00f6rnigMMacLeodARSpectorDLDiederichsS2013The noncoding RNA MALAT1 is a critical regulator of the metastasis phenotype of lung cancer cellsCancer Research731180118910.1158/0008-5472.CAN-12-2850", 
-                "id": "bib9"
+                "pages": {
+                    "first": "1180", 
+                    "last": "1189", 
+                    "range": "1180\u20131189"
+                }, 
+                "doi": "10.1158/0008-5472.CAN-12-2850"
             }, 
             {
-                "article_title": "Role of a neuronal small non-messenger RNA: behavioural alterations in BC1 RNA-deleted mice", 
-                "lpage": "289", 
-                "doi": "10.1016/j.bbr.2004.02.015", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib10", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Lewejohann", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Lewejohann", 
+                            "index": "Lewejohann, L"
+                        }
                     }, 
                     {
-                        "surname": "Skryabin", 
-                        "given-names": "BV", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BV Skryabin", 
+                            "index": "Skryabin, BV"
+                        }
                     }, 
                     {
-                        "surname": "Sachser", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Sachser", 
+                            "index": "Sachser, N"
+                        }
                     }, 
                     {
-                        "surname": "Prehn", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Prehn", 
+                            "index": "Prehn, C"
+                        }
                     }, 
                     {
-                        "surname": "Heiduschka", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Heiduschka", 
+                            "index": "Heiduschka, P"
+                        }
                     }, 
                     {
-                        "surname": "Thanos", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Thanos", 
+                            "index": "Thanos, S"
+                        }
                     }, 
                     {
-                        "surname": "Jordan", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Jordan", 
+                            "index": "Jordan, U"
+                        }
                     }, 
                     {
-                        "surname": "Dell\u2019Omo", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Dell\u2019Omo", 
+                            "index": "Dell\u2019Omo, G"
+                        }
                     }, 
                     {
-                        "surname": "Vyssotski", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Vyssotski", 
+                            "index": "Vyssotski, AL"
+                        }
                     }, 
                     {
-                        "surname": "Pleskacheva", 
-                        "given-names": "MG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MG Pleskacheva", 
+                            "index": "Pleskacheva, MG"
+                        }
                     }, 
                     {
-                        "surname": "Lipp", 
-                        "given-names": "HP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HP Lipp", 
+                            "index": "Lipp, HP"
+                        }
                     }, 
                     {
-                        "surname": "Tiedge", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Tiedge", 
+                            "index": "Tiedge, H"
+                        }
                     }, 
                     {
-                        "surname": "Brosius", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Brosius", 
+                            "index": "Brosius, J"
+                        }
                     }, 
                     {
-                        "surname": "Prior", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Prior", 
+                            "index": "Prior, H"
+                        }
                     }
                 ], 
-                "full_article_title": "Role of a neuronal small non-messenger RNA: behavioural alterations in BC1 RNA-deleted mice", 
-                "publication-type": "journal", 
+                "articleTitle": "Role of a neuronal small non-messenger RNA: behavioural alterations in BC1 RNA-deleted mice", 
+                "journal": {
+                    "name": [
+                        "Behavioural Brain Research"
+                    ]
+                }, 
                 "volume": "154", 
-                "source": "Behavioural Brain Research", 
-                "reference_id": "10.1016/j.bbr.2004.02.015", 
-                "fpage": "273", 
-                "year": "2004", 
-                "position": 10, 
-                "ref": "LewejohannLSkryabinBVSachserNPrehnCHeiduschkaPThanosSJordanUDell\u2019OmoGVyssotskiALPleskachevaMGLippHPTiedgeHBrosiusJPriorH2004Role of a neuronal small non-messenger RNA: behavioural alterations in BC1 RNA-deleted miceBehavioural Brain Research15427328910.1016/j.bbr.2004.02.015", 
-                "id": "bib10"
+                "pages": {
+                    "first": "273", 
+                    "last": "289", 
+                    "range": "273\u2013289"
+                }, 
+                "doi": "10.1016/j.bbr.2004.02.015"
             }, 
             {
-                "article_title": "Targeted disruption of Hotair leads to homeotic transformation and gene derepression", 
-                "lpage": "12", 
-                "doi": "10.1016/j.celrep.2013.09.003", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib11", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Li", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Li", 
+                            "index": "Li, L"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Liu", 
+                            "index": "Liu, B"
+                        }
                     }, 
                     {
-                        "surname": "Wapinski", 
-                        "given-names": "OL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "OL Wapinski", 
+                            "index": "Wapinski, OL"
+                        }
                     }, 
                     {
-                        "surname": "Tsai", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Tsai", 
+                            "index": "Tsai, MC"
+                        }
                     }, 
                     {
-                        "surname": "Qu", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Qu", 
+                            "index": "Qu, K"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Zhang", 
+                            "index": "Zhang, J"
+                        }
                     }, 
                     {
-                        "surname": "Carlson", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Carlson", 
+                            "index": "Carlson, JC"
+                        }
                     }, 
                     {
-                        "surname": "Lin", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Lin", 
+                            "index": "Lin, M"
+                        }
                     }, 
                     {
-                        "surname": "Fang", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Fang", 
+                            "index": "Fang, F"
+                        }
                     }, 
                     {
-                        "surname": "Gupta", 
-                        "given-names": "RA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Gupta", 
+                            "index": "Gupta, RA"
+                        }
                     }, 
                     {
-                        "surname": "Helms", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Helms", 
+                            "index": "Helms, JA"
+                        }
                     }, 
                     {
-                        "surname": "Chang", 
-                        "given-names": "HY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HY Chang", 
+                            "index": "Chang, HY"
+                        }
                     }
                 ], 
-                "full_article_title": "Targeted disruption of Hotair leads to homeotic transformation and gene derepression", 
-                "publication-type": "journal", 
+                "articleTitle": "Targeted disruption of Hotair leads to homeotic transformation and gene derepression", 
+                "journal": {
+                    "name": [
+                        "Cell Reports"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "Cell Reports", 
-                "reference_id": "10.1016/j.celrep.2013.09.003", 
-                "fpage": "3", 
-                "year": "2013", 
-                "position": 11, 
-                "ref": "LiLLiuBWapinskiOLTsaiMCQuKZhangJCarlsonJCLinMFangFGuptaRAHelmsJAChangHY2013Targeted disruption of Hotair leads to homeotic transformation and gene derepressionCell Reports531210.1016/j.celrep.2013.09.003", 
-                "id": "bib11"
+                "pages": {
+                    "first": "3", 
+                    "last": "12", 
+                    "range": "3\u201312"
+                }, 
+                "doi": "10.1016/j.celrep.2013.09.003"
             }, 
             {
-                "article_title": "A meta-analysis of the genomic and transcriptomic composition of complex life", 
-                "lpage": "2072", 
-                "doi": "10.4161/cc.25134", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib12", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Liu", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Liu", 
+                            "index": "Liu, G"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }, 
                     {
-                        "surname": "Taft", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Taft", 
+                            "index": "Taft, RJ"
+                        }
                     }
                 ], 
-                "full_article_title": "A meta-analysis of the genomic and transcriptomic composition of complex life", 
-                "publication-type": "journal", 
+                "articleTitle": "A meta-analysis of the genomic and transcriptomic composition of complex life", 
+                "journal": {
+                    "name": [
+                        "Cell Cycle"
+                    ]
+                }, 
                 "volume": "12", 
-                "source": "Cell Cycle", 
-                "reference_id": "10.4161/cc.25134", 
-                "fpage": "2061", 
-                "year": "2013", 
-                "position": 12, 
-                "ref": "LiuGMattickJSTaftRJ2013A meta-analysis of the genomic and transcriptomic composition of complex lifeCell Cycle122061207210.4161/cc.25134", 
-                "id": "bib12"
+                "pages": {
+                    "first": "2061", 
+                    "last": "2072", 
+                    "range": "2061\u20132072"
+                }, 
+                "doi": "10.4161/cc.25134"
             }, 
             {
-                "publisher_loc": "Sunderland, MA", 
-                "article_doi": "10.7554/eLife.01968", 
-                "publisher_name": "Sinauer Associates", 
-                "year": "2007", 
-                "publication-type": "book", 
-                "source": "The origins of genome architecture", 
+                "type": "book", 
+                "id": "bib13", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Lynch", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Lynch", 
+                            "index": "Lynch, M"
+                        }
                     }
                 ], 
-                "position": 13, 
-                "ref": "LynchM2007The origins of genome architectureSunderland, MASinauer Associates", 
-                "id": "bib13"
+                "bookTitle": "The origins of genome architecture", 
+                "publisher": {
+                    "name": [
+                        "Sinauer Associates"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Sunderland, MA"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Sunderland, MA"
+                            ]
+                        }
+                    }
+                }
             }, 
             {
-                "article_title": "Introns: evolution and function", 
-                "lpage": "831", 
-                "doi": "10.1016/0959-437X(94)90066-3", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib14", 
+                "date": "1994", 
                 "authors": [
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Introns: evolution and function", 
-                "publication-type": "journal", 
+                "articleTitle": "Introns: evolution and function", 
+                "journal": {
+                    "name": [
+                        "Current Opinion in Genetics & Development"
+                    ]
+                }, 
                 "volume": "4", 
-                "source": "Current Opinion in Genetics & Development", 
-                "reference_id": "10.1016/0959-437X(94)90066-3", 
-                "fpage": "823", 
-                "year": "1994", 
-                "position": 14, 
-                "ref": "MattickJS1994Introns: evolution and functionCurrent Opinion in Genetics & Development482383110.1016/0959-437X(94)90066-3", 
-                "id": "bib14"
+                "pages": {
+                    "first": "823", 
+                    "last": "831", 
+                    "range": "823\u2013831"
+                }, 
+                "doi": "10.1016/0959-437X(94)90066-3"
             }, 
             {
-                "article_title": "The genetic signatures of noncoding RNAs", 
-                "doi": "10.1371/journal.pgen.1000459", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib15", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "The genetic signatures of noncoding RNAs", 
-                "publication-type": "journal", 
+                "articleTitle": "The genetic signatures of noncoding RNAs", 
+                "journal": {
+                    "name": [
+                        "PLOS Genetics"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "PLOS Genetics", 
-                "reference_id": "10.1371/journal.pgen.1000459", 
-                "fpage": "e1000459", 
-                "year": "2009", 
-                "position": 15, 
-                "ref": "MattickJS2009The genetic signatures of noncoding RNAsPLOS Genetics5e100045910.1371/journal.pgen.1000459", 
-                "id": "bib15"
+                "pages": "e1000459", 
+                "doi": "10.1371/journal.pgen.1000459"
             }, 
             {
-                "article_title": "Specific expression of long noncoding RNAs in the mouse brain", 
-                "lpage": "721", 
-                "doi": "10.1073/pnas.0706729105", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib16", 
+                "date": "2008", 
                 "authors": [
                     {
-                        "surname": "Mercer", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Mercer", 
+                            "index": "Mercer, TR"
+                        }
                     }, 
                     {
-                        "surname": "Dinger", 
-                        "given-names": "ME", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ME Dinger", 
+                            "index": "Dinger, ME"
+                        }
                     }, 
                     {
-                        "surname": "Sunkin", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Sunkin", 
+                            "index": "Sunkin, SM"
+                        }
                     }, 
                     {
-                        "surname": "Mehler", 
-                        "given-names": "MF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MF Mehler", 
+                            "index": "Mehler, MF"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Specific expression of long noncoding RNAs in the mouse brain", 
-                "publication-type": "journal", 
+                "articleTitle": "Specific expression of long noncoding RNAs in the mouse brain", 
+                "journal": {
+                    "name": [
+                        "Proceedings of the National Academy of Sciences of the United States of America"
+                    ]
+                }, 
                 "volume": "105", 
-                "source": "Proceedings of the National Academy of Sciences of the United States of America", 
-                "reference_id": "10.1073/pnas.0706729105", 
-                "fpage": "716", 
-                "year": "2008", 
-                "position": 16, 
-                "ref": "MercerTRDingerMESunkinSMMehlerMFMattickJS2008Specific expression of long noncoding RNAs in the mouse brainProceedings of the National Academy of Sciences of the United States of America10571672110.1073/pnas.0706729105", 
-                "id": "bib16"
+                "pages": {
+                    "first": "716", 
+                    "last": "721", 
+                    "range": "716\u2013721"
+                }, 
+                "doi": "10.1073/pnas.0706729105"
             }, 
             {
-                "article_title": "Targeted RNA sequencing reveals the deep complexity of the human transcriptome", 
-                "lpage": "104", 
-                "doi": "10.1038/nbt.2024", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib17", 
+                "date": "2012", 
                 "authors": [
                     {
-                        "surname": "Mercer", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Mercer", 
+                            "index": "Mercer, TR"
+                        }
                     }, 
                     {
-                        "surname": "Gerhardt", 
-                        "given-names": "DJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ Gerhardt", 
+                            "index": "Gerhardt, DJ"
+                        }
                     }, 
                     {
-                        "surname": "Dinger", 
-                        "given-names": "ME", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ME Dinger", 
+                            "index": "Dinger, ME"
+                        }
                     }, 
                     {
-                        "surname": "Crawford", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Crawford", 
+                            "index": "Crawford, J"
+                        }
                     }, 
                     {
-                        "surname": "Trapnell", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Trapnell", 
+                            "index": "Trapnell, C"
+                        }
                     }, 
                     {
-                        "surname": "Jeddeloh", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Jeddeloh", 
+                            "index": "Jeddeloh, JA"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }, 
                     {
-                        "surname": "Rinn", 
-                        "given-names": "JL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Rinn", 
+                            "index": "Rinn, JL"
+                        }
                     }
                 ], 
-                "full_article_title": "Targeted RNA sequencing reveals the deep complexity of the human transcriptome", 
-                "publication-type": "journal", 
+                "articleTitle": "Targeted RNA sequencing reveals the deep complexity of the human transcriptome", 
+                "journal": {
+                    "name": [
+                        "Nature Biotechnology"
+                    ]
+                }, 
                 "volume": "30", 
-                "source": "Nature Biotechnology", 
-                "reference_id": "10.1038/nbt.2024", 
-                "fpage": "99", 
-                "year": "2012", 
-                "position": 17, 
-                "ref": "MercerTRGerhardtDJDingerMECrawfordJTrapnellCJeddelohJAMattickJSRinnJL2012Targeted RNA sequencing reveals the deep complexity of the human transcriptomeNature Biotechnology309910410.1038/nbt.2024", 
-                "id": "bib17"
+                "pages": {
+                    "first": "99", 
+                    "last": "104", 
+                    "range": "99\u2013104"
+                }, 
+                "doi": "10.1038/nbt.2024"
             }, 
             {
-                "article_title": "Structure and function of long noncoding RNAs in epigenetic regulation", 
-                "lpage": "307", 
-                "doi": "10.1038/nsmb.2480", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib18", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Mercer", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Mercer", 
+                            "index": "Mercer, TR"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Structure and function of long noncoding RNAs in epigenetic regulation", 
-                "publication-type": "journal", 
+                "articleTitle": "Structure and function of long noncoding RNAs in epigenetic regulation", 
+                "journal": {
+                    "name": [
+                        "Nature Structural and Molecular Biology"
+                    ]
+                }, 
                 "volume": "20", 
-                "source": "Nature Structural and Molecular Biology", 
-                "reference_id": "10.1038/nsmb.2480", 
-                "fpage": "300", 
-                "year": "2013", 
-                "position": 18, 
-                "ref": "MercerTRMattickJS2013Structure and function of long noncoding RNAs in epigenetic regulationNature Structural and Molecular Biology2030030710.1038/nsmb.2480", 
-                "id": "bib18"
+                "pages": {
+                    "first": "300", 
+                    "last": "307", 
+                    "range": "300\u2013307"
+                }, 
+                "doi": "10.1038/nsmb.2480"
             }, 
             {
-                "article_title": "Paraspeckles are subpopulation-specific nuclear bodies that are not essential in mice", 
-                "lpage": "39", 
-                "doi": "10.1083/jcb.201011110", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib19", 
+                "date": "2011", 
                 "authors": [
                     {
-                        "surname": "Nakagawa", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nakagawa", 
+                            "index": "Nakagawa, S"
+                        }
                     }, 
                     {
-                        "surname": "Naganuma", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Naganuma", 
+                            "index": "Naganuma, T"
+                        }
                     }, 
                     {
-                        "surname": "Shioi", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Shioi", 
+                            "index": "Shioi, G"
+                        }
                     }, 
                     {
-                        "surname": "Hirose", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirose", 
+                            "index": "Hirose, T"
+                        }
                     }
                 ], 
-                "full_article_title": "Paraspeckles are subpopulation-specific nuclear bodies that are not essential in mice", 
-                "publication-type": "journal", 
+                "articleTitle": "Paraspeckles are subpopulation-specific nuclear bodies that are not essential in mice", 
+                "journal": {
+                    "name": [
+                        "Journal of Cell Biology"
+                    ]
+                }, 
                 "volume": "193", 
-                "source": "Journal of Cell Biology", 
-                "reference_id": "10.1083/jcb.201011110", 
-                "fpage": "31", 
-                "year": "2011", 
-                "position": 19, 
-                "ref": "NakagawaSNaganumaTShioiGHiroseT2011Paraspeckles are subpopulation-specific nuclear bodies that are not essential in miceJournal of Cell Biology193313910.1083/jcb.201011110", 
-                "id": "bib19"
+                "pages": {
+                    "first": "31", 
+                    "last": "39", 
+                    "range": "31\u201339"
+                }, 
+                "doi": "10.1083/jcb.201011110"
             }, 
             {
-                "article_title": "Raising the estimate of functional human sequences", 
-                "lpage": "1253", 
-                "doi": "10.1101/gr.6406307", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib20", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Pheasant", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pheasant", 
+                            "index": "Pheasant, M"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Raising the estimate of functional human sequences", 
-                "publication-type": "journal", 
+                "articleTitle": "Raising the estimate of functional human sequences", 
+                "journal": {
+                    "name": [
+                        "Genome Research"
+                    ]
+                }, 
                 "volume": "17", 
-                "source": "Genome Research", 
-                "reference_id": "10.1101/gr.6406307", 
-                "fpage": "1245", 
-                "year": "2007", 
-                "position": 20, 
-                "ref": "PheasantMMattickJS2007Raising the estimate of functional human sequencesGenome Research171245125310.1101/gr.6406307", 
-                "id": "bib20"
+                "pages": {
+                    "first": "1245", 
+                    "last": "1253", 
+                    "range": "1245\u20131253"
+                }, 
+                "doi": "10.1101/gr.6406307"
             }, 
             {
-                "article_title": "A mammalian pseudogene lncRNA at the interface of inflammation and anti-inflammatory therapeutics", 
-                "doi": "10.7554/eLife.00762", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib21", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Rapicavoli", 
-                        "given-names": "NA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NA Rapicavoli", 
+                            "index": "Rapicavoli, NA"
+                        }
                     }, 
                     {
-                        "surname": "Qu", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Qu", 
+                            "index": "Qu, K"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Zhang", 
+                            "index": "Zhang, J"
+                        }
                     }, 
                     {
-                        "surname": "Mikhail", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Mikhail", 
+                            "index": "Mikhail, M"
+                        }
                     }, 
                     {
-                        "surname": "Laberge", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Laberge", 
+                            "index": "Laberge, RM"
+                        }
                     }, 
                     {
-                        "surname": "Chang", 
-                        "given-names": "HY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HY Chang", 
+                            "index": "Chang, HY"
+                        }
                     }
                 ], 
-                "full_article_title": "A mammalian pseudogene lncRNA at the interface of inflammation and anti-inflammatory therapeutics", 
-                "publication-type": "journal", 
+                "articleTitle": "A mammalian pseudogene lncRNA at the interface of inflammation and anti-inflammatory therapeutics", 
+                "journal": {
+                    "name": [
+                        "eLife"
+                    ]
+                }, 
                 "volume": "2", 
-                "source": "eLife", 
-                "reference_id": "10.7554/eLife.00762", 
-                "fpage": "e00762", 
-                "year": "2013", 
-                "position": 21, 
-                "ref": "RapicavoliNAQuKZhangJMikhailMLabergeRMChangHY2013A mammalian pseudogene lncRNA at the interface of inflammation and anti-inflammatory therapeuticseLife2e0076210.7554/eLife.00762", 
-                "id": "bib21"
+                "pages": "e00762", 
+                "doi": "10.7554/eLife.00762"
             }, 
             {
-                "article_title": "Multiple knockout mouse models reveal lincRNAs are required for life and brain development", 
-                "doi": "10.7554/eLife.01749", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib22", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Sauvageau", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sauvageau", 
+                            "index": "Sauvageau, M"
+                        }
                     }, 
                     {
-                        "surname": "Goff", 
-                        "given-names": "LA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LA Goff", 
+                            "index": "Goff, LA"
+                        }
                     }, 
                     {
-                        "surname": "Lodato", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Lodato", 
+                            "index": "Lodato, S"
+                        }
                     }, 
                     {
-                        "surname": "Bonev", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Bonev", 
+                            "index": "Bonev, B"
+                        }
                     }, 
                     {
-                        "surname": "Groff", 
-                        "given-names": "AF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AF Groff", 
+                            "index": "Groff, AF"
+                        }
                     }, 
                     {
-                        "surname": "Gerhardinger", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Gerhardinger", 
+                            "index": "Gerhardinger, C"
+                        }
                     }, 
                     {
-                        "surname": "Sanchez-Gomez", 
-                        "given-names": "DB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DB Sanchez-Gomez", 
+                            "index": "Sanchez-Gomez, DB"
+                        }
                     }, 
                     {
-                        "surname": "Hacisuleyman", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Hacisuleyman", 
+                            "index": "Hacisuleyman, E"
+                        }
                     }, 
                     {
-                        "surname": "Li", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Li", 
+                            "index": "Li, E"
+                        }
                     }, 
                     {
-                        "surname": "Spence", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Spence", 
+                            "index": "Spence, M"
+                        }
                     }, 
                     {
-                        "surname": "Liapis", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Liapis", 
+                            "index": "Liapis, SC"
+                        }
                     }, 
                     {
-                        "surname": "Mallard", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Mallard", 
+                            "index": "Mallard, W"
+                        }
                     }, 
                     {
-                        "surname": "Morse", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Morse", 
+                            "index": "Morse, M"
+                        }
                     }, 
                     {
-                        "surname": "Swerdel", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Swerdel", 
+                            "index": "Swerdel, MR"
+                        }
                     }, 
                     {
-                        "surname": "D'Ecclessis", 
-                        "given-names": "MF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MF D'Ecclessis", 
+                            "index": "D'Ecclessis, MF"
+                        }
                     }, 
                     {
-                        "surname": "Moore", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Moore", 
+                            "index": "Moore, JC"
+                        }
                     }, 
                     {
-                        "surname": "Lai", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Lai", 
+                            "index": "Lai, V"
+                        }
                     }, 
                     {
-                        "surname": "Gong", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Gong", 
+                            "index": "Gong, G"
+                        }
                     }, 
                     {
-                        "surname": "Yancopoulos", 
-                        "given-names": "GD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GD Yancopoulos", 
+                            "index": "Yancopoulos, GD"
+                        }
                     }, 
                     {
-                        "surname": "Frendewey", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Frendewey", 
+                            "index": "Frendewey, D"
+                        }
                     }, 
                     {
-                        "surname": "Kellis", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kellis", 
+                            "index": "Kellis, M"
+                        }
                     }, 
                     {
-                        "surname": "Hart", 
-                        "given-names": "RP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RP Hart", 
+                            "index": "Hart, RP"
+                        }
                     }, 
                     {
-                        "surname": "Valenzuela", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Valenzuela", 
+                            "index": "Valenzuela, DM"
+                        }
                     }, 
                     {
-                        "surname": "Arlotta", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Arlotta", 
+                            "index": "Arlotta, P"
+                        }
                     }, 
                     {
-                        "surname": "Rinn", 
-                        "given-names": "JL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Rinn", 
+                            "index": "Rinn, JL"
+                        }
                     }
                 ], 
-                "full_article_title": "Multiple knockout mouse models reveal lincRNAs are required for life and brain development", 
-                "publication-type": "journal", 
+                "articleTitle": "Multiple knockout mouse models reveal lincRNAs are required for life and brain development", 
+                "journal": {
+                    "name": [
+                        "eLife"
+                    ]
+                }, 
                 "volume": "2", 
-                "source": "eLife", 
-                "reference_id": "10.7554/eLife.01749", 
-                "fpage": "01749", 
-                "year": "2013", 
-                "position": 22, 
-                "ref": "SauvageauMGoffLALodatoSBonevBGroffAFGerhardingerCSanchez-GomezDBHacisuleymanELiESpenceMLiapisSCMallardWMorseMSwerdelMRD'EcclessisMFMooreJCLaiVGongGYancopoulosGDFrendeweyDKellisMHartRPValenzuelaDMArlottaPRinnJL2013Multiple knockout mouse models reveal lincRNAs are required for life and brain developmenteLife20174910.7554/eLife.01749", 
-                "id": "bib22"
+                "pages": "01749", 
+                "doi": "10.7554/eLife.01749"
             }, 
             {
-                "article_title": "Widespread purifying selection on RNA structure in mammals", 
-                "lpage": "8236", 
-                "doi": "10.1093/nar/gkt596", 
-                "article_doi": "10.7554/eLife.01968", 
+                "type": "journal", 
+                "id": "bib23", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Smith", 
-                        "given-names": "MA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Smith", 
+                            "index": "Smith, MA"
+                        }
                     }, 
                     {
-                        "surname": "Gesell", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Gesell", 
+                            "index": "Gesell, T"
+                        }
                     }, 
                     {
-                        "surname": "Stadler", 
-                        "given-names": "PF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PF Stadler", 
+                            "index": "Stadler, PF"
+                        }
                     }, 
                     {
-                        "surname": "Mattick", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Mattick", 
+                            "index": "Mattick, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Widespread purifying selection on RNA structure in mammals", 
-                "publication-type": "journal", 
+                "articleTitle": "Widespread purifying selection on RNA structure in mammals", 
+                "journal": {
+                    "name": [
+                        "Nucleic Acids Research"
+                    ]
+                }, 
                 "volume": "41", 
-                "source": "Nucleic Acids Research", 
-                "reference_id": "10.1093/nar/gkt596", 
-                "fpage": "8220", 
-                "year": "2013", 
-                "position": 23, 
-                "ref": "SmithMAGesellTStadlerPFMattickJS2013Widespread purifying selection on RNA structure in mammalsNucleic Acids Research418220823610.1093/nar/gkt596", 
-                "id": "bib23"
+                "pages": {
+                    "first": "8220", 
+                    "last": "8236", 
+                    "range": "8220\u20138236"
+                }, 
+                "doi": "10.1093/nar/gkt596"
             }
         ], 
         "impactStatement": "Genetic knockout experiments on mice confirm that some long noncoding RNA molecules have developmental functions."

--- a/src/publisher/tests/fixtures/ajson/elife-16695-v2.xml.json
+++ b/src/publisher/tests/fixtures/ajson/elife-16695-v2.xml.json
@@ -1613,4362 +1613,5821 @@
         ], 
         "references": [
             {
-                "article_title": "Individual differences in the amount and timing of salivary melatonin secretion", 
-                "doi": "10.1371/journal.pone.0003055", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e3055", 
+                "type": "journal", 
+                "id": "bib1", 
+                "date": "2008", 
                 "authors": [
                     {
-                        "surname": "Burgess", 
-                        "given-names": "HJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HJ Burgess", 
+                            "index": "Burgess, HJ"
+                        }
                     }, 
                     {
-                        "surname": "Fogg", 
-                        "given-names": "LF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LF Fogg", 
+                            "index": "Fogg, LF"
+                        }
                     }
                 ], 
-                "full_article_title": "Individual differences in the amount and timing of salivary melatonin secretion", 
-                "publication-type": "journal", 
+                "articleTitle": "Individual differences in the amount and timing of salivary melatonin secretion", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "3", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0003055", 
-                "year": "2008", 
-                "position": 1, 
-                "ref": "BurgessHJFoggLF2008Individual differences in the amount and timing of salivary melatonin secretionPLoS One3e305510.1371/journal.pone.0003055", 
-                "id": "bib1"
+                "pages": "e3055", 
+                "doi": "10.1371/journal.pone.0003055"
             }, 
             {
-                "article_title": "SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteins", 
-                "lpage": "904", 
-                "doi": "10.1126/science.1141194", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib2", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Busino", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Busino", 
+                            "index": "Busino, L"
+                        }
                     }, 
                     {
-                        "surname": "Bassermann", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Bassermann", 
+                            "index": "Bassermann, F"
+                        }
                     }, 
                     {
-                        "surname": "Maiolica", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Maiolica", 
+                            "index": "Maiolica, A"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lee", 
+                            "index": "Lee, C"
+                        }
                     }, 
                     {
-                        "surname": "Nolan", 
-                        "given-names": "PM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PM Nolan", 
+                            "index": "Nolan, PM"
+                        }
                     }, 
                     {
-                        "surname": "Godinho", 
-                        "given-names": "SI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SI Godinho", 
+                            "index": "Godinho, SI"
+                        }
                     }, 
                     {
-                        "surname": "Draetta", 
-                        "given-names": "GF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GF Draetta", 
+                            "index": "Draetta, GF"
+                        }
                     }, 
                     {
-                        "surname": "Pagano", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pagano", 
+                            "index": "Pagano, M"
+                        }
                     }
                 ], 
-                "full_article_title": "SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteins", 
-                "publication-type": "journal", 
+                "articleTitle": "SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteins", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "316", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1141194", 
-                "fpage": "900", 
-                "year": "2007", 
-                "position": 2, 
-                "ref": "BusinoLBassermannFMaiolicaALeeCNolanPMGodinhoSIDraettaGFPaganoM2007SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteinsScience31690090410.1126/science.1141194", 
-                "id": "bib2"
+                "pages": {
+                    "first": "900", 
+                    "last": "904", 
+                    "range": "900\u2013904"
+                }, 
+                "doi": "10.1126/science.1141194"
             }, 
             {
-                "article_title": "Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian function", 
-                "lpage": "1405", 
-                "doi": "10.1016/j.cell.2013.05.011", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib3", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Czarna", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Czarna", 
+                            "index": "Czarna, A"
+                        }
                     }, 
                     {
-                        "surname": "Berndt", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Berndt", 
+                            "index": "Berndt, A"
+                        }
                     }, 
                     {
-                        "surname": "Singh", 
-                        "given-names": "HR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HR Singh", 
+                            "index": "Singh, HR"
+                        }
                     }, 
                     {
-                        "surname": "Grudziecki", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Grudziecki", 
+                            "index": "Grudziecki, A"
+                        }
                     }, 
                     {
-                        "surname": "Ladurner", 
-                        "given-names": "AG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AG Ladurner", 
+                            "index": "Ladurner, AG"
+                        }
                     }, 
                     {
-                        "surname": "Timinszky", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Timinszky", 
+                            "index": "Timinszky, G"
+                        }
                     }, 
                     {
-                        "surname": "Kramer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kramer", 
+                            "index": "Kramer, A"
+                        }
                     }, 
                     {
-                        "surname": "Wolf", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Wolf", 
+                            "index": "Wolf, E"
+                        }
                     }
                 ], 
-                "full_article_title": "Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian function", 
-                "publication-type": "journal", 
+                "articleTitle": "Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian function", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "153", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2013.05.011", 
-                "fpage": "1394", 
-                "year": "2013", 
-                "position": 3, 
-                "ref": "CzarnaABerndtASinghHRGrudzieckiALadurnerAGTiminszkyGKramerAWolfE2013Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian functionCell1531394140510.1016/j.cell.2013.05.011", 
-                "id": "bib3"
+                "pages": {
+                    "first": "1394", 
+                    "last": "1405", 
+                    "range": "1394\u20131405"
+                }, 
+                "doi": "10.1016/j.cell.2013.05.011"
             }, 
             {
-                "article_title": "New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes risk", 
-                "lpage": "116", 
-                "doi": "10.1038/ng.520", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib4", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Dupuis", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Dupuis", 
+                            "index": "Dupuis, J"
+                        }
                     }, 
                     {
-                        "surname": "Langenberg", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Langenberg", 
+                            "index": "Langenberg, C"
+                        }
                     }, 
                     {
-                        "surname": "Prokopenko", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Prokopenko", 
+                            "index": "Prokopenko, I"
+                        }
                     }, 
                     {
-                        "surname": "Saxena", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Saxena", 
+                            "index": "Saxena, R"
+                        }
                     }, 
                     {
-                        "surname": "Soranzo", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Soranzo", 
+                            "index": "Soranzo, N"
+                        }
                     }, 
                     {
-                        "surname": "Jackson", 
-                        "given-names": "AU", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AU Jackson", 
+                            "index": "Jackson, AU"
+                        }
                     }, 
                     {
-                        "surname": "Wheeler", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Wheeler", 
+                            "index": "Wheeler, E"
+                        }
                     }, 
                     {
-                        "surname": "Glazer", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Glazer", 
+                            "index": "Glazer, NL"
+                        }
                     }, 
                     {
-                        "surname": "Bouatia-Naji", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Bouatia-Naji", 
+                            "index": "Bouatia-Naji, N"
+                        }
                     }, 
                     {
-                        "surname": "Gloyn", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Gloyn", 
+                            "index": "Gloyn, AL"
+                        }
                     }, 
                     {
-                        "surname": "Lindgren", 
-                        "given-names": "CM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Lindgren", 
+                            "index": "Lindgren, CM"
+                        }
                     }, 
                     {
-                        "surname": "M\u00e4gi", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R M\u00e4gi", 
+                            "index": "M\u00e4gi, R"
+                        }
                     }, 
                     {
-                        "surname": "Morris", 
-                        "given-names": "AP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AP Morris", 
+                            "index": "Morris, AP"
+                        }
                     }, 
                     {
-                        "surname": "Randall", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Randall", 
+                            "index": "Randall, J"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Johnson", 
+                            "index": "Johnson, T"
+                        }
                     }, 
                     {
-                        "surname": "Elliott", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Elliott", 
+                            "index": "Elliott, P"
+                        }
                     }, 
                     {
-                        "surname": "Rybin", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Rybin", 
+                            "index": "Rybin, D"
+                        }
                     }, 
                     {
-                        "surname": "Thorleifsson", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Thorleifsson", 
+                            "index": "Thorleifsson, G"
+                        }
                     }, 
                     {
-                        "surname": "Steinthorsdottir", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Steinthorsdottir", 
+                            "index": "Steinthorsdottir, V"
+                        }
                     }, 
                     {
-                        "surname": "Henneman", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Henneman", 
+                            "index": "Henneman, P"
+                        }
                     }, 
                     {
-                        "surname": "Grallert", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Grallert", 
+                            "index": "Grallert, H"
+                        }
                     }, 
                     {
-                        "surname": "Dehghan", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Dehghan", 
+                            "index": "Dehghan, A"
+                        }
                     }, 
                     {
-                        "surname": "Hottenga", 
-                        "given-names": "JJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JJ Hottenga", 
+                            "index": "Hottenga, JJ"
+                        }
                     }, 
                     {
-                        "surname": "Franklin", 
-                        "given-names": "CS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Franklin", 
+                            "index": "Franklin, CS"
+                        }
                     }, 
                     {
-                        "surname": "Navarro", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Navarro", 
+                            "index": "Navarro, P"
+                        }
                     }, 
                     {
-                        "surname": "Song", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Song", 
+                            "index": "Song, K"
+                        }
                     }, 
                     {
-                        "surname": "Goel", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Goel", 
+                            "index": "Goel, A"
+                        }
                     }, 
                     {
-                        "surname": "Perry", 
-                        "given-names": "JR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JR Perry", 
+                            "index": "Perry, JR"
+                        }
                     }, 
                     {
-                        "surname": "Egan", 
-                        "given-names": "JM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Egan", 
+                            "index": "Egan, JM"
+                        }
                     }, 
                     {
-                        "surname": "Lajunen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Lajunen", 
+                            "index": "Lajunen, T"
+                        }
                     }, 
                     {
-                        "surname": "Grarup", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Grarup", 
+                            "index": "Grarup, N"
+                        }
                     }, 
                     {
-                        "surname": "Spars\u00f8", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Spars\u00f8", 
+                            "index": "Spars\u00f8, T"
+                        }
                     }, 
                     {
-                        "surname": "Doney", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Doney", 
+                            "index": "Doney, A"
+                        }
                     }, 
                     {
-                        "surname": "Voight", 
-                        "given-names": "BF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BF Voight", 
+                            "index": "Voight, BF"
+                        }
                     }, 
                     {
-                        "surname": "Stringham", 
-                        "given-names": "HM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HM Stringham", 
+                            "index": "Stringham, HM"
+                        }
                     }, 
                     {
-                        "surname": "Li", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Li", 
+                            "index": "Li, M"
+                        }
                     }, 
                     {
-                        "surname": "Kanoni", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kanoni", 
+                            "index": "Kanoni, S"
+                        }
                     }, 
                     {
-                        "surname": "Shrader", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Shrader", 
+                            "index": "Shrader, P"
+                        }
                     }, 
                     {
-                        "surname": "Cavalcanti-Proen\u00e7a", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Cavalcanti-Proen\u00e7a", 
+                            "index": "Cavalcanti-Proen\u00e7a, C"
+                        }
                     }, 
                     {
-                        "surname": "Kumari", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kumari", 
+                            "index": "Kumari, M"
+                        }
                     }, 
                     {
-                        "surname": "Qi", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Qi", 
+                            "index": "Qi, L"
+                        }
                     }, 
                     {
-                        "surname": "Timpson", 
-                        "given-names": "NJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Timpson", 
+                            "index": "Timpson, NJ"
+                        }
                     }, 
                     {
-                        "surname": "Gieger", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Gieger", 
+                            "index": "Gieger, C"
+                        }
                     }, 
                     {
-                        "surname": "Zabena", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Zabena", 
+                            "index": "Zabena, C"
+                        }
                     }, 
                     {
-                        "surname": "Rocheleau", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Rocheleau", 
+                            "index": "Rocheleau, G"
+                        }
                     }, 
                     {
-                        "surname": "Ingelsson", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Ingelsson", 
+                            "index": "Ingelsson, E"
+                        }
                     }, 
                     {
-                        "surname": "An", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P An", 
+                            "index": "An, P"
+                        }
                     }, 
                     {
-                        "surname": "O'Connell", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J O'Connell", 
+                            "index": "O'Connell, J"
+                        }
                     }, 
                     {
-                        "surname": "Luan", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Luan", 
+                            "index": "Luan, J"
+                        }
                     }, 
                     {
-                        "surname": "Elliott", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Elliott", 
+                            "index": "Elliott, A"
+                        }
                     }, 
                     {
-                        "surname": "McCarroll", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA McCarroll", 
+                            "index": "McCarroll, SA"
+                        }
                     }, 
                     {
-                        "surname": "Payne", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Payne", 
+                            "index": "Payne, F"
+                        }
                     }, 
                     {
-                        "surname": "Roccasecca", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Roccasecca", 
+                            "index": "Roccasecca, RM"
+                        }
                     }, 
                     {
-                        "surname": "Pattou", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Pattou", 
+                            "index": "Pattou, F"
+                        }
                     }, 
                     {
-                        "surname": "Sethupathy", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Sethupathy", 
+                            "index": "Sethupathy, P"
+                        }
                     }, 
                     {
-                        "surname": "Ardlie", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Ardlie", 
+                            "index": "Ardlie, K"
+                        }
                     }, 
                     {
-                        "surname": "Ariyurek", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ariyurek", 
+                            "index": "Ariyurek, Y"
+                        }
                     }, 
                     {
-                        "surname": "Balkau", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Balkau", 
+                            "index": "Balkau, B"
+                        }
                     }, 
                     {
-                        "surname": "Barter", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Barter", 
+                            "index": "Barter, P"
+                        }
                     }, 
                     {
-                        "surname": "Beilby", 
-                        "given-names": "JP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JP Beilby", 
+                            "index": "Beilby, JP"
+                        }
                     }, 
                     {
-                        "surname": "Ben-Shlomo", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ben-Shlomo", 
+                            "index": "Ben-Shlomo, Y"
+                        }
                     }, 
                     {
-                        "surname": "Benediktsson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Benediktsson", 
+                            "index": "Benediktsson, R"
+                        }
                     }, 
                     {
-                        "surname": "Bennett", 
-                        "given-names": "AJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AJ Bennett", 
+                            "index": "Bennett, AJ"
+                        }
                     }, 
                     {
-                        "surname": "Bergmann", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Bergmann", 
+                            "index": "Bergmann, S"
+                        }
                     }, 
                     {
-                        "surname": "Bochud", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Bochud", 
+                            "index": "Bochud, M"
+                        }
                     }, 
                     {
-                        "surname": "Boerwinkle", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Boerwinkle", 
+                            "index": "Boerwinkle, E"
+                        }
                     }, 
                     {
-                        "surname": "Bonnefond", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Bonnefond", 
+                            "index": "Bonnefond, A"
+                        }
                     }, 
                     {
-                        "surname": "Bonnycastle", 
-                        "given-names": "LL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LL Bonnycastle", 
+                            "index": "Bonnycastle, LL"
+                        }
                     }, 
                     {
-                        "surname": "Borch-Johnsen", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Borch-Johnsen", 
+                            "index": "Borch-Johnsen, K"
+                        }
                     }, 
                     {
-                        "surname": "B\u00f6ttcher", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y B\u00f6ttcher", 
+                            "index": "B\u00f6ttcher, Y"
+                        }
                     }, 
                     {
-                        "surname": "Brunner", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Brunner", 
+                            "index": "Brunner, E"
+                        }
                     }, 
                     {
-                        "surname": "Bumpstead", 
-                        "given-names": "SJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SJ Bumpstead", 
+                            "index": "Bumpstead, SJ"
+                        }
                     }, 
                     {
-                        "surname": "Charpentier", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Charpentier", 
+                            "index": "Charpentier, G"
+                        }
                     }, 
                     {
-                        "surname": "Chen", 
-                        "given-names": "YD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YD Chen", 
+                            "index": "Chen, YD"
+                        }
                     }, 
                     {
-                        "surname": "Chines", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Chines", 
+                            "index": "Chines, P"
+                        }
                     }, 
                     {
-                        "surname": "Clarke", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Clarke", 
+                            "index": "Clarke, R"
+                        }
                     }, 
                     {
-                        "surname": "Coin", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Coin", 
+                            "index": "Coin, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "MN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MN Cooper", 
+                            "index": "Cooper, MN"
+                        }
                     }, 
                     {
-                        "surname": "Cornelis", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Cornelis", 
+                            "index": "Cornelis, M"
+                        }
                     }, 
                     {
-                        "surname": "Crawford", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Crawford", 
+                            "index": "Crawford, G"
+                        }
                     }, 
                     {
-                        "surname": "Crisponi", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Crisponi", 
+                            "index": "Crisponi, L"
+                        }
                     }, 
                     {
-                        "surname": "Day", 
-                        "given-names": "IN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IN Day", 
+                            "index": "Day, IN"
+                        }
                     }, 
                     {
-                        "surname": "de Geus", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ de Geus", 
+                            "index": "de Geus, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Delplanque", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Delplanque", 
+                            "index": "Delplanque, J"
+                        }
                     }, 
                     {
-                        "surname": "Dina", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Dina", 
+                            "index": "Dina, C"
+                        }
                     }, 
                     {
-                        "surname": "Erdos", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Erdos", 
+                            "index": "Erdos, MR"
+                        }
                     }, 
                     {
-                        "surname": "Fedson", 
-                        "given-names": "AC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AC Fedson", 
+                            "index": "Fedson, AC"
+                        }
                     }, 
                     {
-                        "surname": "Fischer-Rosinsky", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Fischer-Rosinsky", 
+                            "index": "Fischer-Rosinsky, A"
+                        }
                     }, 
                     {
-                        "surname": "Forouhi", 
-                        "given-names": "NG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NG Forouhi", 
+                            "index": "Forouhi, NG"
+                        }
                     }, 
                     {
-                        "surname": "Fox", 
-                        "given-names": "CS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Fox", 
+                            "index": "Fox, CS"
+                        }
                     }, 
                     {
-                        "surname": "Frants", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Frants", 
+                            "index": "Frants, R"
+                        }
                     }, 
                     {
-                        "surname": "Franzosi", 
-                        "given-names": "MG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MG Franzosi", 
+                            "index": "Franzosi, MG"
+                        }
                     }, 
                     {
-                        "surname": "Galan", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Galan", 
+                            "index": "Galan, P"
+                        }
                     }, 
                     {
-                        "surname": "Goodarzi", 
-                        "given-names": "MO", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MO Goodarzi", 
+                            "index": "Goodarzi, MO"
+                        }
                     }, 
                     {
-                        "surname": "Graessler", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Graessler", 
+                            "index": "Graessler, J"
+                        }
                     }, 
                     {
-                        "surname": "Groves", 
-                        "given-names": "CJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CJ Groves", 
+                            "index": "Groves, CJ"
+                        }
                     }, 
                     {
-                        "surname": "Grundy", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Grundy", 
+                            "index": "Grundy, S"
+                        }
                     }, 
                     {
-                        "surname": "Gwilliam", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Gwilliam", 
+                            "index": "Gwilliam, R"
+                        }
                     }, 
                     {
-                        "surname": "Gyllensten", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Gyllensten", 
+                            "index": "Gyllensten, U"
+                        }
                     }, 
                     {
-                        "surname": "Hadjadj", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Hadjadj", 
+                            "index": "Hadjadj, S"
+                        }
                     }, 
                     {
-                        "surname": "Hallmans", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Hallmans", 
+                            "index": "Hallmans, G"
+                        }
                     }, 
                     {
-                        "surname": "Hammond", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Hammond", 
+                            "index": "Hammond, N"
+                        }
                     }, 
                     {
-                        "surname": "Han", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Han", 
+                            "index": "Han, X"
+                        }
                     }, 
                     {
-                        "surname": "Hartikainen", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Hartikainen", 
+                            "index": "Hartikainen, AL"
+                        }
                     }, 
                     {
-                        "surname": "Hassanali", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Hassanali", 
+                            "index": "Hassanali, N"
+                        }
                     }, 
                     {
-                        "surname": "Hayward", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Hayward", 
+                            "index": "Hayward, C"
+                        }
                     }, 
                     {
-                        "surname": "Heath", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Heath", 
+                            "index": "Heath, SC"
+                        }
                     }, 
                     {
-                        "surname": "Hercberg", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Hercberg", 
+                            "index": "Hercberg, S"
+                        }
                     }, 
                     {
-                        "surname": "Herder", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Herder", 
+                            "index": "Herder, C"
+                        }
                     }, 
                     {
-                        "surname": "Hicks", 
-                        "given-names": "AA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AA Hicks", 
+                            "index": "Hicks, AA"
+                        }
                     }, 
                     {
-                        "surname": "Hillman", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Hillman", 
+                            "index": "Hillman, DR"
+                        }
                     }, 
                     {
-                        "surname": "Hingorani", 
-                        "given-names": "AD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AD Hingorani", 
+                            "index": "Hingorani, AD"
+                        }
                     }, 
                     {
-                        "surname": "Hofman", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hofman", 
+                            "index": "Hofman, A"
+                        }
                     }, 
                     {
-                        "surname": "Hui", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hui", 
+                            "index": "Hui, J"
+                        }
                     }, 
                     {
-                        "surname": "Hung", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hung", 
+                            "index": "Hung, J"
+                        }
                     }, 
                     {
-                        "surname": "Isomaa", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Isomaa", 
+                            "index": "Isomaa, B"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "PR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PR Johnson", 
+                            "index": "Johnson, PR"
+                        }
                     }, 
                     {
-                        "surname": "J\u00f8rgensen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T J\u00f8rgensen", 
+                            "index": "J\u00f8rgensen, T"
+                        }
                     }, 
                     {
-                        "surname": "Jula", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Jula", 
+                            "index": "Jula, A"
+                        }
                     }, 
                     {
-                        "surname": "Kaakinen", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kaakinen", 
+                            "index": "Kaakinen, M"
+                        }
                     }, 
                     {
-                        "surname": "Kaprio", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kaprio", 
+                            "index": "Kaprio, J"
+                        }
                     }, 
                     {
-                        "surname": "Kesaniemi", 
-                        "given-names": "YA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YA Kesaniemi", 
+                            "index": "Kesaniemi, YA"
+                        }
                     }, 
                     {
-                        "surname": "Kivimaki", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kivimaki", 
+                            "index": "Kivimaki, M"
+                        }
                     }, 
                     {
-                        "surname": "Knight", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Knight", 
+                            "index": "Knight, B"
+                        }
                     }, 
                     {
-                        "surname": "Koskinen", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Koskinen", 
+                            "index": "Koskinen, S"
+                        }
                     }, 
                     {
-                        "surname": "Kovacs", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Kovacs", 
+                            "index": "Kovacs, P"
+                        }
                     }, 
                     {
-                        "surname": "Kyvik", 
-                        "given-names": "KO", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KO Kyvik", 
+                            "index": "Kyvik, KO"
+                        }
                     }, 
                     {
-                        "surname": "Lathrop", 
-                        "given-names": "GM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GM Lathrop", 
+                            "index": "Lathrop, GM"
+                        }
                     }, 
                     {
-                        "surname": "Lawlor", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Lawlor", 
+                            "index": "Lawlor, DA"
+                        }
                     }, 
                     {
-                        "surname": "Le Bacquer", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Le Bacquer", 
+                            "index": "Le Bacquer, O"
+                        }
                     }, 
                     {
-                        "surname": "Lecoeur", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lecoeur", 
+                            "index": "Lecoeur, C"
+                        }
                     }, 
                     {
-                        "surname": "Li", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Li", 
+                            "index": "Li, Y"
+                        }
                     }, 
                     {
-                        "surname": "Lyssenko", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Lyssenko", 
+                            "index": "Lyssenko, V"
+                        }
                     }, 
                     {
-                        "surname": "Mahley", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Mahley", 
+                            "index": "Mahley, R"
+                        }
                     }, 
                     {
-                        "surname": "Mangino", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Mangino", 
+                            "index": "Mangino, M"
+                        }
                     }, 
                     {
-                        "surname": "Manning", 
-                        "given-names": "AK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AK Manning", 
+                            "index": "Manning, AK"
+                        }
                     }, 
                     {
-                        "surname": "Mart\u00ednez-Larrad", 
-                        "given-names": "MT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MT Mart\u00ednez-Larrad", 
+                            "index": "Mart\u00ednez-Larrad, MT"
+                        }
                     }, 
                     {
-                        "surname": "McAteer", 
-                        "given-names": "JB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JB McAteer", 
+                            "index": "McAteer, JB"
+                        }
                     }, 
                     {
-                        "surname": "McCulloch", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ McCulloch", 
+                            "index": "McCulloch, LJ"
+                        }
                     }, 
                     {
-                        "surname": "McPherson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R McPherson", 
+                            "index": "McPherson, R"
+                        }
                     }, 
                     {
-                        "surname": "Meisinger", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Meisinger", 
+                            "index": "Meisinger, C"
+                        }
                     }, 
                     {
-                        "surname": "Melzer", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Melzer", 
+                            "index": "Melzer, D"
+                        }
                     }, 
                     {
-                        "surname": "Meyre", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Meyre", 
+                            "index": "Meyre, D"
+                        }
                     }, 
                     {
-                        "surname": "Mitchell", 
-                        "given-names": "BD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BD Mitchell", 
+                            "index": "Mitchell, BD"
+                        }
                     }, 
                     {
-                        "surname": "Morken", 
-                        "given-names": "MA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Morken", 
+                            "index": "Morken, MA"
+                        }
                     }, 
                     {
-                        "surname": "Mukherjee", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Mukherjee", 
+                            "index": "Mukherjee, S"
+                        }
                     }, 
                     {
-                        "surname": "Naitza", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Naitza", 
+                            "index": "Naitza, S"
+                        }
                     }, 
                     {
-                        "surname": "Narisu", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Narisu", 
+                            "index": "Narisu, N"
+                        }
                     }, 
                     {
-                        "surname": "Neville", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Neville", 
+                            "index": "Neville, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Oostra", 
-                        "given-names": "BA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BA Oostra", 
+                            "index": "Oostra, BA"
+                        }
                     }, 
                     {
-                        "surname": "Orr\u00f9", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Orr\u00f9", 
+                            "index": "Orr\u00f9, M"
+                        }
                     }, 
                     {
-                        "surname": "Pakyz", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Pakyz", 
+                            "index": "Pakyz, R"
+                        }
                     }, 
                     {
-                        "surname": "Palmer", 
-                        "given-names": "CN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CN Palmer", 
+                            "index": "Palmer, CN"
+                        }
                     }, 
                     {
-                        "surname": "Paolisso", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Paolisso", 
+                            "index": "Paolisso, G"
+                        }
                     }, 
                     {
-                        "surname": "Pattaro", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Pattaro", 
+                            "index": "Pattaro, C"
+                        }
                     }, 
                     {
-                        "surname": "Pearson", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Pearson", 
+                            "index": "Pearson, D"
+                        }
                     }, 
                     {
-                        "surname": "Peden", 
-                        "given-names": "JF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JF Peden", 
+                            "index": "Peden, JF"
+                        }
                     }, 
                     {
-                        "surname": "Pedersen", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Pedersen", 
+                            "index": "Pedersen, NL"
+                        }
                     }, 
                     {
-                        "surname": "Perola", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Perola", 
+                            "index": "Perola, M"
+                        }
                     }, 
                     {
-                        "surname": "Pfeiffer", 
-                        "given-names": "AF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AF Pfeiffer", 
+                            "index": "Pfeiffer, AF"
+                        }
                     }, 
                     {
-                        "surname": "Pichler", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Pichler", 
+                            "index": "Pichler, I"
+                        }
                     }, 
                     {
-                        "surname": "Polasek", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Polasek", 
+                            "index": "Polasek, O"
+                        }
                     }, 
                     {
-                        "surname": "Posthuma", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Posthuma", 
+                            "index": "Posthuma, D"
+                        }
                     }, 
                     {
-                        "surname": "Potter", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Potter", 
+                            "index": "Potter, SC"
+                        }
                     }, 
                     {
-                        "surname": "Pouta", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Pouta", 
+                            "index": "Pouta, A"
+                        }
                     }, 
                     {
-                        "surname": "Province", 
-                        "given-names": "MA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Province", 
+                            "index": "Province, MA"
+                        }
                     }, 
                     {
-                        "surname": "Psaty", 
-                        "given-names": "BM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BM Psaty", 
+                            "index": "Psaty, BM"
+                        }
                     }, 
                     {
-                        "surname": "Rathmann", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Rathmann", 
+                            "index": "Rathmann, W"
+                        }
                     }, 
                     {
-                        "surname": "Rayner", 
-                        "given-names": "NW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NW Rayner", 
+                            "index": "Rayner, NW"
+                        }
                     }, 
                     {
-                        "surname": "Rice", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Rice", 
+                            "index": "Rice, K"
+                        }
                     }, 
                     {
-                        "surname": "Ripatti", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Ripatti", 
+                            "index": "Ripatti, S"
+                        }
                     }, 
                     {
-                        "surname": "Rivadeneira", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Rivadeneira", 
+                            "index": "Rivadeneira, F"
+                        }
                     }, 
                     {
-                        "surname": "Roden", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Roden", 
+                            "index": "Roden, M"
+                        }
                     }, 
                     {
-                        "surname": "Rolandsson", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Rolandsson", 
+                            "index": "Rolandsson, O"
+                        }
                     }, 
                     {
-                        "surname": "Sandbaek", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sandbaek", 
+                            "index": "Sandbaek, A"
+                        }
                     }, 
                     {
-                        "surname": "Sandhu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sandhu", 
+                            "index": "Sandhu, M"
+                        }
                     }, 
                     {
-                        "surname": "Sanna", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sanna", 
+                            "index": "Sanna, S"
+                        }
                     }, 
                     {
-                        "surname": "Sayer", 
-                        "given-names": "AA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AA Sayer", 
+                            "index": "Sayer, AA"
+                        }
                     }, 
                     {
-                        "surname": "Scheet", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Scheet", 
+                            "index": "Scheet, P"
+                        }
                     }, 
                     {
-                        "surname": "Scott", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Scott", 
+                            "index": "Scott, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Seedorf", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Seedorf", 
+                            "index": "Seedorf, U"
+                        }
                     }, 
                     {
-                        "surname": "Sharp", 
-                        "given-names": "SJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SJ Sharp", 
+                            "index": "Sharp, SJ"
+                        }
                     }, 
                     {
-                        "surname": "Shields", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Shields", 
+                            "index": "Shields, B"
+                        }
                     }, 
                     {
-                        "surname": "Sigurethsson", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Sigurethsson", 
+                            "index": "Sigurethsson, G"
+                        }
                     }, 
                     {
-                        "surname": "Sijbrands", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ Sijbrands", 
+                            "index": "Sijbrands, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Silveira", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Silveira", 
+                            "index": "Silveira, A"
+                        }
                     }, 
                     {
-                        "surname": "Simpson", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Simpson", 
+                            "index": "Simpson, L"
+                        }
                     }, 
                     {
-                        "surname": "Singleton", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Singleton", 
+                            "index": "Singleton, A"
+                        }
                     }, 
                     {
-                        "surname": "Smith", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Smith", 
+                            "index": "Smith, NL"
+                        }
                     }, 
                     {
-                        "surname": "Sovio", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Sovio", 
+                            "index": "Sovio, U"
+                        }
                     }, 
                     {
-                        "surname": "Swift", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Swift", 
+                            "index": "Swift, A"
+                        }
                     }, 
                     {
-                        "surname": "Syddall", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Syddall", 
+                            "index": "Syddall, H"
+                        }
                     }, 
                     {
-                        "surname": "Syv\u00e4nen", 
-                        "given-names": "AC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AC Syv\u00e4nen", 
+                            "index": "Syv\u00e4nen, AC"
+                        }
                     }, 
                     {
-                        "surname": "Tanaka", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Tanaka", 
+                            "index": "Tanaka, T"
+                        }
                     }, 
                     {
-                        "surname": "Thorand", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Thorand", 
+                            "index": "Thorand, B"
+                        }
                     }, 
                     {
-                        "surname": "Tichet", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Tichet", 
+                            "index": "Tichet, J"
+                        }
                     }, 
                     {
-                        "surname": "T\u00f6njes", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A T\u00f6njes", 
+                            "index": "T\u00f6njes, A"
+                        }
                     }, 
                     {
-                        "surname": "Tuomi", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Tuomi", 
+                            "index": "Tuomi, T"
+                        }
                     }, 
                     {
-                        "surname": "Uitterlinden", 
-                        "given-names": "AG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AG Uitterlinden", 
+                            "index": "Uitterlinden, AG"
+                        }
                     }, 
                     {
-                        "surname": "van Dijk", 
-                        "given-names": "KW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KW van Dijk", 
+                            "index": "van Dijk, KW"
+                        }
                     }, 
                     {
-                        "surname": "van Hoek", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M van Hoek", 
+                            "index": "van Hoek, M"
+                        }
                     }, 
                     {
-                        "surname": "Varma", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Varma", 
+                            "index": "Varma, D"
+                        }
                     }, 
                     {
-                        "surname": "Visvikis-Siest", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Visvikis-Siest", 
+                            "index": "Visvikis-Siest, S"
+                        }
                     }, 
                     {
-                        "surname": "Vitart", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Vitart", 
+                            "index": "Vitart, V"
+                        }
                     }, 
                     {
-                        "surname": "Vogelzangs", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Vogelzangs", 
+                            "index": "Vogelzangs, N"
+                        }
                     }, 
                     {
-                        "surname": "Waeber", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Waeber", 
+                            "index": "Waeber, G"
+                        }
                     }, 
                     {
-                        "surname": "Wagner", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Wagner", 
+                            "index": "Wagner, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Walley", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Walley", 
+                            "index": "Walley, A"
+                        }
                     }, 
                     {
-                        "surname": "Walters", 
-                        "given-names": "GB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GB Walters", 
+                            "index": "Walters, GB"
+                        }
                     }, 
                     {
-                        "surname": "Ward", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Ward", 
+                            "index": "Ward, KL"
+                        }
                     }, 
                     {
-                        "surname": "Watkins", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Watkins", 
+                            "index": "Watkins, H"
+                        }
                     }, 
                     {
-                        "surname": "Weedon", 
-                        "given-names": "MN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MN Weedon", 
+                            "index": "Weedon, MN"
+                        }
                     }, 
                     {
-                        "surname": "Wild", 
-                        "given-names": "SH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Wild", 
+                            "index": "Wild, SH"
+                        }
                     }, 
                     {
-                        "surname": "Willemsen", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Willemsen", 
+                            "index": "Willemsen, G"
+                        }
                     }, 
                     {
-                        "surname": "Witteman", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Witteman", 
+                            "index": "Witteman, JC"
+                        }
                     }, 
                     {
-                        "surname": "Yarnell", 
-                        "given-names": "JW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JW Yarnell", 
+                            "index": "Yarnell, JW"
+                        }
                     }, 
                     {
-                        "surname": "Zeggini", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Zeggini", 
+                            "index": "Zeggini, E"
+                        }
                     }, 
                     {
-                        "surname": "Zelenika", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Zelenika", 
+                            "index": "Zelenika, D"
+                        }
                     }, 
                     {
-                        "surname": "Zethelius", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zethelius", 
+                            "index": "Zethelius, B"
+                        }
                     }, 
                     {
-                        "surname": "Zhai", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Zhai", 
+                            "index": "Zhai, G"
+                        }
                     }, 
                     {
-                        "surname": "Zhao", 
-                        "given-names": "JH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JH Zhao", 
+                            "index": "Zhao, JH"
+                        }
                     }, 
                     {
-                        "surname": "Zillikens", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Zillikens", 
+                            "index": "Zillikens, MC"
+                        }
                     }, 
                     {
-                        "surname": "Borecki", 
-                        "given-names": "IB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IB Borecki", 
+                            "index": "Borecki, IB"
+                        }
                     }, 
                     {
-                        "surname": "Loos", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Loos", 
+                            "index": "Loos, RJ"
+                        }
                     }, 
                     {
-                        "surname": "Meneton", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Meneton", 
+                            "index": "Meneton, P"
+                        }
                     }, 
                     {
-                        "surname": "Magnusson", 
-                        "given-names": "PK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PK Magnusson", 
+                            "index": "Magnusson, PK"
+                        }
                     }, 
                     {
-                        "surname": "Nathan", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Nathan", 
+                            "index": "Nathan, DM"
+                        }
                     }, 
                     {
-                        "surname": "Williams", 
-                        "given-names": "GH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GH Williams", 
+                            "index": "Williams, GH"
+                        }
                     }, 
                     {
-                        "surname": "Hattersley", 
-                        "given-names": "AT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AT Hattersley", 
+                            "index": "Hattersley, AT"
+                        }
                     }, 
                     {
-                        "surname": "Silander", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Silander", 
+                            "index": "Silander, K"
+                        }
                     }, 
                     {
-                        "surname": "Salomaa", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Salomaa", 
+                            "index": "Salomaa, V"
+                        }
                     }, 
                     {
-                        "surname": "Smith", 
-                        "given-names": "GD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GD Smith", 
+                            "index": "Smith, GD"
+                        }
                     }, 
                     {
-                        "surname": "Bornstein", 
-                        "given-names": "SR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SR Bornstein", 
+                            "index": "Bornstein, SR"
+                        }
                     }, 
                     {
-                        "surname": "Schwarz", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schwarz", 
+                            "index": "Schwarz, P"
+                        }
                     }, 
                     {
-                        "surname": "Spranger", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Spranger", 
+                            "index": "Spranger, J"
+                        }
                     }, 
                     {
-                        "surname": "Karpe", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Karpe", 
+                            "index": "Karpe, F"
+                        }
                     }, 
                     {
-                        "surname": "Shuldiner", 
-                        "given-names": "AR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AR Shuldiner", 
+                            "index": "Shuldiner, AR"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Cooper", 
+                            "index": "Cooper, C"
+                        }
                     }, 
                     {
-                        "surname": "Dedoussis", 
-                        "given-names": "GV", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GV Dedoussis", 
+                            "index": "Dedoussis, GV"
+                        }
                     }, 
                     {
-                        "surname": "Serrano-R\u00edos", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Serrano-R\u00edos", 
+                            "index": "Serrano-R\u00edos, M"
+                        }
                     }, 
                     {
-                        "surname": "Morris", 
-                        "given-names": "AD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AD Morris", 
+                            "index": "Morris, AD"
+                        }
                     }, 
                     {
-                        "surname": "Lind", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Lind", 
+                            "index": "Lind, L"
+                        }
                     }, 
                     {
-                        "surname": "Palmer", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Palmer", 
+                            "index": "Palmer, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Hu", 
-                        "given-names": "FB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FB Hu", 
+                            "index": "Hu, FB"
+                        }
                     }, 
                     {
-                        "surname": "Franks", 
-                        "given-names": "PW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PW Franks", 
+                            "index": "Franks, PW"
+                        }
                     }, 
                     {
-                        "surname": "Ebrahim", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Ebrahim", 
+                            "index": "Ebrahim, S"
+                        }
                     }, 
                     {
-                        "surname": "Marmot", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Marmot", 
+                            "index": "Marmot, M"
+                        }
                     }, 
                     {
-                        "surname": "Kao", 
-                        "given-names": "WH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kao", 
+                            "index": "Kao, WH"
+                        }
                     }, 
                     {
-                        "surname": "Pankow", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Pankow", 
+                            "index": "Pankow, JS"
+                        }
                     }, 
                     {
-                        "surname": "Sampson", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Sampson", 
+                            "index": "Sampson, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Kuusisto", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kuusisto", 
+                            "index": "Kuusisto, J"
+                        }
                     }, 
                     {
-                        "surname": "Laakso", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Laakso", 
+                            "index": "Laakso, M"
+                        }
                     }, 
                     {
-                        "surname": "Hansen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hansen", 
+                            "index": "Hansen, T"
+                        }
                     }, 
                     {
-                        "surname": "Pedersen", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Pedersen", 
+                            "index": "Pedersen, O"
+                        }
                     }, 
                     {
-                        "surname": "Pramstaller", 
-                        "given-names": "PP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PP Pramstaller", 
+                            "index": "Pramstaller, PP"
+                        }
                     }, 
                     {
-                        "surname": "Wichmann", 
-                        "given-names": "HE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HE Wichmann", 
+                            "index": "Wichmann, HE"
+                        }
                     }, 
                     {
-                        "surname": "Illig", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Illig", 
+                            "index": "Illig, T"
+                        }
                     }, 
                     {
-                        "surname": "Rudan", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Rudan", 
+                            "index": "Rudan, I"
+                        }
                     }, 
                     {
-                        "surname": "Wright", 
-                        "given-names": "AF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AF Wright", 
+                            "index": "Wright, AF"
+                        }
                     }, 
                     {
-                        "surname": "Stumvoll", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Stumvoll", 
+                            "index": "Stumvoll, M"
+                        }
                     }, 
                     {
-                        "surname": "Campbell", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Campbell", 
+                            "index": "Campbell, H"
+                        }
                     }, 
                     {
-                        "surname": "Wilson", 
-                        "given-names": "JF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JF Wilson", 
+                            "index": "Wilson, JF"
+                        }
                     }, 
                     {
-                        "surname": "Bergman", 
-                        "given-names": "RN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RN Bergman", 
+                            "index": "Bergman, RN"
+                        }
                     }, 
                     {
-                        "surname": "Buchanan", 
-                        "given-names": "TA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TA Buchanan", 
+                            "index": "Buchanan, TA"
+                        }
                     }, 
                     {
-                        "surname": "Collins", 
-                        "given-names": "FS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FS Collins", 
+                            "index": "Collins, FS"
+                        }
                     }, 
                     {
-                        "surname": "Mohlke", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Mohlke", 
+                            "index": "Mohlke, KL"
+                        }
                     }, 
                     {
-                        "surname": "Tuomilehto", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Tuomilehto", 
+                            "index": "Tuomilehto, J"
+                        }
                     }, 
                     {
-                        "surname": "Valle", 
-                        "given-names": "TT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TT Valle", 
+                            "index": "Valle, TT"
+                        }
                     }, 
                     {
-                        "surname": "Altshuler", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Altshuler", 
+                            "index": "Altshuler, D"
+                        }
                     }, 
                     {
-                        "surname": "Rotter", 
-                        "given-names": "JI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JI Rotter", 
+                            "index": "Rotter, JI"
+                        }
                     }, 
                     {
-                        "surname": "Siscovick", 
-                        "given-names": "DS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DS Siscovick", 
+                            "index": "Siscovick, DS"
+                        }
                     }, 
                     {
-                        "surname": "Penninx", 
-                        "given-names": "BW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BW Penninx", 
+                            "index": "Penninx, BW"
+                        }
                     }, 
                     {
-                        "surname": "Boomsma", 
-                        "given-names": "DI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DI Boomsma", 
+                            "index": "Boomsma, DI"
+                        }
                     }, 
                     {
-                        "surname": "Deloukas", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Deloukas", 
+                            "index": "Deloukas, P"
+                        }
                     }, 
                     {
-                        "surname": "Spector", 
-                        "given-names": "TD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD Spector", 
+                            "index": "Spector, TD"
+                        }
                     }, 
                     {
-                        "surname": "Frayling", 
-                        "given-names": "TM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TM Frayling", 
+                            "index": "Frayling, TM"
+                        }
                     }, 
                     {
-                        "surname": "Ferrucci", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Ferrucci", 
+                            "index": "Ferrucci, L"
+                        }
                     }, 
                     {
-                        "surname": "Kong", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kong", 
+                            "index": "Kong, A"
+                        }
                     }, 
                     {
-                        "surname": "Thorsteinsdottir", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Thorsteinsdottir", 
+                            "index": "Thorsteinsdottir, U"
+                        }
                     }, 
                     {
-                        "surname": "Stefansson", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Stefansson", 
+                            "index": "Stefansson, K"
+                        }
                     }, 
                     {
-                        "surname": "van Duijn", 
-                        "given-names": "CM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM van Duijn", 
+                            "index": "van Duijn, CM"
+                        }
                     }, 
                     {
-                        "surname": "Aulchenko", 
-                        "given-names": "YS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YS Aulchenko", 
+                            "index": "Aulchenko, YS"
+                        }
                     }, 
                     {
-                        "surname": "Cao", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Cao", 
+                            "index": "Cao, A"
+                        }
                     }, 
                     {
-                        "surname": "Scuteri", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Scuteri", 
+                            "index": "Scuteri, A"
+                        }
                     }, 
                     {
-                        "surname": "Schlessinger", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Schlessinger", 
+                            "index": "Schlessinger, D"
+                        }
                     }, 
                     {
-                        "surname": "Uda", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Uda", 
+                            "index": "Uda, M"
+                        }
                     }, 
                     {
-                        "surname": "Ruokonen", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Ruokonen", 
+                            "index": "Ruokonen, A"
+                        }
                     }, 
                     {
-                        "surname": "Jarvelin", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Jarvelin", 
+                            "index": "Jarvelin, MR"
+                        }
                     }, 
                     {
-                        "surname": "Waterworth", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Waterworth", 
+                            "index": "Waterworth, DM"
+                        }
                     }, 
                     {
-                        "surname": "Vollenweider", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Vollenweider", 
+                            "index": "Vollenweider, P"
+                        }
                     }, 
                     {
-                        "surname": "Peltonen", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Peltonen", 
+                            "index": "Peltonen, L"
+                        }
                     }, 
                     {
-                        "surname": "Mooser", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Mooser", 
+                            "index": "Mooser, V"
+                        }
                     }, 
                     {
-                        "surname": "Abecasis", 
-                        "given-names": "GR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GR Abecasis", 
+                            "index": "Abecasis, GR"
+                        }
                     }, 
                     {
-                        "surname": "Wareham", 
-                        "given-names": "NJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Wareham", 
+                            "index": "Wareham, NJ"
+                        }
                     }, 
                     {
-                        "surname": "Sladek", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Sladek", 
+                            "index": "Sladek, R"
+                        }
                     }, 
                     {
-                        "surname": "Froguel", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Froguel", 
+                            "index": "Froguel, P"
+                        }
                     }, 
                     {
-                        "surname": "Watanabe", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Watanabe", 
+                            "index": "Watanabe, RM"
+                        }
                     }, 
                     {
-                        "surname": "Meigs", 
-                        "given-names": "JB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JB Meigs", 
+                            "index": "Meigs, JB"
+                        }
                     }, 
                     {
-                        "surname": "Groop", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Groop", 
+                            "index": "Groop, L"
+                        }
                     }, 
                     {
-                        "surname": "Boehnke", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Boehnke", 
+                            "index": "Boehnke, M"
+                        }
                     }, 
                     {
-                        "surname": "McCarthy", 
-                        "given-names": "MI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MI McCarthy", 
+                            "index": "McCarthy, MI"
+                        }
                     }, 
                     {
-                        "surname": "Florez", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Florez", 
+                            "index": "Florez, JC"
+                        }
                     }, 
                     {
-                        "surname": "Barroso", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Barroso", 
+                            "index": "Barroso, I"
+                        }
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "DIAGRAM Consortium"
+                        "type": "group", 
+                        "name": "DIAGRAM Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "GIANT Consortium"
+                        "type": "group", 
+                        "name": "GIANT Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "Global BPgen Consortium"
+                        "type": "group", 
+                        "name": "Global BPgen Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "Anders Hamsten on behalf of Procardis Consortium"
+                        "type": "group", 
+                        "name": "Anders Hamsten on behalf of Procardis Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "MAGIC investigators"
+                        "type": "group", 
+                        "name": "MAGIC investigators"
                     }
                 ], 
-                "full_article_title": "New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes risk", 
-                "publication-type": "journal", 
+                "articleTitle": "New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes risk", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
                 "volume": "42", 
-                "source": "Nature Genetics", 
-                "reference_id": "10.1038/ng.520", 
-                "fpage": "105", 
-                "year": "2010", 
-                "position": 4, 
-                "collab": "DIAGRAM Consortium", 
-                "ref": "DupuisJLangenbergCProkopenkoISaxenaRSoranzoNJacksonAUWheelerEGlazerNLBouatia-NajiNGloynALLindgrenCMM\u00e4giRMorrisAPRandallJJohnsonTElliottPRybinDThorleifssonGSteinthorsdottirVHennemanPGrallertHDehghanAHottengaJJFranklinCSNavarroPSongKGoelAPerryJREganJMLajunenTGrarupNSpars\u00f8TDoneyAVoightBFStringhamHMLiMKanoniSShraderPCavalcanti-Proen\u00e7aCKumariMQiLTimpsonNJGiegerCZabenaCRocheleauGIngelssonEAnPO'ConnellJLuanJElliottAMcCarrollSAPayneFRoccaseccaRMPattouFSethupathyPArdlieKAriyurekYBalkauBBarterPBeilbyJPBen-ShlomoYBenediktssonRBennettAJBergmannSBochudMBoerwinkleEBonnefondABonnycastleLLBorch-JohnsenKB\u00f6ttcherYBrunnerEBumpsteadSJCharpentierGChenYDChinesPClarkeRCoinLJCooperMNCornelisMCrawfordGCrisponiLDayINde GeusEJDelplanqueJDinaCErdosMRFedsonACFischer-RosinskyAForouhiNGFoxCSFrantsRFranzosiMGGalanPGoodarziMOGraesslerJGrovesCJGrundySGwilliamRGyllenstenUHadjadjSHallmansGHammondNHanXHartikainenALHassanaliNHaywardCHeathSCHercbergSHerderCHicksAAHillmanDRHingoraniADHofmanAHuiJHungJIsomaaBJohnsonPRJ\u00f8rgensenTJulaAKaakinenMKaprioJKesaniemiYAKivimakiMKnightBKoskinenSKovacsPKyvikKOLathropGMLawlorDALe BacquerOLecoeurCLiYLyssenkoVMahleyRManginoMManningAKMart\u00ednez-LarradMTMcAteerJBMcCullochLJMcPhersonRMeisingerCMelzerDMeyreDMitchellBDMorkenMAMukherjeeSNaitzaSNarisuNNevilleMJOostraBAOrr\u00f9MPakyzRPalmerCNPaolissoGPattaroCPearsonDPedenJFPedersenNLPerolaMPfeifferAFPichlerIPolasekOPosthumaDPotterSCPoutaAProvinceMAPsatyBMRathmannWRaynerNWRiceKRipattiSRivadeneiraFRodenMRolandssonOSandbaekASandhuMSannaSSayerAAScheetPScottLJSeedorfUSharpSJShieldsBSigurethssonGSijbrandsEJSilveiraASimpsonLSingletonASmithNLSovioUSwiftASyddallHSyv\u00e4nenACTanakaTThorandBTichetJT\u00f6njesATuomiTUitterlindenAGvan DijkKWvan HoekMVarmaDVisvikis-SiestSVitartVVogelzangsNWaeberGWagnerPJWalleyAWaltersGBWardKLWatkinsHWeedonMNWildSHWillemsenGWittemanJCYarnellJWZegginiEZelenikaDZetheliusBZhaiGZhaoJHZillikensMCBoreckiIBLoosRJMenetonPMagnussonPKNathanDMWilliamsGHHattersleyATSilanderKSalomaaVSmithGDBornsteinSRSchwarzPSprangerJKarpeFShuldinerARCooperCDedoussisGVSerrano-R\u00edosMMorrisADLindLPalmerLJHuFBFranksPWEbrahimSMarmotMKaoWHPankowJSSampsonMJKuusistoJLaaksoMHansenTPedersenOPramstallerPPWichmannHEIlligTRudanIWrightAFStumvollMCampbellHWilsonJFBergmanRNBuchananTACollinsFSMohlkeKLTuomilehtoJValleTTAltshulerDRotterJISiscovickDSPenninxBWBoomsmaDIDeloukasPSpectorTDFraylingTMFerrucciLKongAThorsteinsdottirUStefanssonKvan DuijnCMAulchenkoYSCaoAScuteriASchlessingerDUdaMRuokonenAJarvelinMRWaterworthDMVollenweiderPPeltonenLMooserVAbecasisGRWarehamNJSladekRFroguelPWatanabeRMMeigsJBGroopLBoehnkeMMcCarthyMIFlorezJCBarrosoIDIAGRAM ConsortiumGIANT ConsortiumGlobal BPgen ConsortiumAnders Hamsten on behalf of Procardis ConsortiumMAGIC investigators2010New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes riskNature Genetics4210511610.1038/ng.520", 
-                "id": "bib4"
+                "pages": {
+                    "first": "105", 
+                    "last": "116", 
+                    "range": "105\u2013116"
+                }, 
+                "doi": "10.1038/ng.520"
             }, 
             {
-                "article_title": "The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian period", 
-                "lpage": "900", 
-                "doi": "10.1126/science.1141138", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib5", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Godinho", 
-                        "given-names": "SI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SI Godinho", 
+                            "index": "Godinho, SI"
+                        }
                     }, 
                     {
-                        "surname": "Maywood", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Maywood", 
+                            "index": "Maywood, ES"
+                        }
                     }, 
                     {
-                        "surname": "Shaw", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Shaw", 
+                            "index": "Shaw, L"
+                        }
                     }, 
                     {
-                        "surname": "Tucci", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Tucci", 
+                            "index": "Tucci, V"
+                        }
                     }, 
                     {
-                        "surname": "Barnard", 
-                        "given-names": "AR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AR Barnard", 
+                            "index": "Barnard, AR"
+                        }
                     }, 
                     {
-                        "surname": "Busino", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Busino", 
+                            "index": "Busino, L"
+                        }
                     }, 
                     {
-                        "surname": "Pagano", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pagano", 
+                            "index": "Pagano, M"
+                        }
                     }, 
                     {
-                        "surname": "Kendall", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Kendall", 
+                            "index": "Kendall, R"
+                        }
                     }, 
                     {
-                        "surname": "Quwailid", 
-                        "given-names": "MM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MM Quwailid", 
+                            "index": "Quwailid, MM"
+                        }
                     }, 
                     {
-                        "surname": "Romero", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Romero", 
+                            "index": "Romero, MR"
+                        }
                     }, 
                     {
-                        "surname": "O'neill", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J O'neill", 
+                            "index": "O'neill, J"
+                        }
                     }, 
                     {
-                        "surname": "Chesham", 
-                        "given-names": "JE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JE Chesham", 
+                            "index": "Chesham, JE"
+                        }
                     }, 
                     {
-                        "surname": "Brooker", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Brooker", 
+                            "index": "Brooker, D"
+                        }
                     }, 
                     {
-                        "surname": "Lalanne", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Lalanne", 
+                            "index": "Lalanne, Z"
+                        }
                     }, 
                     {
-                        "surname": "Hastings", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Hastings", 
+                            "index": "Hastings, MH"
+                        }
                     }, 
                     {
-                        "surname": "Nolan", 
-                        "given-names": "PM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PM Nolan", 
+                            "index": "Nolan, PM"
+                        }
                     }
                 ], 
-                "full_article_title": "The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian period", 
-                "publication-type": "journal", 
+                "articleTitle": "The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian period", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "316", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1141138", 
-                "fpage": "897", 
-                "year": "2007", 
-                "position": 5, 
-                "ref": "GodinhoSIMaywoodESShawLTucciVBarnardARBusinoLPaganoMKendallRQuwailidMMRomeroMRO'neillJCheshamJEBrookerDLalanneZHastingsMHNolanPM2007The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian periodScience31689790010.1126/science.1141138", 
-                "id": "bib5"
+                "pages": {
+                    "first": "897", 
+                    "last": "900", 
+                    "range": "897\u2013900"
+                }, 
+                "doi": "10.1126/science.1141138"
             }, 
             {
-                "article_title": "Light-independent role of CRY1 and CRY2 in the mammalian circadian clock", 
-                "lpage": "771", 
-                "doi": "10.1126/science.286.5440.768", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib6", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Griffin", 
-                        "given-names": "EA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EA Griffin", 
+                            "index": "Griffin, EA"
+                        }
                     }, 
                     {
-                        "surname": "Staknis", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Staknis", 
+                            "index": "Staknis, D"
+                        }
                     }, 
                     {
-                        "surname": "Weitz", 
-                        "given-names": "CJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CJ Weitz", 
+                            "index": "Weitz, CJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Light-independent role of CRY1 and CRY2 in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Light-independent role of CRY1 and CRY2 in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "286", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.286.5440.768", 
-                "fpage": "768", 
-                "year": "1999", 
-                "position": 6, 
-                "ref": "GriffinEAStaknisDWeitzCJ1999Light-independent role of CRY1 and CRY2 in the mammalian circadian clockScience28676877110.1126/science.286.5440.768", 
-                "id": "bib6"
+                "pages": {
+                    "first": "768", 
+                    "last": "771", 
+                    "range": "768\u2013771"
+                }, 
+                "doi": "10.1126/science.286.5440.768"
             }, 
             {
-                "article_title": "Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resetting", 
-                "lpage": "1080", 
-                "doi": "10.1113/jphysiol.2012.242198", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib7", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Guilding", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Guilding", 
+                            "index": "Guilding, C"
+                        }
                     }, 
                     {
-                        "surname": "Scott", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Scott", 
+                            "index": "Scott, F"
+                        }
                     }, 
                     {
-                        "surname": "Bechtold", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Bechtold", 
+                            "index": "Bechtold, DA"
+                        }
                     }, 
                     {
-                        "surname": "Brown", 
-                        "given-names": "TM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TM Brown", 
+                            "index": "Brown, TM"
+                        }
                     }, 
                     {
-                        "surname": "Wegner", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Wegner", 
+                            "index": "Wegner, S"
+                        }
                     }, 
                     {
-                        "surname": "Piggins", 
-                        "given-names": "HD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HD Piggins", 
+                            "index": "Piggins, HD"
+                        }
                     }
                 ], 
-                "full_article_title": "Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resetting", 
-                "publication-type": "journal", 
+                "articleTitle": "Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resetting", 
+                "journal": {
+                    "name": [
+                        "Journal of Physiology"
+                    ]
+                }, 
                 "volume": "591", 
-                "source": "Journal of Physiology", 
-                "reference_id": "10.1113/jphysiol.2012.242198", 
-                "fpage": "1063", 
-                "year": "2013", 
-                "position": 7, 
-                "ref": "GuildingCScottFBechtoldDABrownTMWegnerSPigginsHD2013Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resettingJournal of Physiology5911063108010.1113/jphysiol.2012.242198", 
-                "id": "bib7"
+                "pages": {
+                    "first": "1063", 
+                    "last": "1080", 
+                    "range": "1063\u20131080"
+                }, 
+                "doi": "10.1113/jphysiol.2012.242198"
             }, 
             {
-                "article_title": "The transcriptional repressor DEC2 regulates sleep length in mammals", 
-                "lpage": "870", 
-                "doi": "10.1126/science.1174443", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib8", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "He", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y He", 
+                            "index": "He, Y"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Fujiki", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Fujiki", 
+                            "index": "Fujiki, N"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Guo", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Guo", 
+                            "index": "Guo, B"
+                        }
                     }, 
                     {
-                        "surname": "Holder", 
-                        "given-names": "JL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Holder", 
+                            "index": "Holder, JL"
+                        }
                     }, 
                     {
-                        "surname": "Rossner", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Rossner", 
+                            "index": "Rossner, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Nishino", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nishino", 
+                            "index": "Nishino, S"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "The transcriptional repressor DEC2 regulates sleep length in mammals", 
-                "publication-type": "journal", 
+                "articleTitle": "The transcriptional repressor DEC2 regulates sleep length in mammals", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "325", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1174443", 
-                "fpage": "866", 
-                "year": "2009", 
-                "position": 8, 
-                "ref": "HeYJonesCRFujikiNXuYGuoBHolderJLRossnerMJNishinoSFuYH2009The transcriptional repressor DEC2 regulates sleep length in mammalsScience32586687010.1126/science.1174443", 
-                "id": "bib8"
+                "pages": {
+                    "first": "866", 
+                    "last": "870", 
+                    "range": "866\u2013870"
+                }, 
+                "doi": "10.1126/science.1174443"
             }, 
             {
-                "article_title": "In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clock", 
-                "lpage": "4473", 
-                "doi": "10.1128/MCB.00711-14", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib9", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "Hirano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hirano", 
+                            "index": "Hirano, A"
+                        }
                     }, 
                     {
-                        "surname": "Kurabayashi", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Kurabayashi", 
+                            "index": "Kurabayashi, N"
+                        }
                     }, 
                     {
-                        "surname": "Nakagawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Nakagawa", 
+                            "index": "Nakagawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Shioi", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Shioi", 
+                            "index": "Shioi, G"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Hirota", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirota", 
+                            "index": "Hirota, T"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clock", 
+                "journal": {
+                    "name": [
+                        "Molecular and Cellular Biology"
+                    ]
+                }, 
                 "volume": "34", 
-                "source": "Molecular and Cellular Biology", 
-                "reference_id": "10.1128/MCB.00711-14", 
-                "fpage": "4464", 
-                "year": "2014", 
-                "position": 9, 
-                "ref": "HiranoAKurabayashiNNakagawaTShioiGTodoTHirotaTFukadaY2014In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clockMolecular and Cellular Biology344464447310.1128/MCB.00711-14", 
-                "id": "bib9"
+                "pages": {
+                    "first": "4464", 
+                    "last": "4473", 
+                    "range": "4464\u20134473"
+                }, 
+                "doi": "10.1128/MCB.00711-14"
             }, 
             {
-                "article_title": "FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromes", 
-                "lpage": "1118", 
-                "doi": "10.1016/j.cell.2013.01.054", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib10", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Hirano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hirano", 
+                            "index": "Hirano, A"
+                        }
                     }, 
                     {
-                        "surname": "Yumimoto", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Yumimoto", 
+                            "index": "Yumimoto, K"
+                        }
                     }, 
                     {
-                        "surname": "Tsunematsu", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Tsunematsu", 
+                            "index": "Tsunematsu, R"
+                        }
                     }, 
                     {
-                        "surname": "Matsumoto", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Matsumoto", 
+                            "index": "Matsumoto, M"
+                        }
                     }, 
                     {
-                        "surname": "Oyama", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Oyama", 
+                            "index": "Oyama, M"
+                        }
                     }, 
                     {
-                        "surname": "Kozuka-Hata", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kozuka-Hata", 
+                            "index": "Kozuka-Hata, H"
+                        }
                     }, 
                     {
-                        "surname": "Nakagawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Nakagawa", 
+                            "index": "Nakagawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Lanjakornsiripan", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lanjakornsiripan", 
+                            "index": "Lanjakornsiripan, D"
+                        }
                     }, 
                     {
-                        "surname": "Nakayama", 
-                        "given-names": "KI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KI Nakayama", 
+                            "index": "Nakayama, KI"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromes", 
-                "publication-type": "journal", 
+                "articleTitle": "FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromes", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "152", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2013.01.054", 
-                "fpage": "1106", 
-                "year": "2013", 
-                "position": 10, 
-                "ref": "HiranoAYumimotoKTsunematsuRMatsumotoMOyamaMKozuka-HataHNakagawaTLanjakornsiripanDNakayamaKIFukadaY2013FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromesCell1521106111810.1016/j.cell.2013.01.054", 
-                "id": "bib10"
+                "pages": {
+                    "first": "1106", 
+                    "last": "1118", 
+                    "range": "1106\u20131118"
+                }, 
+                "doi": "10.1016/j.cell.2013.01.054"
             }, 
             {
-                "article_title": "Identification of small molecule activators of cryptochrome", 
-                "lpage": "1097", 
-                "doi": "10.1126/science.1223710", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib11", 
+                "date": "2012", 
                 "authors": [
                     {
-                        "surname": "Hirota", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirota", 
+                            "index": "Hirota, T"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "JW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JW Lee", 
+                            "index": "Lee, JW"
+                        }
                     }, 
                     {
-                        "surname": "St John", 
-                        "given-names": "PC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PC St John", 
+                            "index": "St John, PC"
+                        }
                     }, 
                     {
-                        "surname": "Sawa", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sawa", 
+                            "index": "Sawa, M"
+                        }
                     }, 
                     {
-                        "surname": "Iwaisako", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Iwaisako", 
+                            "index": "Iwaisako, K"
+                        }
                     }, 
                     {
-                        "surname": "Noguchi", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Noguchi", 
+                            "index": "Noguchi, T"
+                        }
                     }, 
                     {
-                        "surname": "Pongsawakul", 
-                        "given-names": "PY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PY Pongsawakul", 
+                            "index": "Pongsawakul, PY"
+                        }
                     }, 
                     {
-                        "surname": "Sonntag", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sonntag", 
+                            "index": "Sonntag, T"
+                        }
                     }, 
                     {
-                        "surname": "Welsh", 
-                        "given-names": "DK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DK Welsh", 
+                            "index": "Welsh, DK"
+                        }
                     }, 
                     {
-                        "surname": "Brenner", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Brenner", 
+                            "index": "Brenner, DA"
+                        }
                     }, 
                     {
-                        "surname": "Doyle", 
-                        "given-names": "FJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FJ Doyle", 
+                            "index": "Doyle, FJ"
+                        }
                     }, 
                     {
-                        "surname": "Schultz", 
-                        "given-names": "PG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PG Schultz", 
+                            "index": "Schultz, PG"
+                        }
                     }, 
                     {
-                        "surname": "Kay", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Kay", 
+                            "index": "Kay, SA"
+                        }
                     }
                 ], 
-                "full_article_title": "Identification of small molecule activators of cryptochrome", 
-                "publication-type": "journal", 
+                "articleTitle": "Identification of small molecule activators of cryptochrome", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "337", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1223710", 
-                "fpage": "1094", 
-                "year": "2012", 
-                "position": 11, 
-                "ref": "HirotaTLeeJWSt JohnPCSawaMIwaisakoKNoguchiTPongsawakulPYSonntagTWelshDKBrennerDADoyleFJSchultzPGKaySA2012Identification of small molecule activators of cryptochromeScience3371094109710.1126/science.1223710", 
-                "id": "bib11"
+                "pages": {
+                    "first": "1094", 
+                    "last": "1097", 
+                    "range": "1094\u20131097"
+                }, 
+                "doi": "10.1126/science.1223710"
             }, 
             {
-                "article_title": "Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromes", 
-                "lpage": "6967", 
-                "doi": "10.1073/pnas.0809180106", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib12", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "Hitomi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Hitomi", 
+                            "index": "Hitomi, K"
+                        }
                     }, 
                     {
-                        "surname": "DiTacchio", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L DiTacchio", 
+                            "index": "DiTacchio, L"
+                        }
                     }, 
                     {
-                        "surname": "Arvai", 
-                        "given-names": "AS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Arvai", 
+                            "index": "Arvai, AS"
+                        }
                     }, 
                     {
-                        "surname": "Yamamoto", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Yamamoto", 
+                            "index": "Yamamoto, J"
+                        }
                     }, 
                     {
-                        "surname": "Kim", 
-                        "given-names": "S-T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S-T Kim", 
+                            "index": "Kim, S-T"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Tainer", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Tainer", 
+                            "index": "Tainer, JA"
+                        }
                     }, 
                     {
-                        "surname": "Iwai", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Iwai", 
+                            "index": "Iwai, S"
+                        }
                     }, 
                     {
-                        "surname": "Panda", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Panda", 
+                            "index": "Panda, S"
+                        }
                     }, 
                     {
-                        "surname": "Getzoff", 
-                        "given-names": "ED", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ED Getzoff", 
+                            "index": "Getzoff, ED"
+                        }
                     }
                 ], 
-                "full_article_title": "Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromes", 
-                "publication-type": "journal", 
+                "articleTitle": "Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromes", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "106", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.0809180106", 
-                "fpage": "6962", 
-                "year": "2009", 
-                "position": 12, 
-                "ref": "HitomiKDiTacchioLArvaiASYamamotoJKimS-TTodoTTainerJAIwaiSPandaSGetzoffED2009Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromesPNAS1066962696710.1073/pnas.0809180106", 
-                "id": "bib12"
+                "pages": {
+                    "first": "6962", 
+                    "last": "6967", 
+                    "range": "6962\u20136967"
+                }, 
+                "doi": "10.1073/pnas.0809180106"
             }, 
             {
-                "article_title": "The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signaling", 
-                "lpage": "548", 
-                "doi": "10.1158/1940-6207.CAPR-09-0127", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib13", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Hoffman", 
-                        "given-names": "AE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AE Hoffman", 
+                            "index": "Hoffman, AE"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Zheng", 
+                            "index": "Zheng, T"
+                        }
                     }, 
                     {
-                        "surname": "Yi", 
-                        "given-names": "CH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CH Yi", 
+                            "index": "Yi, CH"
+                        }
                     }, 
                     {
-                        "surname": "Stevens", 
-                        "given-names": "RG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RG Stevens", 
+                            "index": "Stevens, RG"
+                        }
                     }, 
                     {
-                        "surname": "Ba", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ba", 
+                            "index": "Ba, Y"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Zhang", 
+                            "index": "Zhang, Y"
+                        }
                     }, 
                     {
-                        "surname": "Leaderer", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Leaderer", 
+                            "index": "Leaderer, D"
+                        }
                     }, 
                     {
-                        "surname": "Holford", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Holford", 
+                            "index": "Holford, T"
+                        }
                     }, 
                     {
-                        "surname": "Hansen", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hansen", 
+                            "index": "Hansen, J"
+                        }
                     }, 
                     {
-                        "surname": "Zhu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Zhu", 
+                            "index": "Zhu, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signaling", 
-                "publication-type": "journal", 
+                "articleTitle": "The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signaling", 
+                "journal": {
+                    "name": [
+                        "Cancer Prevention Research"
+                    ]
+                }, 
                 "volume": "3", 
-                "source": "Cancer Prevention Research", 
-                "reference_id": "10.1158/1940-6207.CAPR-09-0127", 
-                "fpage": "539", 
-                "year": "2010", 
-                "position": 13, 
-                "ref": "HoffmanAEZhengTYiCHStevensRGBaYZhangYLeadererDHolfordTHansenJZhuY2010The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signalingCancer Prevention Research353954810.1158/1940-6207.CAPR-09-0127", 
-                "id": "bib13"
+                "pages": {
+                    "first": "539", 
+                    "last": "548", 
+                    "range": "539\u2013548"
+                }, 
+                "doi": "10.1158/1940-6207.CAPR-09-0127"
             }, 
             {
-                "article_title": "Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humans", 
-                "lpage": "1065", 
-                "doi": "10.1038/12502", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib14", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Campbell", 
-                        "given-names": "SS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SS Campbell", 
+                            "index": "Campbell, SS"
+                        }
                     }, 
                     {
-                        "surname": "Zone", 
-                        "given-names": "SE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Zone", 
+                            "index": "Zone, SE"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Cooper", 
+                            "index": "Cooper, F"
+                        }
                     }, 
                     {
-                        "surname": "DeSano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A DeSano", 
+                            "index": "DeSano, A"
+                        }
                     }, 
                     {
-                        "surname": "Murphy", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Murphy", 
+                            "index": "Murphy, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Jones", 
+                            "index": "Jones, B"
+                        }
                     }, 
                     {
-                        "surname": "Czajkowski", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Czajkowski", 
+                            "index": "Czajkowski, L"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humans", 
-                "publication-type": "journal", 
+                "articleTitle": "Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humans", 
+                "journal": {
+                    "name": [
+                        "Nature Medicine"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "Nature Medicine", 
-                "reference_id": "10.1038/12502", 
-                "fpage": "1062", 
-                "year": "1999", 
-                "position": 14, 
-                "ref": "JonesCRCampbellSSZoneSECooperFDeSanoAMurphyPJJonesBCzajkowskiLPt\u00e1cekLJ1999Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humansNature Medicine51062106510.1038/12502", 
-                "id": "bib14"
+                "pages": {
+                    "first": "1062", 
+                    "last": "1065", 
+                    "range": "1062\u20131065"
+                }, 
+                "doi": "10.1038/12502"
             }, 
             {
-                "article_title": "Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clock", 
-                "lpage": "302", 
-                "doi": "10.1016/j.cmet.2012.12.017", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib15", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Kaasik", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kaasik", 
+                            "index": "Kaasik, K"
+                        }
                     }, 
                     {
-                        "surname": "Kivim\u00e4e", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kivim\u00e4e", 
+                            "index": "Kivim\u00e4e, S"
+                        }
                     }, 
                     {
-                        "surname": "Allen", 
-                        "given-names": "JJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JJ Allen", 
+                            "index": "Allen, JJ"
+                        }
                     }, 
                     {
-                        "surname": "Chalkley", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Chalkley", 
+                            "index": "Chalkley, RJ"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Huang", 
+                            "index": "Huang, Y"
+                        }
                     }, 
                     {
-                        "surname": "Baer", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Baer", 
+                            "index": "Baer, K"
+                        }
                     }, 
                     {
-                        "surname": "Kissel", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kissel", 
+                            "index": "Kissel, H"
+                        }
                     }, 
                     {
-                        "surname": "Burlingame", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Burlingame", 
+                            "index": "Burlingame, AL"
+                        }
                     }, 
                     {
-                        "surname": "Shokat", 
-                        "given-names": "KM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KM Shokat", 
+                            "index": "Shokat, KM"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1\u010dek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1\u010dek", 
+                            "index": "Pt\u00e1\u010dek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clock", 
+                "journal": {
+                    "name": [
+                        "Cell Metabolism"
+                    ]
+                }, 
                 "volume": "17", 
-                "source": "Cell Metabolism", 
-                "reference_id": "10.1016/j.cmet.2012.12.017", 
-                "fpage": "291", 
-                "year": "2013", 
-                "position": 15, 
-                "ref": "KaasikKKivim\u00e4eSAllenJJChalkleyRJHuangYBaerKKisselHBurlingameALShokatKMPt\u00e1\u010dekLJFuYH2013Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clockCell Metabolism1729130210.1016/j.cmet.2012.12.017", 
-                "id": "bib15"
+                "pages": {
+                    "first": "291", 
+                    "last": "302", 
+                    "range": "291\u2013302"
+                }, 
+                "doi": "10.1016/j.cmet.2012.12.017"
             }, 
             {
-                "article_title": "CRY2 genetic variants associate with dysthymia", 
-                "doi": "10.1371/journal.pone.0071450", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e71450", 
+                "type": "journal", 
+                "id": "bib16", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Kovanen", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Kovanen", 
+                            "index": "Kovanen, L"
+                        }
                     }, 
                     {
-                        "surname": "Kaunisto", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kaunisto", 
+                            "index": "Kaunisto, M"
+                        }
                     }, 
                     {
-                        "surname": "Donner", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Donner", 
+                            "index": "Donner, K"
+                        }
                     }, 
                     {
-                        "surname": "Saarikoski", 
-                        "given-names": "ST", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ST Saarikoski", 
+                            "index": "Saarikoski, ST"
+                        }
                     }, 
                     {
-                        "surname": "Partonen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Partonen", 
+                            "index": "Partonen, T"
+                        }
                     }
                 ], 
-                "full_article_title": "CRY2 genetic variants associate with dysthymia", 
-                "publication-type": "journal", 
+                "articleTitle": "CRY2 genetic variants associate with dysthymia", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "8", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0071450", 
-                "year": "2013", 
-                "position": 16, 
-                "ref": "KovanenLKaunistoMDonnerKSaarikoskiSTPartonenT2013CRY2 genetic variants associate with dysthymiaPLoS One8e7145010.1371/journal.pone.0071450", 
-                "id": "bib16"
+                "pages": "e71450", 
+                "doi": "10.1371/journal.pone.0071450"
             }, 
             {
-                "article_title": "mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loop", 
-                "lpage": "205", 
-                "doi": "10.1016/S0092-8674(00)81014-4", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib17", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Kume", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kume", 
+                            "index": "Kume, K"
+                        }
                     }, 
                     {
-                        "surname": "Zylka", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Zylka", 
+                            "index": "Zylka, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Sriram", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sriram", 
+                            "index": "Sriram, S"
+                        }
                     }, 
                     {
-                        "surname": "Shearman", 
-                        "given-names": "LP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LP Shearman", 
+                            "index": "Shearman, LP"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Weaver", 
+                            "index": "Weaver, DR"
+                        }
                     }, 
                     {
-                        "surname": "Jin", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Jin", 
+                            "index": "Jin, X"
+                        }
                     }, 
                     {
-                        "surname": "Maywood", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Maywood", 
+                            "index": "Maywood, ES"
+                        }
                     }, 
                     {
-                        "surname": "Hastings", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Hastings", 
+                            "index": "Hastings, MH"
+                        }
                     }, 
                     {
-                        "surname": "Reppert", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Reppert", 
+                            "index": "Reppert, SM"
+                        }
                     }
                 ], 
-                "full_article_title": "mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loop", 
-                "publication-type": "journal", 
+                "articleTitle": "mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loop", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "98", 
-                "source": "Cell", 
-                "reference_id": "10.1016/S0092-8674(00)81014-4", 
-                "fpage": "193", 
-                "year": "1999", 
-                "position": 17, 
-                "ref": "KumeKZylkaMJSriramSShearmanLPWeaverDRJinXMaywoodESHastingsMHReppertSM1999mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loopCell9819320510.1016/S0092-8674(00)81014-4", 
-                "id": "bib17"
+                "pages": {
+                    "first": "193", 
+                    "last": "205", 
+                    "range": "193\u2013205"
+                }, 
+                "doi": "10.1016/S0092-8674(00)81014-4"
             }, 
             {
-                "article_title": "CRY2 is associated with depression", 
-                "doi": "10.1371/journal.pone.0009407", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e9407", 
+                "type": "journal", 
+                "id": "bib18", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Lavebratt", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lavebratt", 
+                            "index": "Lavebratt, C"
+                        }
                     }, 
                     {
-                        "surname": "Sj\u00f6holm", 
-                        "given-names": "LK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LK Sj\u00f6holm", 
+                            "index": "Sj\u00f6holm, LK"
+                        }
                     }, 
                     {
-                        "surname": "Soronen", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Soronen", 
+                            "index": "Soronen, P"
+                        }
                     }, 
                     {
-                        "surname": "Paunio", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Paunio", 
+                            "index": "Paunio, T"
+                        }
                     }, 
                     {
-                        "surname": "Vawter", 
-                        "given-names": "MP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MP Vawter", 
+                            "index": "Vawter, MP"
+                        }
                     }, 
                     {
-                        "surname": "Bunney", 
-                        "given-names": "WE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WE Bunney", 
+                            "index": "Bunney, WE"
+                        }
                     }, 
                     {
-                        "surname": "Adolfsson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Adolfsson", 
+                            "index": "Adolfsson, R"
+                        }
                     }, 
                     {
-                        "surname": "Forsell", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Forsell", 
+                            "index": "Forsell, Y"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Wu", 
+                            "index": "Wu, JC"
+                        }
                     }, 
                     {
-                        "surname": "Kelsoe", 
-                        "given-names": "JR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JR Kelsoe", 
+                            "index": "Kelsoe, JR"
+                        }
                     }, 
                     {
-                        "surname": "Partonen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Partonen", 
+                            "index": "Partonen, T"
+                        }
                     }, 
                     {
-                        "surname": "Schalling", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Schalling", 
+                            "index": "Schalling, M"
+                        }
                     }
                 ], 
-                "full_article_title": "CRY2 is associated with depression", 
-                "publication-type": "journal", 
+                "articleTitle": "CRY2 is associated with depression", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0009407", 
-                "year": "2010", 
-                "position": 18, 
-                "ref": "LavebrattCSj\u00f6holmLKSoronenPPaunioTVawterMPBunneyWEAdolfssonRForsellYWuJCKelsoeJRPartonenTSchallingM2010CRY2 is associated with depressionPLoS One5e940710.1371/journal.pone.0009407", 
-                "id": "bib18"
+                "pages": "e9407", 
+                "doi": "10.1371/journal.pone.0009407"
             }, 
             {
-                "article_title": "Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesia", 
-                "lpage": "518", 
-                "doi": "10.1172/JCI58470", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib19", 
+                "date": "2012", 
                 "authors": [
                     {
-                        "surname": "Lee", 
-                        "given-names": "HY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HY Lee", 
+                            "index": "Lee, HY"
+                        }
                     }, 
                     {
-                        "surname": "Nakayama", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Nakayama", 
+                            "index": "Nakayama, J"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Fan", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Fan", 
+                            "index": "Fan, X"
+                        }
                     }, 
                     {
-                        "surname": "Karouani", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Karouani", 
+                            "index": "Karouani, M"
+                        }
                     }, 
                     {
-                        "surname": "Shen", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Shen", 
+                            "index": "Shen, Y"
+                        }
                     }, 
                     {
-                        "surname": "Pothos", 
-                        "given-names": "EN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EN Pothos", 
+                            "index": "Pothos, EN"
+                        }
                     }, 
                     {
-                        "surname": "Hess", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ Hess", 
+                            "index": "Hess, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }, 
                     {
-                        "surname": "Edwards", 
-                        "given-names": "RH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RH Edwards", 
+                            "index": "Edwards, RH"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesia", 
-                "publication-type": "journal", 
+                "articleTitle": "Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesia", 
+                "journal": {
+                    "name": [
+                        "Journal of Clinical Investigation"
+                    ]
+                }, 
                 "volume": "122", 
-                "source": "Journal of Clinical Investigation", 
-                "reference_id": "10.1172/JCI58470", 
-                "fpage": "507", 
-                "year": "2012", 
-                "position": 19, 
-                "ref": "LeeHYNakayamaJXuYFanXKarouaniMShenYPothosENHessEJFuYHEdwardsRHPt\u00e1cekLJ2012Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesiaJournal of Clinical Investigation12250751810.1172/JCI58470", 
-                "id": "bib19"
+                "pages": {
+                    "first": "507", 
+                    "last": "518", 
+                    "range": "507\u2013518"
+                }, 
+                "doi": "10.1172/JCI58470"
             }, 
             {
-                "article_title": "The cryptochromes", 
-                "doi": "10.1186/gb-2005-6-5-220", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "220", 
+                "type": "journal", 
+                "id": "bib20", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Lin", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lin", 
+                            "index": "Lin, C"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }
                 ], 
-                "full_article_title": "The cryptochromes", 
-                "publication-type": "journal", 
+                "articleTitle": "The cryptochromes", 
+                "journal": {
+                    "name": [
+                        "Genome Biology"
+                    ]
+                }, 
                 "volume": "6", 
-                "source": "Genome Biology", 
-                "reference_id": "10.1186/gb-2005-6-5-220", 
-                "year": "2005", 
-                "position": 20, 
-                "ref": "LinCTodoT2005The cryptochromesGenome Biology622010.1186/gb-2005-6-5-220", 
-                "id": "bib20"
+                "pages": "220", 
+                "doi": "10.1186/gb-2005-6-5-220"
             }, 
             {
-                "article_title": "Positional syntenic cloning and functional characterization of the mammalian circadian mutation tau", 
-                "lpage": "491", 
-                "doi": "10.1126/science.288.5465.483", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib21", 
+                "date": "2000", 
                 "authors": [
                     {
-                        "surname": "Lowrey", 
-                        "given-names": "PL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PL Lowrey", 
+                            "index": "Lowrey, PL"
+                        }
                     }, 
                     {
-                        "surname": "Shimomura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shimomura", 
+                            "index": "Shimomura, K"
+                        }
                     }, 
                     {
-                        "surname": "Antoch", 
-                        "given-names": "MP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MP Antoch", 
+                            "index": "Antoch, MP"
+                        }
                     }, 
                     {
-                        "surname": "Yamazaki", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Yamazaki", 
+                            "index": "Yamazaki, S"
+                        }
                     }, 
                     {
-                        "surname": "Zemenides", 
-                        "given-names": "PD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PD Zemenides", 
+                            "index": "Zemenides, PD"
+                        }
                     }, 
                     {
-                        "surname": "Ralph", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Ralph", 
+                            "index": "Ralph, MR"
+                        }
                     }, 
                     {
-                        "surname": "Menaker", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Menaker", 
+                            "index": "Menaker, M"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Positional syntenic cloning and functional characterization of the mammalian circadian mutation tau", 
-                "publication-type": "journal", 
+                "articleTitle": "Positional syntenic cloning and functional characterization of the mammalian circadian mutation tau", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "288", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.288.5465.483", 
-                "fpage": "483", 
-                "year": "2000", 
-                "position": 21, 
-                "ref": "LowreyPLShimomuraKAntochMPYamazakiSZemenidesPDRalphMRMenakerMTakahashiJS2000Positional syntenic cloning and functional characterization of the mammalian circadian mutation tauScience28848349110.1126/science.288.5465.483", 
-                "id": "bib21"
+                "pages": {
+                    "first": "483", 
+                    "last": "491", 
+                    "range": "483\u2013491"
+                }, 
+                "doi": "10.1126/science.288.5465.483"
             }, 
             {
-                "article_title": "Mammalian circadian biology: elucidating genome-wide levels of temporal organization", 
-                "lpage": "441", 
-                "doi": "10.1146/annurev.genom.5.061903.175925", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib22", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Lowrey", 
-                        "given-names": "PL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PL Lowrey", 
+                            "index": "Lowrey, PL"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Mammalian circadian biology: elucidating genome-wide levels of temporal organization", 
-                "publication-type": "journal", 
+                "articleTitle": "Mammalian circadian biology: elucidating genome-wide levels of temporal organization", 
+                "journal": {
+                    "name": [
+                        "Annual Review of Genomics and Human Genetics"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "Annual Review of Genomics and Human Genetics", 
-                "reference_id": "10.1146/annurev.genom.5.061903.175925", 
-                "fpage": "407", 
-                "year": "2004", 
-                "position": 22, 
-                "ref": "LowreyPLTakahashiJS2004Mammalian circadian biology: elucidating genome-wide levels of temporal organizationAnnual Review of Genomics and Human Genetics540744110.1146/annurev.genom.5.061903.175925", 
-                "id": "bib22"
+                "pages": {
+                    "first": "407", 
+                    "last": "441", 
+                    "range": "407\u2013441"
+                }, 
+                "doi": "10.1146/annurev.genom.5.061903.175925"
             }, 
             {
-                "article_title": "Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligase", 
-                "lpage": "1419", 
-                "doi": "10.1038/cr.2013.136", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib23", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Nangle", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nangle", 
+                            "index": "Nangle, S"
+                        }
                     }, 
                     {
-                        "surname": "Xing", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Xing", 
+                            "index": "Xing, W"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Zheng", 
+                            "index": "Zheng, N"
+                        }
                     }
                 ], 
-                "full_article_title": "Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligase", 
-                "publication-type": "journal", 
+                "articleTitle": "Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligase", 
+                "journal": {
+                    "name": [
+                        "Cell Research"
+                    ]
+                }, 
                 "volume": "23", 
-                "source": "Cell Research", 
-                "reference_id": "10.1038/cr.2013.136", 
-                "fpage": "1417", 
-                "year": "2013", 
-                "position": 23, 
-                "ref": "NangleSXingWZhengN2013Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligaseCell Research231417141910.1038/cr.2013.136", 
-                "id": "bib23"
+                "pages": {
+                    "first": "1417", 
+                    "last": "1419", 
+                    "range": "1417\u20131419"
+                }, 
+                "doi": "10.1038/cr.2013.136"
             }, 
             {
-                "article_title": "Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clock", 
-                "lpage": "2534", 
-                "doi": "10.1126/science.286.5449.2531", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib24", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Okamura", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Okamura", 
+                            "index": "Okamura, H"
+                        }
                     }, 
                     {
-                        "surname": "Miyake", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Miyake", 
+                            "index": "Miyake, S"
+                        }
                     }, 
                     {
-                        "surname": "Sumi", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Sumi", 
+                            "index": "Sumi, Y"
+                        }
                     }, 
                     {
-                        "surname": "Yamaguchi", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Yamaguchi", 
+                            "index": "Yamaguchi, S"
+                        }
                     }, 
                     {
-                        "surname": "Yasui", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Yasui", 
+                            "index": "Yasui, A"
+                        }
                     }, 
                     {
-                        "surname": "Muijtjens", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Muijtjens", 
+                            "index": "Muijtjens, M"
+                        }
                     }, 
                     {
-                        "surname": "Hoeijmakers", 
-                        "given-names": "JH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JH Hoeijmakers", 
+                            "index": "Hoeijmakers, JH"
+                        }
                     }, 
                     {
-                        "surname": "van der Horst", 
-                        "given-names": "GT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GT van der Horst", 
+                            "index": "van der Horst, GT"
+                        }
                     }
                 ], 
-                "full_article_title": "Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clock", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "286", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.286.5449.2531", 
-                "fpage": "2531", 
-                "year": "1999", 
-                "position": 24, 
-                "ref": "OkamuraHMiyakeSSumiYYamaguchiSYasuiAMuijtjensMHoeijmakersJHvan der HorstGT1999Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clockScience2862531253410.1126/science.286.5449.2531", 
-                "id": "bib24"
+                "pages": {
+                    "first": "2531", 
+                    "last": "2534", 
+                    "range": "2531\u20132534"
+                }, 
+                "doi": "10.1126/science.286.5449.2531"
             }, 
             {
-                "article_title": "Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measures", 
-                "lpage": "604", 
-                "doi": "10.1111/jsr.12144", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib25", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "Parsons", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Parsons", 
+                            "index": "Parsons, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Lester", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Lester", 
+                            "index": "Lester, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Barclay", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Barclay", 
+                            "index": "Barclay, NL"
+                        }
                     }, 
                     {
-                        "surname": "Archer", 
-                        "given-names": "SN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SN Archer", 
+                            "index": "Archer, SN"
+                        }
                     }, 
                     {
-                        "surname": "Nolan", 
-                        "given-names": "PM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PM Nolan", 
+                            "index": "Nolan, PM"
+                        }
                     }, 
                     {
-                        "surname": "Eley", 
-                        "given-names": "TC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TC Eley", 
+                            "index": "Eley, TC"
+                        }
                     }, 
                     {
-                        "surname": "Gregory", 
-                        "given-names": "AM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AM Gregory", 
+                            "index": "Gregory, AM"
+                        }
                     }
                 ], 
-                "full_article_title": "Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measures", 
-                "publication-type": "journal", 
+                "articleTitle": "Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measures", 
+                "journal": {
+                    "name": [
+                        "Journal of Sleep Research"
+                    ]
+                }, 
                 "volume": "23", 
-                "source": "Journal of Sleep Research", 
-                "reference_id": "10.1111/jsr.12144", 
-                "fpage": "595", 
-                "year": "2014", 
-                "position": 25, 
-                "ref": "ParsonsMJLesterKJBarclayNLArcherSNNolanPMEleyTCGregoryAM2014Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measuresJournal of Sleep Research2359560410.1111/jsr.12144", 
-                "id": "bib25"
+                "pages": {
+                    "first": "595", 
+                    "last": "604", 
+                    "range": "595\u2013604"
+                }, 
+                "doi": "10.1111/jsr.12144"
             }, 
             {
-                "article_title": "Cryptochromes and circadian photoreception in animals", 
-                "lpage": "745", 
-                "doi": "10.1016/S0076-6879(05)93038-3", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib26", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Partch", 
-                        "given-names": "CL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CL Partch", 
+                            "index": "Partch, CL"
+                        }
                     }, 
                     {
-                        "surname": "Sancar", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sancar", 
+                            "index": "Sancar, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Cryptochromes and circadian photoreception in animals", 
-                "publication-type": "journal", 
+                "articleTitle": "Cryptochromes and circadian photoreception in animals", 
+                "journal": {
+                    "name": [
+                        "Methods in Enzymology"
+                    ]
+                }, 
                 "volume": "393", 
-                "source": "Methods in Enzymology", 
-                "reference_id": "10.1016/S0076-6879(05)93038-3", 
-                "fpage": "726", 
-                "year": "2005", 
-                "position": 26, 
-                "ref": "PartchCLSancarA2005Cryptochromes and circadian photoreception in animalsMethods in Enzymology39372674510.1016/S0076-6879(05)93038-3", 
-                "id": "bib26"
+                "pages": {
+                    "first": "726", 
+                    "last": "745", 
+                    "range": "726\u2013745"
+                }, 
+                "doi": "10.1016/S0076-6879(05)93038-3"
             }, 
             {
-                "article_title": "UCSF Chimera--a visualization system for exploratory research and analysis", 
-                "lpage": "1612", 
-                "doi": "10.1002/jcc.20084", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib27", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Pettersen", 
-                        "given-names": "EF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EF Pettersen", 
+                            "index": "Pettersen, EF"
+                        }
                     }, 
                     {
-                        "surname": "Goddard", 
-                        "given-names": "TD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD Goddard", 
+                            "index": "Goddard, TD"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "CC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CC Huang", 
+                            "index": "Huang, CC"
+                        }
                     }, 
                     {
-                        "surname": "Couch", 
-                        "given-names": "GS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GS Couch", 
+                            "index": "Couch, GS"
+                        }
                     }, 
                     {
-                        "surname": "Greenblatt", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Greenblatt", 
+                            "index": "Greenblatt, DM"
+                        }
                     }, 
                     {
-                        "surname": "Meng", 
-                        "given-names": "EC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EC Meng", 
+                            "index": "Meng, EC"
+                        }
                     }, 
                     {
-                        "surname": "Ferrin", 
-                        "given-names": "TE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TE Ferrin", 
+                            "index": "Ferrin, TE"
+                        }
                     }
                 ], 
-                "full_article_title": "UCSF Chimera--a visualization system for exploratory research and analysis", 
-                "publication-type": "journal", 
+                "articleTitle": "UCSF Chimera--a visualization system for exploratory research and analysis", 
+                "journal": {
+                    "name": [
+                        "Journal of Computational Chemistry"
+                    ]
+                }, 
                 "volume": "25", 
-                "source": "Journal of Computational Chemistry", 
-                "reference_id": "10.1002/jcc.20084", 
-                "fpage": "1605", 
-                "year": "2004", 
-                "position": 27, 
-                "ref": "PettersenEFGoddardTDHuangCCCouchGSGreenblattDMMengECFerrinTE2004UCSF Chimera--a visualization system for exploratory research and analysisJournal of Computational Chemistry251605161210.1002/jcc.20084", 
-                "id": "bib27"
+                "pages": {
+                    "first": "1605", 
+                    "last": "1612", 
+                    "range": "1605\u20131612"
+                }, 
+                "doi": "10.1002/jcc.20084"
             }, 
             {
-                "article_title": "Circadian rhythm sleep disorders", 
-                "lpage": "473", 
-                "doi": "10.1016/j.pop.2005.02.002", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib28", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Reid", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Reid", 
+                            "index": "Reid, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Burgess", 
-                        "given-names": "HJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HJ Burgess", 
+                            "index": "Burgess, HJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Circadian rhythm sleep disorders", 
-                "publication-type": "journal", 
+                "articleTitle": "Circadian rhythm sleep disorders", 
+                "journal": {
+                    "name": [
+                        "Primary Care"
+                    ]
+                }, 
                 "volume": "32", 
-                "source": "Primary Care", 
-                "reference_id": "10.1016/j.pop.2005.02.002", 
-                "fpage": "449", 
-                "year": "2005", 
-                "position": 28, 
-                "ref": "ReidKJBurgessHJ2005Circadian rhythm sleep disordersPrimary Care3244947310.1016/j.pop.2005.02.002", 
-                "id": "bib28"
+                "pages": {
+                    "first": "449", 
+                    "last": "473", 
+                    "range": "449\u2013473"
+                }, 
+                "doi": "10.1016/j.pop.2005.02.002"
             }, 
             {
-                "article_title": "Familial advanced sleep phase syndrome", 
-                "lpage": "1094", 
-                "doi": "10.1001/archneur.58.7.1089", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib29", 
+                "date": "2001", 
                 "authors": [
                     {
-                        "surname": "Reid", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Reid", 
+                            "index": "Reid, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Chang", 
-                        "given-names": "AM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AM Chang", 
+                            "index": "Chang, AM"
+                        }
                     }, 
                     {
-                        "surname": "Dubocovich", 
-                        "given-names": "ML", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ML Dubocovich", 
+                            "index": "Dubocovich, ML"
+                        }
                     }, 
                     {
-                        "surname": "Turek", 
-                        "given-names": "FW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FW Turek", 
+                            "index": "Turek, FW"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }, 
                     {
-                        "surname": "Zee", 
-                        "given-names": "PC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PC Zee", 
+                            "index": "Zee, PC"
+                        }
                     }
                 ], 
-                "full_article_title": "Familial advanced sleep phase syndrome", 
-                "publication-type": "journal", 
+                "articleTitle": "Familial advanced sleep phase syndrome", 
+                "journal": {
+                    "name": [
+                        "Archives of Neurology"
+                    ]
+                }, 
                 "volume": "58", 
-                "source": "Archives of Neurology", 
-                "reference_id": "10.1001/archneur.58.7.1089", 
-                "fpage": "1089", 
-                "year": "2001", 
-                "position": 29, 
-                "ref": "ReidKJChangAMDubocovichMLTurekFWTakahashiJSZeePC2001Familial advanced sleep phase syndromeArchives of Neurology581089109410.1001/archneur.58.7.1089", 
-                "id": "bib29"
+                "pages": {
+                    "first": "1089", 
+                    "last": "1094", 
+                    "range": "1089\u20131094"
+                }, 
+                "doi": "10.1001/archneur.58.7.1089"
             }, 
             {
-                "article_title": "Kinases and phosphatases in the mammalian circadian clock", 
-                "lpage": "1399", 
-                "doi": "10.1016/j.febslet.2011.02.038", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib30", 
+                "date": "2011", 
                 "authors": [
                     {
-                        "surname": "Reischl", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Reischl", 
+                            "index": "Reischl, S"
+                        }
                     }, 
                     {
-                        "surname": "Kramer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kramer", 
+                            "index": "Kramer, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Kinases and phosphatases in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Kinases and phosphatases in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "FEBS Letters"
+                    ]
+                }, 
                 "volume": "585", 
-                "source": "FEBS Letters", 
-                "reference_id": "10.1016/j.febslet.2011.02.038", 
-                "fpage": "1393", 
-                "year": "2011", 
-                "position": 30, 
-                "ref": "ReischlSKramerA2011Kinases and phosphatases in the mammalian circadian clockFEBS Letters5851393139910.1016/j.febslet.2011.02.038", 
-                "id": "bib30"
+                "pages": {
+                    "first": "1393", 
+                    "last": "1399", 
+                    "range": "1393\u20131399"
+                }, 
+                "doi": "10.1016/j.febslet.2011.02.038"
             }, 
             {
-                "article_title": "Molecular analysis of mammalian circadian rhythms", 
-                "lpage": "676", 
-                "doi": "10.1146/annurev.physiol.63.1.647", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib31", 
+                "date": "2001", 
                 "authors": [
                     {
-                        "surname": "Reppert", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Reppert", 
+                            "index": "Reppert, SM"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Weaver", 
+                            "index": "Weaver, DR"
+                        }
                     }
                 ], 
-                "full_article_title": "Molecular analysis of mammalian circadian rhythms", 
-                "publication-type": "journal", 
+                "articleTitle": "Molecular analysis of mammalian circadian rhythms", 
+                "journal": {
+                    "name": [
+                        "Annual Review of Physiology"
+                    ]
+                }, 
                 "volume": "63", 
-                "source": "Annual Review of Physiology", 
-                "reference_id": "10.1146/annurev.physiol.63.1.647", 
-                "fpage": "647", 
-                "year": "2001", 
-                "position": 31, 
-                "ref": "ReppertSMWeaverDR2001Molecular analysis of mammalian circadian rhythmsAnnual Review of Physiology6364767610.1146/annurev.physiol.63.1.647", 
-                "id": "bib31"
+                "pages": {
+                    "first": "647", 
+                    "last": "676", 
+                    "range": "647\u2013676"
+                }, 
+                "doi": "10.1146/annurev.physiol.63.1.647"
             }, 
             {
-                "article_title": "A marker for the end of adolescence", 
-                "lpage": "R1039", 
-                "doi": "10.1016/j.cub.2004.11.039", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib32", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Roenneberg", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Roenneberg", 
+                            "index": "Roenneberg, T"
+                        }
                     }, 
                     {
-                        "surname": "Kuehnle", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Kuehnle", 
+                            "index": "Kuehnle, T"
+                        }
                     }, 
                     {
-                        "surname": "Pramstaller", 
-                        "given-names": "PP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PP Pramstaller", 
+                            "index": "Pramstaller, PP"
+                        }
                     }, 
                     {
-                        "surname": "Ricken", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Ricken", 
+                            "index": "Ricken, J"
+                        }
                     }, 
                     {
-                        "surname": "Havel", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Havel", 
+                            "index": "Havel, M"
+                        }
                     }, 
                     {
-                        "surname": "Guth", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Guth", 
+                            "index": "Guth, A"
+                        }
                     }, 
                     {
-                        "surname": "Merrow", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Merrow", 
+                            "index": "Merrow, M"
+                        }
                     }
                 ], 
-                "full_article_title": "A marker for the end of adolescence", 
-                "publication-type": "journal", 
+                "articleTitle": "A marker for the end of adolescence", 
+                "journal": {
+                    "name": [
+                        "Current Biology"
+                    ]
+                }, 
                 "volume": "14", 
-                "source": "Current Biology", 
-                "reference_id": "10.1016/j.cub.2004.11.039", 
-                "fpage": "R1038", 
-                "year": "2004", 
-                "position": 32, 
-                "ref": "RoennebergTKuehnleTPramstallerPPRickenJHavelMGuthAMerrowM2004A marker for the end of adolescenceCurrent Biology14R1038R103910.1016/j.cub.2004.11.039", 
-                "id": "bib32"
+                "pages": {
+                    "first": "R1038", 
+                    "last": "R1039", 
+                    "range": "R1038\u2013R1039"
+                }, 
+                "doi": "10.1016/j.cub.2004.11.039"
             }, 
             {
-                "article_title": "Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinase", 
-                "lpage": "708", 
-                "doi": "10.1111/j.1356-9597.2004.00758.x", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib33", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Sanada", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Sanada", 
+                            "index": "Sanada, K"
+                        }
                     }, 
                     {
-                        "surname": "Harada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Harada", 
+                            "index": "Harada, Y"
+                        }
                     }, 
                     {
-                        "surname": "Sakai", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sakai", 
+                            "index": "Sakai, M"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinase", 
-                "publication-type": "journal", 
+                "articleTitle": "Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinase", 
+                "journal": {
+                    "name": [
+                        "Genes to Cells"
+                    ]
+                }, 
                 "volume": "9", 
-                "source": "Genes to Cells", 
-                "reference_id": "10.1111/j.1356-9597.2004.00758.x", 
-                "fpage": "697", 
-                "year": "2004", 
-                "position": 33, 
-                "ref": "SanadaKHaradaYSakaiMTodoTFukadaY2004Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinaseGenes to Cells969770810.1111/j.1356-9597.2004.00758.x", 
-                "id": "bib33"
+                "pages": {
+                    "first": "697", 
+                    "last": "708", 
+                    "range": "697\u2013708"
+                }, 
+                "doi": "10.1111/j.1356-9597.2004.00758.x"
             }, 
             {
-                "article_title": "Interacting molecular loops in the mammalian circadian clock", 
-                "lpage": "1019", 
-                "doi": "10.1126/science.288.5468.1013", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib34", 
+                "date": "2000", 
                 "authors": [
                     {
-                        "surname": "Shearman", 
-                        "given-names": "LP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LP Shearman", 
+                            "index": "Shearman, LP"
+                        }
                     }, 
                     {
-                        "surname": "Sriram", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sriram", 
+                            "index": "Sriram, S"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Weaver", 
+                            "index": "Weaver, DR"
+                        }
                     }, 
                     {
-                        "surname": "Maywood", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Maywood", 
+                            "index": "Maywood, ES"
+                        }
                     }, 
                     {
-                        "surname": "Chaves", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Chaves", 
+                            "index": "Chaves, I"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zheng", 
+                            "index": "Zheng, B"
+                        }
                     }, 
                     {
-                        "surname": "Kume", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kume", 
+                            "index": "Kume, K"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "CC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CC Lee", 
+                            "index": "Lee, CC"
+                        }
                     }, 
                     {
-                        "surname": "van der Horst", 
-                        "given-names": "GT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GT van der Horst", 
+                            "index": "van der Horst, GT"
+                        }
                     }, 
                     {
-                        "surname": "Hastings", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Hastings", 
+                            "index": "Hastings, MH"
+                        }
                     }, 
                     {
-                        "surname": "Reppert", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Reppert", 
+                            "index": "Reppert, SM"
+                        }
                     }
                 ], 
-                "full_article_title": "Interacting molecular loops in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Interacting molecular loops in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "288", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.288.5468.1013", 
-                "fpage": "1013", 
-                "year": "2000", 
-                "position": 34, 
-                "ref": "ShearmanLPSriramSWeaverDRMaywoodESChavesIZhengBKumeKLeeCCvan der HorstGTHastingsMHReppertSM2000Interacting molecular loops in the mammalian circadian clockScience2881013101910.1126/science.288.5468.1013", 
-                "id": "bib34"
+                "pages": {
+                    "first": "1013", 
+                    "last": "1019", 
+                    "range": "1013\u20131019"
+                }, 
+                "doi": "10.1126/science.288.5468.1013"
             }, 
             {
-                "article_title": "Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clock", 
-                "lpage": "4755", 
-                "doi": "10.1073/pnas.1302560110", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib35", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Shi", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Shi", 
+                            "index": "Shi, G"
+                        }
                     }, 
                     {
-                        "surname": "Xing", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Xing", 
+                            "index": "Xing, L"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Liu", 
+                            "index": "Liu, Z"
+                        }
                     }, 
                     {
-                        "surname": "Qu", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Qu", 
+                            "index": "Qu, Z"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Wu", 
+                            "index": "Wu, X"
+                        }
                     }, 
                     {
-                        "surname": "Dong", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Dong", 
+                            "index": "Dong, Z"
+                        }
                     }, 
                     {
-                        "surname": "Wang", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Wang", 
+                            "index": "Wang, X"
+                        }
                     }, 
                     {
-                        "surname": "Gao", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Gao", 
+                            "index": "Gao, X"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Huang", 
+                            "index": "Huang, M"
+                        }
                     }, 
                     {
-                        "surname": "Yan", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Yan", 
+                            "index": "Yan, J"
+                        }
                     }, 
                     {
-                        "surname": "Yang", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Yang", 
+                            "index": "Yang, L"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Liu", 
+                            "index": "Liu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Ptacek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Ptacek", 
+                            "index": "Ptacek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clock", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "110", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.1302560110", 
-                "fpage": "4750", 
-                "year": "2013", 
-                "position": 35, 
-                "ref": "ShiGXingLLiuZQuZWuXDongZWangXGaoXHuangMYanJYangLLiuYPtacekLJXuY2013Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clockPNAS1104750475510.1073/pnas.1302560110", 
-                "id": "bib35"
+                "pages": {
+                    "first": "4750", 
+                    "last": "4755", 
+                    "range": "4750\u20134755"
+                }, 
+                "doi": "10.1073/pnas.1302560110"
             }, 
             {
-                "article_title": "Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expression", 
-                "lpage": "1023", 
-                "doi": "10.1016/j.cell.2007.04.030", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib36", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Siepka", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Siepka", 
+                            "index": "Siepka, SM"
+                        }
                     }, 
                     {
-                        "surname": "Yoo", 
-                        "given-names": "SH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Yoo", 
+                            "index": "Yoo, SH"
+                        }
                     }, 
                     {
-                        "surname": "Park", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Park", 
+                            "index": "Park, J"
+                        }
                     }, 
                     {
-                        "surname": "Song", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Song", 
+                            "index": "Song, W"
+                        }
                     }, 
                     {
-                        "surname": "Kumar", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Kumar", 
+                            "index": "Kumar, V"
+                        }
                     }, 
                     {
-                        "surname": "Hu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Hu", 
+                            "index": "Hu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lee", 
+                            "index": "Lee, C"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expression", 
-                "publication-type": "journal", 
+                "articleTitle": "Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expression", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "129", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2007.04.030", 
-                "fpage": "1011", 
-                "year": "2007", 
-                "position": 36, 
-                "ref": "SiepkaSMYooSHParkJSongWKumarVHuYLeeCTakahashiJS2007Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expressionCell1291011102310.1016/j.cell.2007.04.030", 
-                "id": "bib36"
+                "pages": {
+                    "first": "1011", 
+                    "last": "1023", 
+                    "range": "1011\u20131023"
+                }, 
+                "doi": "10.1016/j.cell.2007.04.030"
             }, 
             {
-                "article_title": "CRY2 is associated with rapid cycling in bipolar disorder patients", 
-                "doi": "10.1371/journal.pone.0012632", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e12632", 
+                "type": "journal", 
+                "id": "bib37", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Sj\u00f6holm", 
-                        "given-names": "LK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LK Sj\u00f6holm", 
+                            "index": "Sj\u00f6holm, LK"
+                        }
                     }, 
                     {
-                        "surname": "Backlund", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Backlund", 
+                            "index": "Backlund, L"
+                        }
                     }, 
                     {
-                        "surname": "Cheteh", 
-                        "given-names": "EH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EH Cheteh", 
+                            "index": "Cheteh, EH"
+                        }
                     }, 
                     {
-                        "surname": "Ek", 
-                        "given-names": "IR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IR Ek", 
+                            "index": "Ek, IR"
+                        }
                     }, 
                     {
-                        "surname": "Fris\u00e9n", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Fris\u00e9n", 
+                            "index": "Fris\u00e9n, L"
+                        }
                     }, 
                     {
-                        "surname": "Schalling", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Schalling", 
+                            "index": "Schalling, M"
+                        }
                     }, 
                     {
-                        "surname": "Osby", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Osby", 
+                            "index": "Osby, U"
+                        }
                     }, 
                     {
-                        "surname": "Lavebratt", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lavebratt", 
+                            "index": "Lavebratt, C"
+                        }
                     }, 
                     {
-                        "surname": "Nikamo", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Nikamo", 
+                            "index": "Nikamo, P"
+                        }
                     }
                 ], 
-                "full_article_title": "CRY2 is associated with rapid cycling in bipolar disorder patients", 
-                "publication-type": "journal", 
+                "articleTitle": "CRY2 is associated with rapid cycling in bipolar disorder patients", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0012632", 
-                "year": "2010", 
-                "position": 37, 
-                "ref": "Sj\u00f6holmLKBacklundLChetehEHEkIRFris\u00e9nLSchallingMOsbyULavebrattCNikamoP2010CRY2 is associated with rapid cycling in bipolar disorder patientsPLoS One5e1263210.1371/journal.pone.0012632", 
-                "id": "bib37"
+                "pages": "e12632", 
+                "doi": "10.1371/journal.pone.0012632"
             }, 
             {
-                "article_title": "Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clock", 
-                "lpage": "2045", 
-                "doi": "10.1073/pnas.1323618111", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib38", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "St. John", 
-                        "given-names": "PC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PC St. John", 
+                            "index": "St. John, PC"
+                        }
                     }, 
                     {
-                        "surname": "Hirota", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirota", 
+                            "index": "Hirota, T"
+                        }
                     }, 
                     {
-                        "surname": "Kay", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Kay", 
+                            "index": "Kay, SA"
+                        }
                     }, 
                     {
-                        "surname": "Doyle", 
-                        "given-names": "FJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FJ Doyle", 
+                            "index": "Doyle, FJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "111", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.1323618111", 
-                "fpage": "2040", 
-                "year": "2014", 
-                "position": 38, 
-                "ref": "St. JohnPCHirotaTKaySADoyleFJ2014Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clockPNAS1112040204510.1073/pnas.1323618111", 
-                "id": "bib38"
+                "pages": {
+                    "first": "2040", 
+                    "last": "2045", 
+                    "range": "2040\u20132045"
+                }, 
+                "doi": "10.1073/pnas.1323618111"
             }, 
             {
-                "article_title": "A central role for ubiquitination within a circadian clock protein modification code", 
-                "doi": "10.3389/fnmol.2014.00069", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "69", 
+                "type": "journal", 
+                "id": "bib39", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "Stojkovic", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Stojkovic", 
+                            "index": "Stojkovic, K"
+                        }
                     }, 
                     {
-                        "surname": "Wing", 
-                        "given-names": "SS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SS Wing", 
+                            "index": "Wing, SS"
+                        }
                     }, 
                     {
-                        "surname": "Cermakian", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Cermakian", 
+                            "index": "Cermakian, N"
+                        }
                     }
                 ], 
-                "full_article_title": "A central role for ubiquitination within a circadian clock protein modification code", 
-                "publication-type": "journal", 
+                "articleTitle": "A central role for ubiquitination within a circadian clock protein modification code", 
+                "journal": {
+                    "name": [
+                        "Frontiers in Molecular Neuroscience"
+                    ]
+                }, 
                 "volume": "7", 
-                "source": "Frontiers in Molecular Neuroscience", 
-                "reference_id": "10.3389/fnmol.2014.00069", 
-                "year": "2014", 
-                "position": 39, 
-                "ref": "StojkovicKWingSSCermakianN2014A central role for ubiquitination within a circadian clock protein modification codeFrontiers in Molecular Neuroscience76910.3389/fnmol.2014.00069", 
-                "id": "bib39"
+                "pages": "69", 
+                "doi": "10.3389/fnmol.2014.00069"
             }, 
             {
-                "article_title": "Molecular neurobiology and genetics of circadian rhythms in mammals", 
-                "lpage": "553", 
-                "doi": "10.1146/annurev.ne.18.030195.002531", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib40", 
+                "date": "1995", 
                 "authors": [
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Molecular neurobiology and genetics of circadian rhythms in mammals", 
-                "publication-type": "journal", 
+                "articleTitle": "Molecular neurobiology and genetics of circadian rhythms in mammals", 
+                "journal": {
+                    "name": [
+                        "Annual Review of Neuroscience"
+                    ]
+                }, 
                 "volume": "18", 
-                "source": "Annual Review of Neuroscience", 
-                "reference_id": "10.1146/annurev.ne.18.030195.002531", 
-                "fpage": "531", 
-                "year": "1995", 
-                "position": 40, 
-                "ref": "TakahashiJS1995Molecular neurobiology and genetics of circadian rhythms in mammalsAnnual Review of Neuroscience1853155310.1146/annurev.ne.18.030195.002531", 
-                "id": "bib40"
+                "pages": {
+                    "first": "531", 
+                    "last": "553", 
+                    "range": "531\u2013553"
+                }, 
+                "doi": "10.1146/annurev.ne.18.030195.002531"
             }, 
             {
-                "article_title": "An hPer2 phosphorylation site mutation in familial advanced sleep phase syndrome", 
-                "lpage": "1043", 
-                "doi": "10.1126/science.1057499", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib41", 
+                "date": "2001", 
                 "authors": [
                     {
-                        "surname": "Toh", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Toh", 
+                            "index": "Toh, KL"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "He", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y He", 
+                            "index": "He, Y"
+                        }
                     }, 
                     {
-                        "surname": "Eide", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ Eide", 
+                            "index": "Eide, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Hinz", 
-                        "given-names": "WA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WA Hinz", 
+                            "index": "Hinz, WA"
+                        }
                     }, 
                     {
-                        "surname": "Virshup", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Virshup", 
+                            "index": "Virshup, DM"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "An hPer2 phosphorylation site mutation in familial advanced sleep phase syndrome", 
-                "publication-type": "journal", 
+                "articleTitle": "An hPer2 phosphorylation site mutation in familial advanced sleep phase syndrome", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "291", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1057499", 
-                "fpage": "1040", 
-                "year": "2001", 
-                "position": 41, 
-                "ref": "TohKLJonesCRHeYEideEJHinzWAVirshupDMPt\u00e1cekLJFuYH2001An hPer2 phosphorylation site mutation in familial advanced sleep phase syndromeScience2911040104310.1126/science.1057499", 
-                "id": "bib41"
+                "pages": {
+                    "first": "1040", 
+                    "last": "1043", 
+                    "range": "1040\u20131043"
+                }, 
+                "doi": "10.1126/science.1057499"
             }, 
             {
-                "article_title": "Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythms", 
-                "lpage": "630", 
-                "doi": "10.1038/19323", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib42", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "van der Horst", 
-                        "given-names": "GT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GT van der Horst", 
+                            "index": "van der Horst, GT"
+                        }
                     }, 
                     {
-                        "surname": "Muijtjens", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Muijtjens", 
+                            "index": "Muijtjens, M"
+                        }
                     }, 
                     {
-                        "surname": "Kobayashi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kobayashi", 
+                            "index": "Kobayashi, K"
+                        }
                     }, 
                     {
-                        "surname": "Takano", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Takano", 
+                            "index": "Takano, R"
+                        }
                     }, 
                     {
-                        "surname": "Kanno", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kanno", 
+                            "index": "Kanno, S"
+                        }
                     }, 
                     {
-                        "surname": "Takao", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Takao", 
+                            "index": "Takao, M"
+                        }
                     }, 
                     {
-                        "surname": "de Wit", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J de Wit", 
+                            "index": "de Wit, J"
+                        }
                     }, 
                     {
-                        "surname": "Verkerk", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Verkerk", 
+                            "index": "Verkerk, A"
+                        }
                     }, 
                     {
-                        "surname": "Eker", 
-                        "given-names": "AP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AP Eker", 
+                            "index": "Eker, AP"
+                        }
                     }, 
                     {
-                        "surname": "van Leenen", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D van Leenen", 
+                            "index": "van Leenen, D"
+                        }
                     }, 
                     {
-                        "surname": "Buijs", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Buijs", 
+                            "index": "Buijs, R"
+                        }
                     }, 
                     {
-                        "surname": "Bootsma", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Bootsma", 
+                            "index": "Bootsma, D"
+                        }
                     }, 
                     {
-                        "surname": "Hoeijmakers", 
-                        "given-names": "JH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JH Hoeijmakers", 
+                            "index": "Hoeijmakers, JH"
+                        }
                     }, 
                     {
-                        "surname": "Yasui", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Yasui", 
+                            "index": "Yasui, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythms", 
-                "publication-type": "journal", 
+                "articleTitle": "Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythms", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "398", 
-                "source": "Nature", 
-                "reference_id": "10.1038/19323", 
-                "fpage": "627", 
-                "year": "1999", 
-                "position": 42, 
-                "ref": "van der HorstGTMuijtjensMKobayashiKTakanoRKannoSTakaoMde WitJVerkerkAEkerAPvan LeenenDBuijsRBootsmaDHoeijmakersJHYasuiA1999Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythmsNature39862763010.1038/19323", 
-                "id": "bib42"
+                "pages": {
+                    "first": "627", 
+                    "last": "630", 
+                    "range": "627\u2013630"
+                }, 
+                "doi": "10.1038/19323"
             }, 
             {
-                "article_title": "Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2", 
-                "lpage": "12119", 
-                "doi": "10.1073/pnas.96.21.12114", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib43", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Vitaterna", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Vitaterna", 
+                            "index": "Vitaterna, MH"
+                        }
                     }, 
                     {
-                        "surname": "Selby", 
-                        "given-names": "CP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CP Selby", 
+                            "index": "Selby, CP"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Niwa", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Niwa", 
+                            "index": "Niwa, H"
+                        }
                     }, 
                     {
-                        "surname": "Thompson", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Thompson", 
+                            "index": "Thompson, C"
+                        }
                     }, 
                     {
-                        "surname": "Fruechte", 
-                        "given-names": "EM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Fruechte", 
+                            "index": "Fruechte, EM"
+                        }
                     }, 
                     {
-                        "surname": "Hitomi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Hitomi", 
+                            "index": "Hitomi, K"
+                        }
                     }, 
                     {
-                        "surname": "Thresher", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Thresher", 
+                            "index": "Thresher, RJ"
+                        }
                     }, 
                     {
-                        "surname": "Ishikawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Ishikawa", 
+                            "index": "Ishikawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Miyazaki", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Miyazaki", 
+                            "index": "Miyazaki, J"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }, 
                     {
-                        "surname": "Sancar", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sancar", 
+                            "index": "Sancar, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2", 
-                "publication-type": "journal", 
+                "articleTitle": "Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "96", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.96.21.12114", 
-                "fpage": "12114", 
-                "year": "1999", 
-                "position": 43, 
-                "ref": "VitaternaMHSelbyCPTodoTNiwaHThompsonCFruechteEMHitomiKThresherRJIshikawaTMiyazakiJTakahashiJSSancarA1999Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2PNAS96121141211910.1073/pnas.96.21.12114", 
-                "id": "bib43"
+                "pages": {
+                    "first": "12114", 
+                    "last": "12119", 
+                    "range": "12114\u201312119"
+                }, 
+                "doi": "10.1073/pnas.96.21.12114"
             }, 
             {
-                "article_title": "SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocket", 
-                "lpage": "68", 
-                "doi": "10.1038/nature11964", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib44", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Xing", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Xing", 
+                            "index": "Xing, W"
+                        }
                     }, 
                     {
-                        "surname": "Busino", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Busino", 
+                            "index": "Busino, L"
+                        }
                     }, 
                     {
-                        "surname": "Hinds", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Hinds", 
+                            "index": "Hinds, TR"
+                        }
                     }, 
                     {
-                        "surname": "Marionni", 
-                        "given-names": "ST", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ST Marionni", 
+                            "index": "Marionni, ST"
+                        }
                     }, 
                     {
-                        "surname": "Saifee", 
-                        "given-names": "NH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NH Saifee", 
+                            "index": "Saifee, NH"
+                        }
                     }, 
                     {
-                        "surname": "Bush", 
-                        "given-names": "MF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MF Bush", 
+                            "index": "Bush, MF"
+                        }
                     }, 
                     {
-                        "surname": "Pagano", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pagano", 
+                            "index": "Pagano, M"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Zheng", 
+                            "index": "Zheng, N"
+                        }
                     }
                 ], 
-                "full_article_title": "SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocket", 
-                "publication-type": "journal", 
+                "articleTitle": "SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocket", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "496", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature11964", 
-                "fpage": "64", 
-                "year": "2013", 
-                "position": 44, 
-                "ref": "XingWBusinoLHindsTRMarionniSTSaifeeNHBushMFPaganoMZhengN2013SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocketNature496646810.1038/nature11964", 
-                "id": "bib44"
+                "pages": {
+                    "first": "64", 
+                    "last": "68", 
+                    "range": "64\u201368"
+                }, 
+                "doi": "10.1038/nature11964"
             }, 
             {
-                "article_title": "Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndrome", 
-                "lpage": "644", 
-                "doi": "10.1038/nature03453", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib45", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Padiath", 
-                        "given-names": "QS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "QS Padiath", 
+                            "index": "Padiath, QS"
+                        }
                     }, 
                     {
-                        "surname": "Shapiro", 
-                        "given-names": "RE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RE Shapiro", 
+                            "index": "Shapiro, RE"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Wu", 
+                            "index": "Wu, SC"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Saigoh", 
+                            "index": "Saigoh, N"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Saigoh", 
+                            "index": "Saigoh, K"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndrome", 
-                "publication-type": "journal", 
+                "articleTitle": "Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndrome", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "434", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature03453", 
-                "fpage": "640", 
-                "year": "2005", 
-                "position": 45, 
-                "ref": "XuYPadiathQSShapiroREJonesCRWuSCSaigohNSaigohKPt\u00e1cekLJFuYH2005Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndromeNature43464064410.1038/nature03453", 
-                "id": "bib45"
+                "pages": {
+                    "first": "640", 
+                    "last": "644", 
+                    "range": "640\u2013644"
+                }, 
+                "doi": "10.1038/nature03453"
             }, 
             {
-                "article_title": "Modeling of a human circadian mutation yields insights into clock regulation by PER2", 
-                "lpage": "70", 
-                "doi": "10.1016/j.cell.2006.11.043", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib46", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Toh", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Toh", 
+                            "index": "Toh, KL"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Shin", 
-                        "given-names": "JY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JY Shin", 
+                            "index": "Shin, JY"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Modeling of a human circadian mutation yields insights into clock regulation by PER2", 
-                "publication-type": "journal", 
+                "articleTitle": "Modeling of a human circadian mutation yields insights into clock regulation by PER2", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "128", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2006.11.043", 
-                "fpage": "59", 
-                "year": "2007", 
-                "position": 46, 
-                "ref": "XuYTohKLJonesCRShinJYFuYHPt\u00e1cekLJ2007Modeling of a human circadian mutation yields insights into clock regulation by PER2Cell128597010.1016/j.cell.2006.11.043", 
-                "id": "bib46"
+                "pages": {
+                    "first": "59", 
+                    "last": "70", 
+                    "range": "59\u201370"
+                }, 
+                "doi": "10.1016/j.cell.2006.11.043"
             }, 
             {
-                "article_title": "Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasm", 
-                "lpage": "1105", 
-                "doi": "10.1016/j.cell.2013.01.055", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib47", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Yoo", 
-                        "given-names": "SH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Yoo", 
+                            "index": "Yoo, SH"
+                        }
                     }, 
                     {
-                        "surname": "Mohawk", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Mohawk", 
+                            "index": "Mohawk, JA"
+                        }
                     }, 
                     {
-                        "surname": "Siepka", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Siepka", 
+                            "index": "Siepka, SM"
+                        }
                     }, 
                     {
-                        "surname": "Shan", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Shan", 
+                            "index": "Shan, Y"
+                        }
                     }, 
                     {
-                        "surname": "Huh", 
-                        "given-names": "SK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SK Huh", 
+                            "index": "Huh, SK"
+                        }
                     }, 
                     {
-                        "surname": "Hong", 
-                        "given-names": "HK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HK Hong", 
+                            "index": "Hong, HK"
+                        }
                     }, 
                     {
-                        "surname": "Kornblum", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Kornblum", 
+                            "index": "Kornblum, I"
+                        }
                     }, 
                     {
-                        "surname": "Kumar", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Kumar", 
+                            "index": "Kumar, V"
+                        }
                     }, 
                     {
-                        "surname": "Koike", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Koike", 
+                            "index": "Koike, N"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Xu", 
+                            "index": "Xu, M"
+                        }
                     }, 
                     {
-                        "surname": "Nussbaum", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Nussbaum", 
+                            "index": "Nussbaum, J"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Liu", 
+                            "index": "Liu, X"
+                        }
                     }, 
                     {
-                        "surname": "Chen", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Chen", 
+                            "index": "Chen, Z"
+                        }
                     }, 
                     {
-                        "surname": "Chen", 
-                        "given-names": "ZJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ZJ Chen", 
+                            "index": "Chen, ZJ"
+                        }
                     }, 
                     {
-                        "surname": "Green", 
-                        "given-names": "CB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CB Green", 
+                            "index": "Green, CB"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasm", 
-                "publication-type": "journal", 
+                "articleTitle": "Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasm", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "152", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2013.01.055", 
-                "fpage": "1091", 
-                "year": "2013", 
-                "position": 47, 
-                "ref": "YooSHMohawkJASiepkaSMShanYHuhSKHongHKKornblumIKumarVKoikeNXuMNussbaumJLiuXChenZChenZJGreenCBTakahashiJS2013Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasmCell1521091110510.1016/j.cell.2013.01.055", 
-                "id": "bib47"
+                "pages": {
+                    "first": "1091", 
+                    "last": "1105", 
+                    "range": "1091\u20131105"
+                }, 
+                "doi": "10.1016/j.cell.2013.01.055"
             }, 
             {
-                "article_title": "PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissues", 
-                "lpage": "5346", 
-                "doi": "10.1073/pnas.0308709101", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib48", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Yoo", 
-                        "given-names": "S-H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S-H Yoo", 
+                            "index": "Yoo, S-H"
+                        }
                     }, 
                     {
-                        "surname": "Yamazaki", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Yamazaki", 
+                            "index": "Yamazaki, S"
+                        }
                     }, 
                     {
-                        "surname": "Lowrey", 
-                        "given-names": "PL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PL Lowrey", 
+                            "index": "Lowrey, PL"
+                        }
                     }, 
                     {
-                        "surname": "Shimomura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shimomura", 
+                            "index": "Shimomura, K"
+                        }
                     }, 
                     {
-                        "surname": "Ko", 
-                        "given-names": "CH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CH Ko", 
+                            "index": "Ko, CH"
+                        }
                     }, 
                     {
-                        "surname": "Buhr", 
-                        "given-names": "ED", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ED Buhr", 
+                            "index": "Buhr, ED"
+                        }
                     }, 
                     {
-                        "surname": "Siepka", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Siepka", 
+                            "index": "Siepka, SM"
+                        }
                     }, 
                     {
-                        "surname": "Hong", 
-                        "given-names": "H-K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H-K Hong", 
+                            "index": "Hong, H-K"
+                        }
                     }, 
                     {
-                        "surname": "Oh", 
-                        "given-names": "WJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WJ Oh", 
+                            "index": "Oh, WJ"
+                        }
                     }, 
                     {
-                        "surname": "Yoo", 
-                        "given-names": "OJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "OJ Yoo", 
+                            "index": "Yoo, OJ"
+                        }
                     }, 
                     {
-                        "surname": "Menaker", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Menaker", 
+                            "index": "Menaker, M"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissues", 
-                "publication-type": "journal", 
+                "articleTitle": "PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissues", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "101", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.0308709101", 
-                "fpage": "5339", 
-                "year": "2004", 
-                "position": 48, 
-                "ref": "YooS-HYamazakiSLowreyPLShimomuraKKoCHBuhrEDSiepkaSMHongH-KOhWJYooOJMenakerMTakahashiJS2004PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissuesPNAS1015339534610.1073/pnas.0308709101", 
-                "id": "bib48"
+                "pages": {
+                    "first": "5339", 
+                    "last": "5346", 
+                    "range": "5339\u20135346"
+                }, 
+                "doi": "10.1073/pnas.0308709101"
             }, 
             {
-                "article_title": "Roles of CLOCK phosphorylation in suppression of E-box-dependent transcription", 
-                "lpage": "3686", 
-                "doi": "10.1128/MCB.01864-08", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib49", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "Yoshitane", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Yoshitane", 
+                            "index": "Yoshitane, H"
+                        }
                     }, 
                     {
-                        "surname": "Takao", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Takao", 
+                            "index": "Takao, T"
+                        }
                     }, 
                     {
-                        "surname": "Satomi", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Satomi", 
+                            "index": "Satomi, Y"
+                        }
                     }, 
                     {
-                        "surname": "Du", 
-                        "given-names": "NH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NH Du", 
+                            "index": "Du, NH"
+                        }
                     }, 
                     {
-                        "surname": "Okano", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Okano", 
+                            "index": "Okano, T"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "Roles of CLOCK phosphorylation in suppression of E-box-dependent transcription", 
-                "publication-type": "journal", 
+                "articleTitle": "Roles of CLOCK phosphorylation in suppression of E-box-dependent transcription", 
+                "journal": {
+                    "name": [
+                        "Molecular and Cellular Biology"
+                    ]
+                }, 
                 "volume": "29", 
-                "source": "Molecular and Cellular Biology", 
-                "reference_id": "10.1128/MCB.01864-08", 
-                "fpage": "3675", 
-                "year": "2009", 
-                "position": 49, 
-                "ref": "YoshitaneHTakaoTSatomiYDuNHOkanoTFukadaY2009Roles of CLOCK phosphorylation in suppression of E-box-dependent transcriptionMolecular and Cellular Biology293675368610.1128/MCB.01864-08", 
-                "id": "bib49"
+                "pages": {
+                    "first": "3675", 
+                    "last": "3686", 
+                    "range": "3675\u20133686"
+                }, 
+                "doi": "10.1128/MCB.01864-08"
             }, 
             {
-                "article_title": "A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood trait", 
-                "lpage": "E1544", 
-                "doi": "10.1073/pnas.1600039113", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib50", 
+                "date": "2016", 
                 "authors": [
                     {
-                        "surname": "Zhang", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Zhang", 
+                            "index": "Zhang, L"
+                        }
                     }, 
                     {
-                        "surname": "Hirano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hirano", 
+                            "index": "Hirano, A"
+                        }
                     }, 
                     {
-                        "surname": "Hsu", 
-                        "given-names": "P-K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P-K Hsu", 
+                            "index": "Hsu, P-K"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Sakai", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Sakai", 
+                            "index": "Sakai, N"
+                        }
                     }, 
                     {
-                        "surname": "Okuro", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Okuro", 
+                            "index": "Okuro, M"
+                        }
                     }, 
                     {
-                        "surname": "McMahon", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T McMahon", 
+                            "index": "McMahon, T"
+                        }
                     }, 
                     {
-                        "surname": "Yamazaki", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Yamazaki", 
+                            "index": "Yamazaki, M"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Saigoh", 
+                            "index": "Saigoh, N"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Saigoh", 
+                            "index": "Saigoh, K"
+                        }
                     }, 
                     {
-                        "surname": "Lin", 
-                        "given-names": "S-T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S-T Lin", 
+                            "index": "Lin, S-T"
+                        }
                     }, 
                     {
-                        "surname": "Kaasik", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kaasik", 
+                            "index": "Kaasik, K"
+                        }
                     }, 
                     {
-                        "surname": "Nishino", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nishino", 
+                            "index": "Nishino, S"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1\u010dek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1\u010dek", 
+                            "index": "Pt\u00e1\u010dek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "Y-H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y-H Fu", 
+                            "index": "Fu, Y-H"
+                        }
                     }
                 ], 
-                "full_article_title": "A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood trait", 
-                "publication-type": "journal", 
+                "articleTitle": "A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood trait", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "113", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.1600039113", 
-                "fpage": "E1536", 
-                "year": "2016", 
-                "position": 50, 
-                "ref": "ZhangLHiranoAHsuP-KJonesCRSakaiNOkuroMMcMahonTYamazakiMXuYSaigohNSaigohKLinS-TKaasikKNishinoSPt\u00e1\u010dekLJFuY-H2016A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood traitPNAS113E1536E154410.1073/pnas.1600039113", 
-                "id": "bib50"
+                "pages": {
+                    "first": "E1536", 
+                    "last": "E1544", 
+                    "range": "E1536\u2013E1544"
+                }, 
+                "doi": "10.1073/pnas.1600039113"
             }, 
             {
-                "article_title": "Diversity of human clock genotypes and consequences", 
-                "lpage": "81", 
-                "doi": "10.1016/B978-0-12-396971-2.00003-8", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib51", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Zhang", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Zhang", 
+                            "index": "Zhang, L"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1\u010dek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1\u010dek", 
+                            "index": "Pt\u00e1\u010dek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "Diversity of human clock genotypes and consequences", 
-                "publication-type": "journal", 
+                "articleTitle": "Diversity of human clock genotypes and consequences", 
+                "journal": {
+                    "name": [
+                        "Progress in Molecular Biology and Translational Science"
+                    ]
+                }, 
                 "volume": "119", 
-                "source": "Progress in Molecular Biology and Translational Science", 
-                "reference_id": "10.1016/B978-0-12-396971-2.00003-8", 
-                "fpage": "51", 
-                "year": "2013", 
-                "position": 51, 
-                "ref": "ZhangLPt\u00e1\u010dekLJFuYH2013Diversity of human clock genotypes and consequencesProgress in Molecular Biology and Translational Science119518110.1016/B978-0-12-396971-2.00003-8", 
-                "id": "bib51"
+                "pages": {
+                    "first": "51", 
+                    "last": "81", 
+                    "range": "51\u201381"
+                }, 
+                "doi": "10.1016/B978-0-12-396971-2.00003-8"
+            }
+        ], 
+        "acknowledgements": [
+            {
+                "type": "paragraph", 
+                "text": "This work was funded by NIH grant GM079180 and HL059596 to LJP and Y-HF and by the William Bowes Neurogenetics Fund. The initial sequencing and analysis were performed at Lawrence Berkeley National Laboratory and at the United States Department of Energy Joint Genome Institute (Department of Energy Contract DE-AC02-05CH11231, University of California). The authors wish to thank Drs. Philip Kurien and Pei-Ken Hsu and Mr. David Wu for suggestions and critical reading of the manuscript. We thank Dr. Yoshitaka Fukada (University of Tokyo) for providing anti-CRY2 antibody and 0.3 kbp-m<italic>Bmal1</italic>-luc construct. LJP is an investigator of the Howard Hughes Medical Institute. AH was supported by the Japanese Society for the Promotion of Science (JSPS) and the Uehara Memorial Foundation (Japan)."
             }
         ], 
         "decisionLetter": {

--- a/src/publisher/tests/fixtures/ajson/elife-16695-v3.xml.json
+++ b/src/publisher/tests/fixtures/ajson/elife-16695-v3.xml.json
@@ -1613,4362 +1613,5821 @@
         ], 
         "references": [
             {
-                "article_title": "Individual differences in the amount and timing of salivary melatonin secretion", 
-                "doi": "10.1371/journal.pone.0003055", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e3055", 
+                "type": "journal", 
+                "id": "bib1", 
+                "date": "2008", 
                 "authors": [
                     {
-                        "surname": "Burgess", 
-                        "given-names": "HJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HJ Burgess", 
+                            "index": "Burgess, HJ"
+                        }
                     }, 
                     {
-                        "surname": "Fogg", 
-                        "given-names": "LF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LF Fogg", 
+                            "index": "Fogg, LF"
+                        }
                     }
                 ], 
-                "full_article_title": "Individual differences in the amount and timing of salivary melatonin secretion", 
-                "publication-type": "journal", 
+                "articleTitle": "Individual differences in the amount and timing of salivary melatonin secretion", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "3", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0003055", 
-                "year": "2008", 
-                "position": 1, 
-                "ref": "BurgessHJFoggLF2008Individual differences in the amount and timing of salivary melatonin secretionPLoS One3e305510.1371/journal.pone.0003055", 
-                "id": "bib1"
+                "pages": "e3055", 
+                "doi": "10.1371/journal.pone.0003055"
             }, 
             {
-                "article_title": "SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteins", 
-                "lpage": "904", 
-                "doi": "10.1126/science.1141194", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib2", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Busino", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Busino", 
+                            "index": "Busino, L"
+                        }
                     }, 
                     {
-                        "surname": "Bassermann", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Bassermann", 
+                            "index": "Bassermann, F"
+                        }
                     }, 
                     {
-                        "surname": "Maiolica", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Maiolica", 
+                            "index": "Maiolica, A"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lee", 
+                            "index": "Lee, C"
+                        }
                     }, 
                     {
-                        "surname": "Nolan", 
-                        "given-names": "PM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PM Nolan", 
+                            "index": "Nolan, PM"
+                        }
                     }, 
                     {
-                        "surname": "Godinho", 
-                        "given-names": "SI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SI Godinho", 
+                            "index": "Godinho, SI"
+                        }
                     }, 
                     {
-                        "surname": "Draetta", 
-                        "given-names": "GF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GF Draetta", 
+                            "index": "Draetta, GF"
+                        }
                     }, 
                     {
-                        "surname": "Pagano", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pagano", 
+                            "index": "Pagano, M"
+                        }
                     }
                 ], 
-                "full_article_title": "SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteins", 
-                "publication-type": "journal", 
+                "articleTitle": "SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteins", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "316", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1141194", 
-                "fpage": "900", 
-                "year": "2007", 
-                "position": 2, 
-                "ref": "BusinoLBassermannFMaiolicaALeeCNolanPMGodinhoSIDraettaGFPaganoM2007SCFFbxl3 controls the oscillation of the circadian clock by directing the degradation of cryptochrome proteinsScience31690090410.1126/science.1141194", 
-                "id": "bib2"
+                "pages": {
+                    "first": "900", 
+                    "last": "904", 
+                    "range": "900\u2013904"
+                }, 
+                "doi": "10.1126/science.1141194"
             }, 
             {
-                "article_title": "Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian function", 
-                "lpage": "1405", 
-                "doi": "10.1016/j.cell.2013.05.011", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib3", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Czarna", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Czarna", 
+                            "index": "Czarna, A"
+                        }
                     }, 
                     {
-                        "surname": "Berndt", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Berndt", 
+                            "index": "Berndt, A"
+                        }
                     }, 
                     {
-                        "surname": "Singh", 
-                        "given-names": "HR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HR Singh", 
+                            "index": "Singh, HR"
+                        }
                     }, 
                     {
-                        "surname": "Grudziecki", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Grudziecki", 
+                            "index": "Grudziecki, A"
+                        }
                     }, 
                     {
-                        "surname": "Ladurner", 
-                        "given-names": "AG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AG Ladurner", 
+                            "index": "Ladurner, AG"
+                        }
                     }, 
                     {
-                        "surname": "Timinszky", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Timinszky", 
+                            "index": "Timinszky, G"
+                        }
                     }, 
                     {
-                        "surname": "Kramer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kramer", 
+                            "index": "Kramer, A"
+                        }
                     }, 
                     {
-                        "surname": "Wolf", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Wolf", 
+                            "index": "Wolf, E"
+                        }
                     }
                 ], 
-                "full_article_title": "Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian function", 
-                "publication-type": "journal", 
+                "articleTitle": "Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian function", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "153", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2013.05.011", 
-                "fpage": "1394", 
-                "year": "2013", 
-                "position": 3, 
-                "ref": "CzarnaABerndtASinghHRGrudzieckiALadurnerAGTiminszkyGKramerAWolfE2013Structures of Drosophila cryptochrome and mouse cryptochrome1 provide insight into circadian functionCell1531394140510.1016/j.cell.2013.05.011", 
-                "id": "bib3"
+                "pages": {
+                    "first": "1394", 
+                    "last": "1405", 
+                    "range": "1394\u20131405"
+                }, 
+                "doi": "10.1016/j.cell.2013.05.011"
             }, 
             {
-                "article_title": "New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes risk", 
-                "lpage": "116", 
-                "doi": "10.1038/ng.520", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib4", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Dupuis", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Dupuis", 
+                            "index": "Dupuis, J"
+                        }
                     }, 
                     {
-                        "surname": "Langenberg", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Langenberg", 
+                            "index": "Langenberg, C"
+                        }
                     }, 
                     {
-                        "surname": "Prokopenko", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Prokopenko", 
+                            "index": "Prokopenko, I"
+                        }
                     }, 
                     {
-                        "surname": "Saxena", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Saxena", 
+                            "index": "Saxena, R"
+                        }
                     }, 
                     {
-                        "surname": "Soranzo", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Soranzo", 
+                            "index": "Soranzo, N"
+                        }
                     }, 
                     {
-                        "surname": "Jackson", 
-                        "given-names": "AU", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AU Jackson", 
+                            "index": "Jackson, AU"
+                        }
                     }, 
                     {
-                        "surname": "Wheeler", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Wheeler", 
+                            "index": "Wheeler, E"
+                        }
                     }, 
                     {
-                        "surname": "Glazer", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Glazer", 
+                            "index": "Glazer, NL"
+                        }
                     }, 
                     {
-                        "surname": "Bouatia-Naji", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Bouatia-Naji", 
+                            "index": "Bouatia-Naji, N"
+                        }
                     }, 
                     {
-                        "surname": "Gloyn", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Gloyn", 
+                            "index": "Gloyn, AL"
+                        }
                     }, 
                     {
-                        "surname": "Lindgren", 
-                        "given-names": "CM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Lindgren", 
+                            "index": "Lindgren, CM"
+                        }
                     }, 
                     {
-                        "surname": "M\u00e4gi", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R M\u00e4gi", 
+                            "index": "M\u00e4gi, R"
+                        }
                     }, 
                     {
-                        "surname": "Morris", 
-                        "given-names": "AP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AP Morris", 
+                            "index": "Morris, AP"
+                        }
                     }, 
                     {
-                        "surname": "Randall", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Randall", 
+                            "index": "Randall, J"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Johnson", 
+                            "index": "Johnson, T"
+                        }
                     }, 
                     {
-                        "surname": "Elliott", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Elliott", 
+                            "index": "Elliott, P"
+                        }
                     }, 
                     {
-                        "surname": "Rybin", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Rybin", 
+                            "index": "Rybin, D"
+                        }
                     }, 
                     {
-                        "surname": "Thorleifsson", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Thorleifsson", 
+                            "index": "Thorleifsson, G"
+                        }
                     }, 
                     {
-                        "surname": "Steinthorsdottir", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Steinthorsdottir", 
+                            "index": "Steinthorsdottir, V"
+                        }
                     }, 
                     {
-                        "surname": "Henneman", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Henneman", 
+                            "index": "Henneman, P"
+                        }
                     }, 
                     {
-                        "surname": "Grallert", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Grallert", 
+                            "index": "Grallert, H"
+                        }
                     }, 
                     {
-                        "surname": "Dehghan", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Dehghan", 
+                            "index": "Dehghan, A"
+                        }
                     }, 
                     {
-                        "surname": "Hottenga", 
-                        "given-names": "JJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JJ Hottenga", 
+                            "index": "Hottenga, JJ"
+                        }
                     }, 
                     {
-                        "surname": "Franklin", 
-                        "given-names": "CS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Franklin", 
+                            "index": "Franklin, CS"
+                        }
                     }, 
                     {
-                        "surname": "Navarro", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Navarro", 
+                            "index": "Navarro, P"
+                        }
                     }, 
                     {
-                        "surname": "Song", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Song", 
+                            "index": "Song, K"
+                        }
                     }, 
                     {
-                        "surname": "Goel", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Goel", 
+                            "index": "Goel, A"
+                        }
                     }, 
                     {
-                        "surname": "Perry", 
-                        "given-names": "JR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JR Perry", 
+                            "index": "Perry, JR"
+                        }
                     }, 
                     {
-                        "surname": "Egan", 
-                        "given-names": "JM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Egan", 
+                            "index": "Egan, JM"
+                        }
                     }, 
                     {
-                        "surname": "Lajunen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Lajunen", 
+                            "index": "Lajunen, T"
+                        }
                     }, 
                     {
-                        "surname": "Grarup", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Grarup", 
+                            "index": "Grarup, N"
+                        }
                     }, 
                     {
-                        "surname": "Spars\u00f8", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Spars\u00f8", 
+                            "index": "Spars\u00f8, T"
+                        }
                     }, 
                     {
-                        "surname": "Doney", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Doney", 
+                            "index": "Doney, A"
+                        }
                     }, 
                     {
-                        "surname": "Voight", 
-                        "given-names": "BF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BF Voight", 
+                            "index": "Voight, BF"
+                        }
                     }, 
                     {
-                        "surname": "Stringham", 
-                        "given-names": "HM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HM Stringham", 
+                            "index": "Stringham, HM"
+                        }
                     }, 
                     {
-                        "surname": "Li", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Li", 
+                            "index": "Li, M"
+                        }
                     }, 
                     {
-                        "surname": "Kanoni", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kanoni", 
+                            "index": "Kanoni, S"
+                        }
                     }, 
                     {
-                        "surname": "Shrader", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Shrader", 
+                            "index": "Shrader, P"
+                        }
                     }, 
                     {
-                        "surname": "Cavalcanti-Proen\u00e7a", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Cavalcanti-Proen\u00e7a", 
+                            "index": "Cavalcanti-Proen\u00e7a, C"
+                        }
                     }, 
                     {
-                        "surname": "Kumari", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kumari", 
+                            "index": "Kumari, M"
+                        }
                     }, 
                     {
-                        "surname": "Qi", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Qi", 
+                            "index": "Qi, L"
+                        }
                     }, 
                     {
-                        "surname": "Timpson", 
-                        "given-names": "NJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Timpson", 
+                            "index": "Timpson, NJ"
+                        }
                     }, 
                     {
-                        "surname": "Gieger", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Gieger", 
+                            "index": "Gieger, C"
+                        }
                     }, 
                     {
-                        "surname": "Zabena", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Zabena", 
+                            "index": "Zabena, C"
+                        }
                     }, 
                     {
-                        "surname": "Rocheleau", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Rocheleau", 
+                            "index": "Rocheleau, G"
+                        }
                     }, 
                     {
-                        "surname": "Ingelsson", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Ingelsson", 
+                            "index": "Ingelsson, E"
+                        }
                     }, 
                     {
-                        "surname": "An", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P An", 
+                            "index": "An, P"
+                        }
                     }, 
                     {
-                        "surname": "O'Connell", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J O'Connell", 
+                            "index": "O'Connell, J"
+                        }
                     }, 
                     {
-                        "surname": "Luan", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Luan", 
+                            "index": "Luan, J"
+                        }
                     }, 
                     {
-                        "surname": "Elliott", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Elliott", 
+                            "index": "Elliott, A"
+                        }
                     }, 
                     {
-                        "surname": "McCarroll", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA McCarroll", 
+                            "index": "McCarroll, SA"
+                        }
                     }, 
                     {
-                        "surname": "Payne", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Payne", 
+                            "index": "Payne, F"
+                        }
                     }, 
                     {
-                        "surname": "Roccasecca", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Roccasecca", 
+                            "index": "Roccasecca, RM"
+                        }
                     }, 
                     {
-                        "surname": "Pattou", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Pattou", 
+                            "index": "Pattou, F"
+                        }
                     }, 
                     {
-                        "surname": "Sethupathy", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Sethupathy", 
+                            "index": "Sethupathy, P"
+                        }
                     }, 
                     {
-                        "surname": "Ardlie", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Ardlie", 
+                            "index": "Ardlie, K"
+                        }
                     }, 
                     {
-                        "surname": "Ariyurek", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ariyurek", 
+                            "index": "Ariyurek, Y"
+                        }
                     }, 
                     {
-                        "surname": "Balkau", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Balkau", 
+                            "index": "Balkau, B"
+                        }
                     }, 
                     {
-                        "surname": "Barter", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Barter", 
+                            "index": "Barter, P"
+                        }
                     }, 
                     {
-                        "surname": "Beilby", 
-                        "given-names": "JP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JP Beilby", 
+                            "index": "Beilby, JP"
+                        }
                     }, 
                     {
-                        "surname": "Ben-Shlomo", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ben-Shlomo", 
+                            "index": "Ben-Shlomo, Y"
+                        }
                     }, 
                     {
-                        "surname": "Benediktsson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Benediktsson", 
+                            "index": "Benediktsson, R"
+                        }
                     }, 
                     {
-                        "surname": "Bennett", 
-                        "given-names": "AJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AJ Bennett", 
+                            "index": "Bennett, AJ"
+                        }
                     }, 
                     {
-                        "surname": "Bergmann", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Bergmann", 
+                            "index": "Bergmann, S"
+                        }
                     }, 
                     {
-                        "surname": "Bochud", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Bochud", 
+                            "index": "Bochud, M"
+                        }
                     }, 
                     {
-                        "surname": "Boerwinkle", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Boerwinkle", 
+                            "index": "Boerwinkle, E"
+                        }
                     }, 
                     {
-                        "surname": "Bonnefond", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Bonnefond", 
+                            "index": "Bonnefond, A"
+                        }
                     }, 
                     {
-                        "surname": "Bonnycastle", 
-                        "given-names": "LL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LL Bonnycastle", 
+                            "index": "Bonnycastle, LL"
+                        }
                     }, 
                     {
-                        "surname": "Borch-Johnsen", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Borch-Johnsen", 
+                            "index": "Borch-Johnsen, K"
+                        }
                     }, 
                     {
-                        "surname": "B\u00f6ttcher", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y B\u00f6ttcher", 
+                            "index": "B\u00f6ttcher, Y"
+                        }
                     }, 
                     {
-                        "surname": "Brunner", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Brunner", 
+                            "index": "Brunner, E"
+                        }
                     }, 
                     {
-                        "surname": "Bumpstead", 
-                        "given-names": "SJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SJ Bumpstead", 
+                            "index": "Bumpstead, SJ"
+                        }
                     }, 
                     {
-                        "surname": "Charpentier", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Charpentier", 
+                            "index": "Charpentier, G"
+                        }
                     }, 
                     {
-                        "surname": "Chen", 
-                        "given-names": "YD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YD Chen", 
+                            "index": "Chen, YD"
+                        }
                     }, 
                     {
-                        "surname": "Chines", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Chines", 
+                            "index": "Chines, P"
+                        }
                     }, 
                     {
-                        "surname": "Clarke", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Clarke", 
+                            "index": "Clarke, R"
+                        }
                     }, 
                     {
-                        "surname": "Coin", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Coin", 
+                            "index": "Coin, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "MN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MN Cooper", 
+                            "index": "Cooper, MN"
+                        }
                     }, 
                     {
-                        "surname": "Cornelis", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Cornelis", 
+                            "index": "Cornelis, M"
+                        }
                     }, 
                     {
-                        "surname": "Crawford", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Crawford", 
+                            "index": "Crawford, G"
+                        }
                     }, 
                     {
-                        "surname": "Crisponi", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Crisponi", 
+                            "index": "Crisponi, L"
+                        }
                     }, 
                     {
-                        "surname": "Day", 
-                        "given-names": "IN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IN Day", 
+                            "index": "Day, IN"
+                        }
                     }, 
                     {
-                        "surname": "de Geus", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ de Geus", 
+                            "index": "de Geus, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Delplanque", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Delplanque", 
+                            "index": "Delplanque, J"
+                        }
                     }, 
                     {
-                        "surname": "Dina", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Dina", 
+                            "index": "Dina, C"
+                        }
                     }, 
                     {
-                        "surname": "Erdos", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Erdos", 
+                            "index": "Erdos, MR"
+                        }
                     }, 
                     {
-                        "surname": "Fedson", 
-                        "given-names": "AC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AC Fedson", 
+                            "index": "Fedson, AC"
+                        }
                     }, 
                     {
-                        "surname": "Fischer-Rosinsky", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Fischer-Rosinsky", 
+                            "index": "Fischer-Rosinsky, A"
+                        }
                     }, 
                     {
-                        "surname": "Forouhi", 
-                        "given-names": "NG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NG Forouhi", 
+                            "index": "Forouhi, NG"
+                        }
                     }, 
                     {
-                        "surname": "Fox", 
-                        "given-names": "CS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Fox", 
+                            "index": "Fox, CS"
+                        }
                     }, 
                     {
-                        "surname": "Frants", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Frants", 
+                            "index": "Frants, R"
+                        }
                     }, 
                     {
-                        "surname": "Franzosi", 
-                        "given-names": "MG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MG Franzosi", 
+                            "index": "Franzosi, MG"
+                        }
                     }, 
                     {
-                        "surname": "Galan", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Galan", 
+                            "index": "Galan, P"
+                        }
                     }, 
                     {
-                        "surname": "Goodarzi", 
-                        "given-names": "MO", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MO Goodarzi", 
+                            "index": "Goodarzi, MO"
+                        }
                     }, 
                     {
-                        "surname": "Graessler", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Graessler", 
+                            "index": "Graessler, J"
+                        }
                     }, 
                     {
-                        "surname": "Groves", 
-                        "given-names": "CJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CJ Groves", 
+                            "index": "Groves, CJ"
+                        }
                     }, 
                     {
-                        "surname": "Grundy", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Grundy", 
+                            "index": "Grundy, S"
+                        }
                     }, 
                     {
-                        "surname": "Gwilliam", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Gwilliam", 
+                            "index": "Gwilliam, R"
+                        }
                     }, 
                     {
-                        "surname": "Gyllensten", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Gyllensten", 
+                            "index": "Gyllensten, U"
+                        }
                     }, 
                     {
-                        "surname": "Hadjadj", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Hadjadj", 
+                            "index": "Hadjadj, S"
+                        }
                     }, 
                     {
-                        "surname": "Hallmans", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Hallmans", 
+                            "index": "Hallmans, G"
+                        }
                     }, 
                     {
-                        "surname": "Hammond", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Hammond", 
+                            "index": "Hammond, N"
+                        }
                     }, 
                     {
-                        "surname": "Han", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Han", 
+                            "index": "Han, X"
+                        }
                     }, 
                     {
-                        "surname": "Hartikainen", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Hartikainen", 
+                            "index": "Hartikainen, AL"
+                        }
                     }, 
                     {
-                        "surname": "Hassanali", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Hassanali", 
+                            "index": "Hassanali, N"
+                        }
                     }, 
                     {
-                        "surname": "Hayward", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Hayward", 
+                            "index": "Hayward, C"
+                        }
                     }, 
                     {
-                        "surname": "Heath", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Heath", 
+                            "index": "Heath, SC"
+                        }
                     }, 
                     {
-                        "surname": "Hercberg", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Hercberg", 
+                            "index": "Hercberg, S"
+                        }
                     }, 
                     {
-                        "surname": "Herder", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Herder", 
+                            "index": "Herder, C"
+                        }
                     }, 
                     {
-                        "surname": "Hicks", 
-                        "given-names": "AA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AA Hicks", 
+                            "index": "Hicks, AA"
+                        }
                     }, 
                     {
-                        "surname": "Hillman", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Hillman", 
+                            "index": "Hillman, DR"
+                        }
                     }, 
                     {
-                        "surname": "Hingorani", 
-                        "given-names": "AD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AD Hingorani", 
+                            "index": "Hingorani, AD"
+                        }
                     }, 
                     {
-                        "surname": "Hofman", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hofman", 
+                            "index": "Hofman, A"
+                        }
                     }, 
                     {
-                        "surname": "Hui", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hui", 
+                            "index": "Hui, J"
+                        }
                     }, 
                     {
-                        "surname": "Hung", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hung", 
+                            "index": "Hung, J"
+                        }
                     }, 
                     {
-                        "surname": "Isomaa", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Isomaa", 
+                            "index": "Isomaa, B"
+                        }
                     }, 
                     {
-                        "surname": "Johnson", 
-                        "given-names": "PR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PR Johnson", 
+                            "index": "Johnson, PR"
+                        }
                     }, 
                     {
-                        "surname": "J\u00f8rgensen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T J\u00f8rgensen", 
+                            "index": "J\u00f8rgensen, T"
+                        }
                     }, 
                     {
-                        "surname": "Jula", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Jula", 
+                            "index": "Jula, A"
+                        }
                     }, 
                     {
-                        "surname": "Kaakinen", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kaakinen", 
+                            "index": "Kaakinen, M"
+                        }
                     }, 
                     {
-                        "surname": "Kaprio", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kaprio", 
+                            "index": "Kaprio, J"
+                        }
                     }, 
                     {
-                        "surname": "Kesaniemi", 
-                        "given-names": "YA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YA Kesaniemi", 
+                            "index": "Kesaniemi, YA"
+                        }
                     }, 
                     {
-                        "surname": "Kivimaki", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kivimaki", 
+                            "index": "Kivimaki, M"
+                        }
                     }, 
                     {
-                        "surname": "Knight", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Knight", 
+                            "index": "Knight, B"
+                        }
                     }, 
                     {
-                        "surname": "Koskinen", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Koskinen", 
+                            "index": "Koskinen, S"
+                        }
                     }, 
                     {
-                        "surname": "Kovacs", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Kovacs", 
+                            "index": "Kovacs, P"
+                        }
                     }, 
                     {
-                        "surname": "Kyvik", 
-                        "given-names": "KO", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KO Kyvik", 
+                            "index": "Kyvik, KO"
+                        }
                     }, 
                     {
-                        "surname": "Lathrop", 
-                        "given-names": "GM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GM Lathrop", 
+                            "index": "Lathrop, GM"
+                        }
                     }, 
                     {
-                        "surname": "Lawlor", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Lawlor", 
+                            "index": "Lawlor, DA"
+                        }
                     }, 
                     {
-                        "surname": "Le Bacquer", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Le Bacquer", 
+                            "index": "Le Bacquer, O"
+                        }
                     }, 
                     {
-                        "surname": "Lecoeur", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lecoeur", 
+                            "index": "Lecoeur, C"
+                        }
                     }, 
                     {
-                        "surname": "Li", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Li", 
+                            "index": "Li, Y"
+                        }
                     }, 
                     {
-                        "surname": "Lyssenko", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Lyssenko", 
+                            "index": "Lyssenko, V"
+                        }
                     }, 
                     {
-                        "surname": "Mahley", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Mahley", 
+                            "index": "Mahley, R"
+                        }
                     }, 
                     {
-                        "surname": "Mangino", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Mangino", 
+                            "index": "Mangino, M"
+                        }
                     }, 
                     {
-                        "surname": "Manning", 
-                        "given-names": "AK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AK Manning", 
+                            "index": "Manning, AK"
+                        }
                     }, 
                     {
-                        "surname": "Mart\u00ednez-Larrad", 
-                        "given-names": "MT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MT Mart\u00ednez-Larrad", 
+                            "index": "Mart\u00ednez-Larrad, MT"
+                        }
                     }, 
                     {
-                        "surname": "McAteer", 
-                        "given-names": "JB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JB McAteer", 
+                            "index": "McAteer, JB"
+                        }
                     }, 
                     {
-                        "surname": "McCulloch", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ McCulloch", 
+                            "index": "McCulloch, LJ"
+                        }
                     }, 
                     {
-                        "surname": "McPherson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R McPherson", 
+                            "index": "McPherson, R"
+                        }
                     }, 
                     {
-                        "surname": "Meisinger", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Meisinger", 
+                            "index": "Meisinger, C"
+                        }
                     }, 
                     {
-                        "surname": "Melzer", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Melzer", 
+                            "index": "Melzer, D"
+                        }
                     }, 
                     {
-                        "surname": "Meyre", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Meyre", 
+                            "index": "Meyre, D"
+                        }
                     }, 
                     {
-                        "surname": "Mitchell", 
-                        "given-names": "BD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BD Mitchell", 
+                            "index": "Mitchell, BD"
+                        }
                     }, 
                     {
-                        "surname": "Morken", 
-                        "given-names": "MA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Morken", 
+                            "index": "Morken, MA"
+                        }
                     }, 
                     {
-                        "surname": "Mukherjee", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Mukherjee", 
+                            "index": "Mukherjee, S"
+                        }
                     }, 
                     {
-                        "surname": "Naitza", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Naitza", 
+                            "index": "Naitza, S"
+                        }
                     }, 
                     {
-                        "surname": "Narisu", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Narisu", 
+                            "index": "Narisu, N"
+                        }
                     }, 
                     {
-                        "surname": "Neville", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Neville", 
+                            "index": "Neville, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Oostra", 
-                        "given-names": "BA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BA Oostra", 
+                            "index": "Oostra, BA"
+                        }
                     }, 
                     {
-                        "surname": "Orr\u00f9", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Orr\u00f9", 
+                            "index": "Orr\u00f9, M"
+                        }
                     }, 
                     {
-                        "surname": "Pakyz", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Pakyz", 
+                            "index": "Pakyz, R"
+                        }
                     }, 
                     {
-                        "surname": "Palmer", 
-                        "given-names": "CN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CN Palmer", 
+                            "index": "Palmer, CN"
+                        }
                     }, 
                     {
-                        "surname": "Paolisso", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Paolisso", 
+                            "index": "Paolisso, G"
+                        }
                     }, 
                     {
-                        "surname": "Pattaro", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Pattaro", 
+                            "index": "Pattaro, C"
+                        }
                     }, 
                     {
-                        "surname": "Pearson", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Pearson", 
+                            "index": "Pearson, D"
+                        }
                     }, 
                     {
-                        "surname": "Peden", 
-                        "given-names": "JF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JF Peden", 
+                            "index": "Peden, JF"
+                        }
                     }, 
                     {
-                        "surname": "Pedersen", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Pedersen", 
+                            "index": "Pedersen, NL"
+                        }
                     }, 
                     {
-                        "surname": "Perola", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Perola", 
+                            "index": "Perola, M"
+                        }
                     }, 
                     {
-                        "surname": "Pfeiffer", 
-                        "given-names": "AF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AF Pfeiffer", 
+                            "index": "Pfeiffer, AF"
+                        }
                     }, 
                     {
-                        "surname": "Pichler", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Pichler", 
+                            "index": "Pichler, I"
+                        }
                     }, 
                     {
-                        "surname": "Polasek", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Polasek", 
+                            "index": "Polasek, O"
+                        }
                     }, 
                     {
-                        "surname": "Posthuma", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Posthuma", 
+                            "index": "Posthuma, D"
+                        }
                     }, 
                     {
-                        "surname": "Potter", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Potter", 
+                            "index": "Potter, SC"
+                        }
                     }, 
                     {
-                        "surname": "Pouta", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Pouta", 
+                            "index": "Pouta, A"
+                        }
                     }, 
                     {
-                        "surname": "Province", 
-                        "given-names": "MA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Province", 
+                            "index": "Province, MA"
+                        }
                     }, 
                     {
-                        "surname": "Psaty", 
-                        "given-names": "BM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BM Psaty", 
+                            "index": "Psaty, BM"
+                        }
                     }, 
                     {
-                        "surname": "Rathmann", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Rathmann", 
+                            "index": "Rathmann, W"
+                        }
                     }, 
                     {
-                        "surname": "Rayner", 
-                        "given-names": "NW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NW Rayner", 
+                            "index": "Rayner, NW"
+                        }
                     }, 
                     {
-                        "surname": "Rice", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Rice", 
+                            "index": "Rice, K"
+                        }
                     }, 
                     {
-                        "surname": "Ripatti", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Ripatti", 
+                            "index": "Ripatti, S"
+                        }
                     }, 
                     {
-                        "surname": "Rivadeneira", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Rivadeneira", 
+                            "index": "Rivadeneira, F"
+                        }
                     }, 
                     {
-                        "surname": "Roden", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Roden", 
+                            "index": "Roden, M"
+                        }
                     }, 
                     {
-                        "surname": "Rolandsson", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Rolandsson", 
+                            "index": "Rolandsson, O"
+                        }
                     }, 
                     {
-                        "surname": "Sandbaek", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sandbaek", 
+                            "index": "Sandbaek, A"
+                        }
                     }, 
                     {
-                        "surname": "Sandhu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sandhu", 
+                            "index": "Sandhu, M"
+                        }
                     }, 
                     {
-                        "surname": "Sanna", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sanna", 
+                            "index": "Sanna, S"
+                        }
                     }, 
                     {
-                        "surname": "Sayer", 
-                        "given-names": "AA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AA Sayer", 
+                            "index": "Sayer, AA"
+                        }
                     }, 
                     {
-                        "surname": "Scheet", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Scheet", 
+                            "index": "Scheet, P"
+                        }
                     }, 
                     {
-                        "surname": "Scott", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Scott", 
+                            "index": "Scott, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Seedorf", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Seedorf", 
+                            "index": "Seedorf, U"
+                        }
                     }, 
                     {
-                        "surname": "Sharp", 
-                        "given-names": "SJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SJ Sharp", 
+                            "index": "Sharp, SJ"
+                        }
                     }, 
                     {
-                        "surname": "Shields", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Shields", 
+                            "index": "Shields, B"
+                        }
                     }, 
                     {
-                        "surname": "Sigurethsson", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Sigurethsson", 
+                            "index": "Sigurethsson, G"
+                        }
                     }, 
                     {
-                        "surname": "Sijbrands", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ Sijbrands", 
+                            "index": "Sijbrands, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Silveira", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Silveira", 
+                            "index": "Silveira, A"
+                        }
                     }, 
                     {
-                        "surname": "Simpson", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Simpson", 
+                            "index": "Simpson, L"
+                        }
                     }, 
                     {
-                        "surname": "Singleton", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Singleton", 
+                            "index": "Singleton, A"
+                        }
                     }, 
                     {
-                        "surname": "Smith", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Smith", 
+                            "index": "Smith, NL"
+                        }
                     }, 
                     {
-                        "surname": "Sovio", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Sovio", 
+                            "index": "Sovio, U"
+                        }
                     }, 
                     {
-                        "surname": "Swift", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Swift", 
+                            "index": "Swift, A"
+                        }
                     }, 
                     {
-                        "surname": "Syddall", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Syddall", 
+                            "index": "Syddall, H"
+                        }
                     }, 
                     {
-                        "surname": "Syv\u00e4nen", 
-                        "given-names": "AC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AC Syv\u00e4nen", 
+                            "index": "Syv\u00e4nen, AC"
+                        }
                     }, 
                     {
-                        "surname": "Tanaka", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Tanaka", 
+                            "index": "Tanaka, T"
+                        }
                     }, 
                     {
-                        "surname": "Thorand", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Thorand", 
+                            "index": "Thorand, B"
+                        }
                     }, 
                     {
-                        "surname": "Tichet", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Tichet", 
+                            "index": "Tichet, J"
+                        }
                     }, 
                     {
-                        "surname": "T\u00f6njes", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A T\u00f6njes", 
+                            "index": "T\u00f6njes, A"
+                        }
                     }, 
                     {
-                        "surname": "Tuomi", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Tuomi", 
+                            "index": "Tuomi, T"
+                        }
                     }, 
                     {
-                        "surname": "Uitterlinden", 
-                        "given-names": "AG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AG Uitterlinden", 
+                            "index": "Uitterlinden, AG"
+                        }
                     }, 
                     {
-                        "surname": "van Dijk", 
-                        "given-names": "KW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KW van Dijk", 
+                            "index": "van Dijk, KW"
+                        }
                     }, 
                     {
-                        "surname": "van Hoek", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M van Hoek", 
+                            "index": "van Hoek, M"
+                        }
                     }, 
                     {
-                        "surname": "Varma", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Varma", 
+                            "index": "Varma, D"
+                        }
                     }, 
                     {
-                        "surname": "Visvikis-Siest", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Visvikis-Siest", 
+                            "index": "Visvikis-Siest, S"
+                        }
                     }, 
                     {
-                        "surname": "Vitart", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Vitart", 
+                            "index": "Vitart, V"
+                        }
                     }, 
                     {
-                        "surname": "Vogelzangs", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Vogelzangs", 
+                            "index": "Vogelzangs, N"
+                        }
                     }, 
                     {
-                        "surname": "Waeber", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Waeber", 
+                            "index": "Waeber, G"
+                        }
                     }, 
                     {
-                        "surname": "Wagner", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Wagner", 
+                            "index": "Wagner, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Walley", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Walley", 
+                            "index": "Walley, A"
+                        }
                     }, 
                     {
-                        "surname": "Walters", 
-                        "given-names": "GB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GB Walters", 
+                            "index": "Walters, GB"
+                        }
                     }, 
                     {
-                        "surname": "Ward", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Ward", 
+                            "index": "Ward, KL"
+                        }
                     }, 
                     {
-                        "surname": "Watkins", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Watkins", 
+                            "index": "Watkins, H"
+                        }
                     }, 
                     {
-                        "surname": "Weedon", 
-                        "given-names": "MN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MN Weedon", 
+                            "index": "Weedon, MN"
+                        }
                     }, 
                     {
-                        "surname": "Wild", 
-                        "given-names": "SH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Wild", 
+                            "index": "Wild, SH"
+                        }
                     }, 
                     {
-                        "surname": "Willemsen", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Willemsen", 
+                            "index": "Willemsen, G"
+                        }
                     }, 
                     {
-                        "surname": "Witteman", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Witteman", 
+                            "index": "Witteman, JC"
+                        }
                     }, 
                     {
-                        "surname": "Yarnell", 
-                        "given-names": "JW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JW Yarnell", 
+                            "index": "Yarnell, JW"
+                        }
                     }, 
                     {
-                        "surname": "Zeggini", 
-                        "given-names": "E", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Zeggini", 
+                            "index": "Zeggini, E"
+                        }
                     }, 
                     {
-                        "surname": "Zelenika", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Zelenika", 
+                            "index": "Zelenika, D"
+                        }
                     }, 
                     {
-                        "surname": "Zethelius", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zethelius", 
+                            "index": "Zethelius, B"
+                        }
                     }, 
                     {
-                        "surname": "Zhai", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Zhai", 
+                            "index": "Zhai, G"
+                        }
                     }, 
                     {
-                        "surname": "Zhao", 
-                        "given-names": "JH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JH Zhao", 
+                            "index": "Zhao, JH"
+                        }
                     }, 
                     {
-                        "surname": "Zillikens", 
-                        "given-names": "MC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Zillikens", 
+                            "index": "Zillikens, MC"
+                        }
                     }, 
                     {
-                        "surname": "Borecki", 
-                        "given-names": "IB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IB Borecki", 
+                            "index": "Borecki, IB"
+                        }
                     }, 
                     {
-                        "surname": "Loos", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Loos", 
+                            "index": "Loos, RJ"
+                        }
                     }, 
                     {
-                        "surname": "Meneton", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Meneton", 
+                            "index": "Meneton, P"
+                        }
                     }, 
                     {
-                        "surname": "Magnusson", 
-                        "given-names": "PK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PK Magnusson", 
+                            "index": "Magnusson, PK"
+                        }
                     }, 
                     {
-                        "surname": "Nathan", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Nathan", 
+                            "index": "Nathan, DM"
+                        }
                     }, 
                     {
-                        "surname": "Williams", 
-                        "given-names": "GH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GH Williams", 
+                            "index": "Williams, GH"
+                        }
                     }, 
                     {
-                        "surname": "Hattersley", 
-                        "given-names": "AT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AT Hattersley", 
+                            "index": "Hattersley, AT"
+                        }
                     }, 
                     {
-                        "surname": "Silander", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Silander", 
+                            "index": "Silander, K"
+                        }
                     }, 
                     {
-                        "surname": "Salomaa", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Salomaa", 
+                            "index": "Salomaa, V"
+                        }
                     }, 
                     {
-                        "surname": "Smith", 
-                        "given-names": "GD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GD Smith", 
+                            "index": "Smith, GD"
+                        }
                     }, 
                     {
-                        "surname": "Bornstein", 
-                        "given-names": "SR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SR Bornstein", 
+                            "index": "Bornstein, SR"
+                        }
                     }, 
                     {
-                        "surname": "Schwarz", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schwarz", 
+                            "index": "Schwarz, P"
+                        }
                     }, 
                     {
-                        "surname": "Spranger", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Spranger", 
+                            "index": "Spranger, J"
+                        }
                     }, 
                     {
-                        "surname": "Karpe", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Karpe", 
+                            "index": "Karpe, F"
+                        }
                     }, 
                     {
-                        "surname": "Shuldiner", 
-                        "given-names": "AR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AR Shuldiner", 
+                            "index": "Shuldiner, AR"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Cooper", 
+                            "index": "Cooper, C"
+                        }
                     }, 
                     {
-                        "surname": "Dedoussis", 
-                        "given-names": "GV", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GV Dedoussis", 
+                            "index": "Dedoussis, GV"
+                        }
                     }, 
                     {
-                        "surname": "Serrano-R\u00edos", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Serrano-R\u00edos", 
+                            "index": "Serrano-R\u00edos, M"
+                        }
                     }, 
                     {
-                        "surname": "Morris", 
-                        "given-names": "AD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AD Morris", 
+                            "index": "Morris, AD"
+                        }
                     }, 
                     {
-                        "surname": "Lind", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Lind", 
+                            "index": "Lind, L"
+                        }
                     }, 
                     {
-                        "surname": "Palmer", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Palmer", 
+                            "index": "Palmer, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Hu", 
-                        "given-names": "FB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FB Hu", 
+                            "index": "Hu, FB"
+                        }
                     }, 
                     {
-                        "surname": "Franks", 
-                        "given-names": "PW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PW Franks", 
+                            "index": "Franks, PW"
+                        }
                     }, 
                     {
-                        "surname": "Ebrahim", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Ebrahim", 
+                            "index": "Ebrahim, S"
+                        }
                     }, 
                     {
-                        "surname": "Marmot", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Marmot", 
+                            "index": "Marmot, M"
+                        }
                     }, 
                     {
-                        "surname": "Kao", 
-                        "given-names": "WH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kao", 
+                            "index": "Kao, WH"
+                        }
                     }, 
                     {
-                        "surname": "Pankow", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Pankow", 
+                            "index": "Pankow, JS"
+                        }
                     }, 
                     {
-                        "surname": "Sampson", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Sampson", 
+                            "index": "Sampson, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Kuusisto", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Kuusisto", 
+                            "index": "Kuusisto, J"
+                        }
                     }, 
                     {
-                        "surname": "Laakso", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Laakso", 
+                            "index": "Laakso, M"
+                        }
                     }, 
                     {
-                        "surname": "Hansen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hansen", 
+                            "index": "Hansen, T"
+                        }
                     }, 
                     {
-                        "surname": "Pedersen", 
-                        "given-names": "O", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Pedersen", 
+                            "index": "Pedersen, O"
+                        }
                     }, 
                     {
-                        "surname": "Pramstaller", 
-                        "given-names": "PP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PP Pramstaller", 
+                            "index": "Pramstaller, PP"
+                        }
                     }, 
                     {
-                        "surname": "Wichmann", 
-                        "given-names": "HE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HE Wichmann", 
+                            "index": "Wichmann, HE"
+                        }
                     }, 
                     {
-                        "surname": "Illig", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Illig", 
+                            "index": "Illig, T"
+                        }
                     }, 
                     {
-                        "surname": "Rudan", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Rudan", 
+                            "index": "Rudan, I"
+                        }
                     }, 
                     {
-                        "surname": "Wright", 
-                        "given-names": "AF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AF Wright", 
+                            "index": "Wright, AF"
+                        }
                     }, 
                     {
-                        "surname": "Stumvoll", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Stumvoll", 
+                            "index": "Stumvoll, M"
+                        }
                     }, 
                     {
-                        "surname": "Campbell", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Campbell", 
+                            "index": "Campbell, H"
+                        }
                     }, 
                     {
-                        "surname": "Wilson", 
-                        "given-names": "JF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JF Wilson", 
+                            "index": "Wilson, JF"
+                        }
                     }, 
                     {
-                        "surname": "Bergman", 
-                        "given-names": "RN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RN Bergman", 
+                            "index": "Bergman, RN"
+                        }
                     }, 
                     {
-                        "surname": "Buchanan", 
-                        "given-names": "TA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TA Buchanan", 
+                            "index": "Buchanan, TA"
+                        }
                     }, 
                     {
-                        "surname": "Collins", 
-                        "given-names": "FS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FS Collins", 
+                            "index": "Collins, FS"
+                        }
                     }, 
                     {
-                        "surname": "Mohlke", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Mohlke", 
+                            "index": "Mohlke, KL"
+                        }
                     }, 
                     {
-                        "surname": "Tuomilehto", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Tuomilehto", 
+                            "index": "Tuomilehto, J"
+                        }
                     }, 
                     {
-                        "surname": "Valle", 
-                        "given-names": "TT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TT Valle", 
+                            "index": "Valle, TT"
+                        }
                     }, 
                     {
-                        "surname": "Altshuler", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Altshuler", 
+                            "index": "Altshuler, D"
+                        }
                     }, 
                     {
-                        "surname": "Rotter", 
-                        "given-names": "JI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JI Rotter", 
+                            "index": "Rotter, JI"
+                        }
                     }, 
                     {
-                        "surname": "Siscovick", 
-                        "given-names": "DS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DS Siscovick", 
+                            "index": "Siscovick, DS"
+                        }
                     }, 
                     {
-                        "surname": "Penninx", 
-                        "given-names": "BW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BW Penninx", 
+                            "index": "Penninx, BW"
+                        }
                     }, 
                     {
-                        "surname": "Boomsma", 
-                        "given-names": "DI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DI Boomsma", 
+                            "index": "Boomsma, DI"
+                        }
                     }, 
                     {
-                        "surname": "Deloukas", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Deloukas", 
+                            "index": "Deloukas, P"
+                        }
                     }, 
                     {
-                        "surname": "Spector", 
-                        "given-names": "TD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD Spector", 
+                            "index": "Spector, TD"
+                        }
                     }, 
                     {
-                        "surname": "Frayling", 
-                        "given-names": "TM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TM Frayling", 
+                            "index": "Frayling, TM"
+                        }
                     }, 
                     {
-                        "surname": "Ferrucci", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Ferrucci", 
+                            "index": "Ferrucci, L"
+                        }
                     }, 
                     {
-                        "surname": "Kong", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kong", 
+                            "index": "Kong, A"
+                        }
                     }, 
                     {
-                        "surname": "Thorsteinsdottir", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Thorsteinsdottir", 
+                            "index": "Thorsteinsdottir, U"
+                        }
                     }, 
                     {
-                        "surname": "Stefansson", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Stefansson", 
+                            "index": "Stefansson, K"
+                        }
                     }, 
                     {
-                        "surname": "van Duijn", 
-                        "given-names": "CM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM van Duijn", 
+                            "index": "van Duijn, CM"
+                        }
                     }, 
                     {
-                        "surname": "Aulchenko", 
-                        "given-names": "YS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YS Aulchenko", 
+                            "index": "Aulchenko, YS"
+                        }
                     }, 
                     {
-                        "surname": "Cao", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Cao", 
+                            "index": "Cao, A"
+                        }
                     }, 
                     {
-                        "surname": "Scuteri", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Scuteri", 
+                            "index": "Scuteri, A"
+                        }
                     }, 
                     {
-                        "surname": "Schlessinger", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Schlessinger", 
+                            "index": "Schlessinger, D"
+                        }
                     }, 
                     {
-                        "surname": "Uda", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Uda", 
+                            "index": "Uda, M"
+                        }
                     }, 
                     {
-                        "surname": "Ruokonen", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Ruokonen", 
+                            "index": "Ruokonen, A"
+                        }
                     }, 
                     {
-                        "surname": "Jarvelin", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Jarvelin", 
+                            "index": "Jarvelin, MR"
+                        }
                     }, 
                     {
-                        "surname": "Waterworth", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Waterworth", 
+                            "index": "Waterworth, DM"
+                        }
                     }, 
                     {
-                        "surname": "Vollenweider", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Vollenweider", 
+                            "index": "Vollenweider, P"
+                        }
                     }, 
                     {
-                        "surname": "Peltonen", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Peltonen", 
+                            "index": "Peltonen, L"
+                        }
                     }, 
                     {
-                        "surname": "Mooser", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Mooser", 
+                            "index": "Mooser, V"
+                        }
                     }, 
                     {
-                        "surname": "Abecasis", 
-                        "given-names": "GR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GR Abecasis", 
+                            "index": "Abecasis, GR"
+                        }
                     }, 
                     {
-                        "surname": "Wareham", 
-                        "given-names": "NJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Wareham", 
+                            "index": "Wareham, NJ"
+                        }
                     }, 
                     {
-                        "surname": "Sladek", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Sladek", 
+                            "index": "Sladek, R"
+                        }
                     }, 
                     {
-                        "surname": "Froguel", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Froguel", 
+                            "index": "Froguel, P"
+                        }
                     }, 
                     {
-                        "surname": "Watanabe", 
-                        "given-names": "RM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RM Watanabe", 
+                            "index": "Watanabe, RM"
+                        }
                     }, 
                     {
-                        "surname": "Meigs", 
-                        "given-names": "JB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JB Meigs", 
+                            "index": "Meigs, JB"
+                        }
                     }, 
                     {
-                        "surname": "Groop", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Groop", 
+                            "index": "Groop, L"
+                        }
                     }, 
                     {
-                        "surname": "Boehnke", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Boehnke", 
+                            "index": "Boehnke, M"
+                        }
                     }, 
                     {
-                        "surname": "McCarthy", 
-                        "given-names": "MI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MI McCarthy", 
+                            "index": "McCarthy, MI"
+                        }
                     }, 
                     {
-                        "surname": "Florez", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Florez", 
+                            "index": "Florez, JC"
+                        }
                     }, 
                     {
-                        "surname": "Barroso", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Barroso", 
+                            "index": "Barroso, I"
+                        }
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "DIAGRAM Consortium"
+                        "type": "group", 
+                        "name": "DIAGRAM Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "GIANT Consortium"
+                        "type": "group", 
+                        "name": "GIANT Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "Global BPgen Consortium"
+                        "type": "group", 
+                        "name": "Global BPgen Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "Anders Hamsten on behalf of Procardis Consortium"
+                        "type": "group", 
+                        "name": "Anders Hamsten on behalf of Procardis Consortium"
                     }, 
                     {
-                        "group-type": "author", 
-                        "collab": "MAGIC investigators"
+                        "type": "group", 
+                        "name": "MAGIC investigators"
                     }
                 ], 
-                "full_article_title": "New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes risk", 
-                "publication-type": "journal", 
+                "articleTitle": "New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes risk", 
+                "journal": {
+                    "name": [
+                        "Nature Genetics"
+                    ]
+                }, 
                 "volume": "42", 
-                "source": "Nature Genetics", 
-                "reference_id": "10.1038/ng.520", 
-                "fpage": "105", 
-                "year": "2010", 
-                "position": 4, 
-                "collab": "DIAGRAM Consortium", 
-                "ref": "DupuisJLangenbergCProkopenkoISaxenaRSoranzoNJacksonAUWheelerEGlazerNLBouatia-NajiNGloynALLindgrenCMM\u00e4giRMorrisAPRandallJJohnsonTElliottPRybinDThorleifssonGSteinthorsdottirVHennemanPGrallertHDehghanAHottengaJJFranklinCSNavarroPSongKGoelAPerryJREganJMLajunenTGrarupNSpars\u00f8TDoneyAVoightBFStringhamHMLiMKanoniSShraderPCavalcanti-Proen\u00e7aCKumariMQiLTimpsonNJGiegerCZabenaCRocheleauGIngelssonEAnPO'ConnellJLuanJElliottAMcCarrollSAPayneFRoccaseccaRMPattouFSethupathyPArdlieKAriyurekYBalkauBBarterPBeilbyJPBen-ShlomoYBenediktssonRBennettAJBergmannSBochudMBoerwinkleEBonnefondABonnycastleLLBorch-JohnsenKB\u00f6ttcherYBrunnerEBumpsteadSJCharpentierGChenYDChinesPClarkeRCoinLJCooperMNCornelisMCrawfordGCrisponiLDayINde GeusEJDelplanqueJDinaCErdosMRFedsonACFischer-RosinskyAForouhiNGFoxCSFrantsRFranzosiMGGalanPGoodarziMOGraesslerJGrovesCJGrundySGwilliamRGyllenstenUHadjadjSHallmansGHammondNHanXHartikainenALHassanaliNHaywardCHeathSCHercbergSHerderCHicksAAHillmanDRHingoraniADHofmanAHuiJHungJIsomaaBJohnsonPRJ\u00f8rgensenTJulaAKaakinenMKaprioJKesaniemiYAKivimakiMKnightBKoskinenSKovacsPKyvikKOLathropGMLawlorDALe BacquerOLecoeurCLiYLyssenkoVMahleyRManginoMManningAKMart\u00ednez-LarradMTMcAteerJBMcCullochLJMcPhersonRMeisingerCMelzerDMeyreDMitchellBDMorkenMAMukherjeeSNaitzaSNarisuNNevilleMJOostraBAOrr\u00f9MPakyzRPalmerCNPaolissoGPattaroCPearsonDPedenJFPedersenNLPerolaMPfeifferAFPichlerIPolasekOPosthumaDPotterSCPoutaAProvinceMAPsatyBMRathmannWRaynerNWRiceKRipattiSRivadeneiraFRodenMRolandssonOSandbaekASandhuMSannaSSayerAAScheetPScottLJSeedorfUSharpSJShieldsBSigurethssonGSijbrandsEJSilveiraASimpsonLSingletonASmithNLSovioUSwiftASyddallHSyv\u00e4nenACTanakaTThorandBTichetJT\u00f6njesATuomiTUitterlindenAGvan DijkKWvan HoekMVarmaDVisvikis-SiestSVitartVVogelzangsNWaeberGWagnerPJWalleyAWaltersGBWardKLWatkinsHWeedonMNWildSHWillemsenGWittemanJCYarnellJWZegginiEZelenikaDZetheliusBZhaiGZhaoJHZillikensMCBoreckiIBLoosRJMenetonPMagnussonPKNathanDMWilliamsGHHattersleyATSilanderKSalomaaVSmithGDBornsteinSRSchwarzPSprangerJKarpeFShuldinerARCooperCDedoussisGVSerrano-R\u00edosMMorrisADLindLPalmerLJHuFBFranksPWEbrahimSMarmotMKaoWHPankowJSSampsonMJKuusistoJLaaksoMHansenTPedersenOPramstallerPPWichmannHEIlligTRudanIWrightAFStumvollMCampbellHWilsonJFBergmanRNBuchananTACollinsFSMohlkeKLTuomilehtoJValleTTAltshulerDRotterJISiscovickDSPenninxBWBoomsmaDIDeloukasPSpectorTDFraylingTMFerrucciLKongAThorsteinsdottirUStefanssonKvan DuijnCMAulchenkoYSCaoAScuteriASchlessingerDUdaMRuokonenAJarvelinMRWaterworthDMVollenweiderPPeltonenLMooserVAbecasisGRWarehamNJSladekRFroguelPWatanabeRMMeigsJBGroopLBoehnkeMMcCarthyMIFlorezJCBarrosoIDIAGRAM ConsortiumGIANT ConsortiumGlobal BPgen ConsortiumAnders Hamsten on behalf of Procardis ConsortiumMAGIC investigators2010New genetic loci implicated in fasting glucose homeostasis and their impact on type 2 diabetes riskNature Genetics4210511610.1038/ng.520", 
-                "id": "bib4"
+                "pages": {
+                    "first": "105", 
+                    "last": "116", 
+                    "range": "105\u2013116"
+                }, 
+                "doi": "10.1038/ng.520"
             }, 
             {
-                "article_title": "The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian period", 
-                "lpage": "900", 
-                "doi": "10.1126/science.1141138", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib5", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Godinho", 
-                        "given-names": "SI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SI Godinho", 
+                            "index": "Godinho, SI"
+                        }
                     }, 
                     {
-                        "surname": "Maywood", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Maywood", 
+                            "index": "Maywood, ES"
+                        }
                     }, 
                     {
-                        "surname": "Shaw", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Shaw", 
+                            "index": "Shaw, L"
+                        }
                     }, 
                     {
-                        "surname": "Tucci", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Tucci", 
+                            "index": "Tucci, V"
+                        }
                     }, 
                     {
-                        "surname": "Barnard", 
-                        "given-names": "AR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AR Barnard", 
+                            "index": "Barnard, AR"
+                        }
                     }, 
                     {
-                        "surname": "Busino", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Busino", 
+                            "index": "Busino, L"
+                        }
                     }, 
                     {
-                        "surname": "Pagano", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pagano", 
+                            "index": "Pagano, M"
+                        }
                     }, 
                     {
-                        "surname": "Kendall", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Kendall", 
+                            "index": "Kendall, R"
+                        }
                     }, 
                     {
-                        "surname": "Quwailid", 
-                        "given-names": "MM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MM Quwailid", 
+                            "index": "Quwailid, MM"
+                        }
                     }, 
                     {
-                        "surname": "Romero", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Romero", 
+                            "index": "Romero, MR"
+                        }
                     }, 
                     {
-                        "surname": "O'neill", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J O'neill", 
+                            "index": "O'neill, J"
+                        }
                     }, 
                     {
-                        "surname": "Chesham", 
-                        "given-names": "JE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JE Chesham", 
+                            "index": "Chesham, JE"
+                        }
                     }, 
                     {
-                        "surname": "Brooker", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Brooker", 
+                            "index": "Brooker, D"
+                        }
                     }, 
                     {
-                        "surname": "Lalanne", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Lalanne", 
+                            "index": "Lalanne, Z"
+                        }
                     }, 
                     {
-                        "surname": "Hastings", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Hastings", 
+                            "index": "Hastings, MH"
+                        }
                     }, 
                     {
-                        "surname": "Nolan", 
-                        "given-names": "PM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PM Nolan", 
+                            "index": "Nolan, PM"
+                        }
                     }
                 ], 
-                "full_article_title": "The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian period", 
-                "publication-type": "journal", 
+                "articleTitle": "The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian period", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "316", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1141138", 
-                "fpage": "897", 
-                "year": "2007", 
-                "position": 5, 
-                "ref": "GodinhoSIMaywoodESShawLTucciVBarnardARBusinoLPaganoMKendallRQuwailidMMRomeroMRO'neillJCheshamJEBrookerDLalanneZHastingsMHNolanPM2007The after-hours mutant reveals a role for Fbxl3 in determining mammalian circadian periodScience31689790010.1126/science.1141138", 
-                "id": "bib5"
+                "pages": {
+                    "first": "897", 
+                    "last": "900", 
+                    "range": "897\u2013900"
+                }, 
+                "doi": "10.1126/science.1141138"
             }, 
             {
-                "article_title": "Light-independent role of CRY1 and CRY2 in the mammalian circadian clock", 
-                "lpage": "771", 
-                "doi": "10.1126/science.286.5440.768", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib6", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Griffin", 
-                        "given-names": "EA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EA Griffin", 
+                            "index": "Griffin, EA"
+                        }
                     }, 
                     {
-                        "surname": "Staknis", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Staknis", 
+                            "index": "Staknis, D"
+                        }
                     }, 
                     {
-                        "surname": "Weitz", 
-                        "given-names": "CJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CJ Weitz", 
+                            "index": "Weitz, CJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Light-independent role of CRY1 and CRY2 in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Light-independent role of CRY1 and CRY2 in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "286", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.286.5440.768", 
-                "fpage": "768", 
-                "year": "1999", 
-                "position": 6, 
-                "ref": "GriffinEAStaknisDWeitzCJ1999Light-independent role of CRY1 and CRY2 in the mammalian circadian clockScience28676877110.1126/science.286.5440.768", 
-                "id": "bib6"
+                "pages": {
+                    "first": "768", 
+                    "last": "771", 
+                    "range": "768\u2013771"
+                }, 
+                "doi": "10.1126/science.286.5440.768"
             }, 
             {
-                "article_title": "Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resetting", 
-                "lpage": "1080", 
-                "doi": "10.1113/jphysiol.2012.242198", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib7", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Guilding", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Guilding", 
+                            "index": "Guilding, C"
+                        }
                     }, 
                     {
-                        "surname": "Scott", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Scott", 
+                            "index": "Scott, F"
+                        }
                     }, 
                     {
-                        "surname": "Bechtold", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Bechtold", 
+                            "index": "Bechtold, DA"
+                        }
                     }, 
                     {
-                        "surname": "Brown", 
-                        "given-names": "TM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TM Brown", 
+                            "index": "Brown, TM"
+                        }
                     }, 
                     {
-                        "surname": "Wegner", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Wegner", 
+                            "index": "Wegner, S"
+                        }
                     }, 
                     {
-                        "surname": "Piggins", 
-                        "given-names": "HD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HD Piggins", 
+                            "index": "Piggins, HD"
+                        }
                     }
                 ], 
-                "full_article_title": "Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resetting", 
-                "publication-type": "journal", 
+                "articleTitle": "Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resetting", 
+                "journal": {
+                    "name": [
+                        "Journal of Physiology"
+                    ]
+                }, 
                 "volume": "591", 
-                "source": "Journal of Physiology", 
-                "reference_id": "10.1113/jphysiol.2012.242198", 
-                "fpage": "1063", 
-                "year": "2013", 
-                "position": 7, 
-                "ref": "GuildingCScottFBechtoldDABrownTMWegnerSPigginsHD2013Suppressed cellular oscillations in after-hours mutant mice are associated with enhanced circadian phase-resettingJournal of Physiology5911063108010.1113/jphysiol.2012.242198", 
-                "id": "bib7"
+                "pages": {
+                    "first": "1063", 
+                    "last": "1080", 
+                    "range": "1063\u20131080"
+                }, 
+                "doi": "10.1113/jphysiol.2012.242198"
             }, 
             {
-                "article_title": "The transcriptional repressor DEC2 regulates sleep length in mammals", 
-                "lpage": "870", 
-                "doi": "10.1126/science.1174443", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib8", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "He", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y He", 
+                            "index": "He, Y"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Fujiki", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Fujiki", 
+                            "index": "Fujiki, N"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Guo", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Guo", 
+                            "index": "Guo, B"
+                        }
                     }, 
                     {
-                        "surname": "Holder", 
-                        "given-names": "JL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Holder", 
+                            "index": "Holder, JL"
+                        }
                     }, 
                     {
-                        "surname": "Rossner", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Rossner", 
+                            "index": "Rossner, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Nishino", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nishino", 
+                            "index": "Nishino, S"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "The transcriptional repressor DEC2 regulates sleep length in mammals", 
-                "publication-type": "journal", 
+                "articleTitle": "The transcriptional repressor DEC2 regulates sleep length in mammals", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "325", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1174443", 
-                "fpage": "866", 
-                "year": "2009", 
-                "position": 8, 
-                "ref": "HeYJonesCRFujikiNXuYGuoBHolderJLRossnerMJNishinoSFuYH2009The transcriptional repressor DEC2 regulates sleep length in mammalsScience32586687010.1126/science.1174443", 
-                "id": "bib8"
+                "pages": {
+                    "first": "866", 
+                    "last": "870", 
+                    "range": "866\u2013870"
+                }, 
+                "doi": "10.1126/science.1174443"
             }, 
             {
-                "article_title": "In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clock", 
-                "lpage": "4473", 
-                "doi": "10.1128/MCB.00711-14", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib9", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "Hirano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hirano", 
+                            "index": "Hirano, A"
+                        }
                     }, 
                     {
-                        "surname": "Kurabayashi", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Kurabayashi", 
+                            "index": "Kurabayashi, N"
+                        }
                     }, 
                     {
-                        "surname": "Nakagawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Nakagawa", 
+                            "index": "Nakagawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Shioi", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Shioi", 
+                            "index": "Shioi, G"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Hirota", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirota", 
+                            "index": "Hirota, T"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clock", 
+                "journal": {
+                    "name": [
+                        "Molecular and Cellular Biology"
+                    ]
+                }, 
                 "volume": "34", 
-                "source": "Molecular and Cellular Biology", 
-                "reference_id": "10.1128/MCB.00711-14", 
-                "fpage": "4464", 
-                "year": "2014", 
-                "position": 9, 
-                "ref": "HiranoAKurabayashiNNakagawaTShioiGTodoTHirotaTFukadaY2014In vivo role of phosphorylation of cryptochrome 2 in the mouse circadian clockMolecular and Cellular Biology344464447310.1128/MCB.00711-14", 
-                "id": "bib9"
+                "pages": {
+                    "first": "4464", 
+                    "last": "4473", 
+                    "range": "4464\u20134473"
+                }, 
+                "doi": "10.1128/MCB.00711-14"
             }, 
             {
-                "article_title": "FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromes", 
-                "lpage": "1118", 
-                "doi": "10.1016/j.cell.2013.01.054", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib10", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Hirano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hirano", 
+                            "index": "Hirano, A"
+                        }
                     }, 
                     {
-                        "surname": "Yumimoto", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Yumimoto", 
+                            "index": "Yumimoto, K"
+                        }
                     }, 
                     {
-                        "surname": "Tsunematsu", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Tsunematsu", 
+                            "index": "Tsunematsu, R"
+                        }
                     }, 
                     {
-                        "surname": "Matsumoto", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Matsumoto", 
+                            "index": "Matsumoto, M"
+                        }
                     }, 
                     {
-                        "surname": "Oyama", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Oyama", 
+                            "index": "Oyama, M"
+                        }
                     }, 
                     {
-                        "surname": "Kozuka-Hata", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kozuka-Hata", 
+                            "index": "Kozuka-Hata, H"
+                        }
                     }, 
                     {
-                        "surname": "Nakagawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Nakagawa", 
+                            "index": "Nakagawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Lanjakornsiripan", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lanjakornsiripan", 
+                            "index": "Lanjakornsiripan, D"
+                        }
                     }, 
                     {
-                        "surname": "Nakayama", 
-                        "given-names": "KI", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KI Nakayama", 
+                            "index": "Nakayama, KI"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromes", 
-                "publication-type": "journal", 
+                "articleTitle": "FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromes", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "152", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2013.01.054", 
-                "fpage": "1106", 
-                "year": "2013", 
-                "position": 10, 
-                "ref": "HiranoAYumimotoKTsunematsuRMatsumotoMOyamaMKozuka-HataHNakagawaTLanjakornsiripanDNakayamaKIFukadaY2013FBXL21 regulates oscillation of the circadian clock through ubiquitination and stabilization of cryptochromesCell1521106111810.1016/j.cell.2013.01.054", 
-                "id": "bib10"
+                "pages": {
+                    "first": "1106", 
+                    "last": "1118", 
+                    "range": "1106\u20131118"
+                }, 
+                "doi": "10.1016/j.cell.2013.01.054"
             }, 
             {
-                "article_title": "Identification of small molecule activators of cryptochrome", 
-                "lpage": "1097", 
-                "doi": "10.1126/science.1223710", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib11", 
+                "date": "2012", 
                 "authors": [
                     {
-                        "surname": "Hirota", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirota", 
+                            "index": "Hirota, T"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "JW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JW Lee", 
+                            "index": "Lee, JW"
+                        }
                     }, 
                     {
-                        "surname": "St John", 
-                        "given-names": "PC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PC St John", 
+                            "index": "St John, PC"
+                        }
                     }, 
                     {
-                        "surname": "Sawa", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sawa", 
+                            "index": "Sawa, M"
+                        }
                     }, 
                     {
-                        "surname": "Iwaisako", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Iwaisako", 
+                            "index": "Iwaisako, K"
+                        }
                     }, 
                     {
-                        "surname": "Noguchi", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Noguchi", 
+                            "index": "Noguchi, T"
+                        }
                     }, 
                     {
-                        "surname": "Pongsawakul", 
-                        "given-names": "PY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PY Pongsawakul", 
+                            "index": "Pongsawakul, PY"
+                        }
                     }, 
                     {
-                        "surname": "Sonntag", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sonntag", 
+                            "index": "Sonntag, T"
+                        }
                     }, 
                     {
-                        "surname": "Welsh", 
-                        "given-names": "DK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DK Welsh", 
+                            "index": "Welsh, DK"
+                        }
                     }, 
                     {
-                        "surname": "Brenner", 
-                        "given-names": "DA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DA Brenner", 
+                            "index": "Brenner, DA"
+                        }
                     }, 
                     {
-                        "surname": "Doyle", 
-                        "given-names": "FJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FJ Doyle", 
+                            "index": "Doyle, FJ"
+                        }
                     }, 
                     {
-                        "surname": "Schultz", 
-                        "given-names": "PG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PG Schultz", 
+                            "index": "Schultz, PG"
+                        }
                     }, 
                     {
-                        "surname": "Kay", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Kay", 
+                            "index": "Kay, SA"
+                        }
                     }
                 ], 
-                "full_article_title": "Identification of small molecule activators of cryptochrome", 
-                "publication-type": "journal", 
+                "articleTitle": "Identification of small molecule activators of cryptochrome", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "337", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1223710", 
-                "fpage": "1094", 
-                "year": "2012", 
-                "position": 11, 
-                "ref": "HirotaTLeeJWSt JohnPCSawaMIwaisakoKNoguchiTPongsawakulPYSonntagTWelshDKBrennerDADoyleFJSchultzPGKaySA2012Identification of small molecule activators of cryptochromeScience3371094109710.1126/science.1223710", 
-                "id": "bib11"
+                "pages": {
+                    "first": "1094", 
+                    "last": "1097", 
+                    "range": "1094\u20131097"
+                }, 
+                "doi": "10.1126/science.1223710"
             }, 
             {
-                "article_title": "Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromes", 
-                "lpage": "6967", 
-                "doi": "10.1073/pnas.0809180106", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib12", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "Hitomi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Hitomi", 
+                            "index": "Hitomi, K"
+                        }
                     }, 
                     {
-                        "surname": "DiTacchio", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L DiTacchio", 
+                            "index": "DiTacchio, L"
+                        }
                     }, 
                     {
-                        "surname": "Arvai", 
-                        "given-names": "AS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Arvai", 
+                            "index": "Arvai, AS"
+                        }
                     }, 
                     {
-                        "surname": "Yamamoto", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Yamamoto", 
+                            "index": "Yamamoto, J"
+                        }
                     }, 
                     {
-                        "surname": "Kim", 
-                        "given-names": "S-T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S-T Kim", 
+                            "index": "Kim, S-T"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Tainer", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Tainer", 
+                            "index": "Tainer, JA"
+                        }
                     }, 
                     {
-                        "surname": "Iwai", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Iwai", 
+                            "index": "Iwai, S"
+                        }
                     }, 
                     {
-                        "surname": "Panda", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Panda", 
+                            "index": "Panda, S"
+                        }
                     }, 
                     {
-                        "surname": "Getzoff", 
-                        "given-names": "ED", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ED Getzoff", 
+                            "index": "Getzoff, ED"
+                        }
                     }
                 ], 
-                "full_article_title": "Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromes", 
-                "publication-type": "journal", 
+                "articleTitle": "Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromes", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "106", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.0809180106", 
-                "fpage": "6962", 
-                "year": "2009", 
-                "position": 12, 
-                "ref": "HitomiKDiTacchioLArvaiASYamamotoJKimS-TTodoTTainerJAIwaiSPandaSGetzoffED2009Functional motifs in the (6-4) photolyase crystal structure make a comparative framework for DNA repair photolyases and clock cryptochromesPNAS1066962696710.1073/pnas.0809180106", 
-                "id": "bib12"
+                "pages": {
+                    "first": "6962", 
+                    "last": "6967", 
+                    "range": "6962\u20136967"
+                }, 
+                "doi": "10.1073/pnas.0809180106"
             }, 
             {
-                "article_title": "The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signaling", 
-                "lpage": "548", 
-                "doi": "10.1158/1940-6207.CAPR-09-0127", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib13", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Hoffman", 
-                        "given-names": "AE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AE Hoffman", 
+                            "index": "Hoffman, AE"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Zheng", 
+                            "index": "Zheng, T"
+                        }
                     }, 
                     {
-                        "surname": "Yi", 
-                        "given-names": "CH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CH Yi", 
+                            "index": "Yi, CH"
+                        }
                     }, 
                     {
-                        "surname": "Stevens", 
-                        "given-names": "RG", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RG Stevens", 
+                            "index": "Stevens, RG"
+                        }
                     }, 
                     {
-                        "surname": "Ba", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Ba", 
+                            "index": "Ba, Y"
+                        }
                     }, 
                     {
-                        "surname": "Zhang", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Zhang", 
+                            "index": "Zhang, Y"
+                        }
                     }, 
                     {
-                        "surname": "Leaderer", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Leaderer", 
+                            "index": "Leaderer, D"
+                        }
                     }, 
                     {
-                        "surname": "Holford", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Holford", 
+                            "index": "Holford, T"
+                        }
                     }, 
                     {
-                        "surname": "Hansen", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hansen", 
+                            "index": "Hansen, J"
+                        }
                     }, 
                     {
-                        "surname": "Zhu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Zhu", 
+                            "index": "Zhu, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signaling", 
-                "publication-type": "journal", 
+                "articleTitle": "The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signaling", 
+                "journal": {
+                    "name": [
+                        "Cancer Prevention Research"
+                    ]
+                }, 
                 "volume": "3", 
-                "source": "Cancer Prevention Research", 
-                "reference_id": "10.1158/1940-6207.CAPR-09-0127", 
-                "fpage": "539", 
-                "year": "2010", 
-                "position": 13, 
-                "ref": "HoffmanAEZhengTYiCHStevensRGBaYZhangYLeadererDHolfordTHansenJZhuY2010The core circadian gene Cryptochrome 2 influences breast cancer risk, possibly by mediating hormone signalingCancer Prevention Research353954810.1158/1940-6207.CAPR-09-0127", 
-                "id": "bib13"
+                "pages": {
+                    "first": "539", 
+                    "last": "548", 
+                    "range": "539\u2013548"
+                }, 
+                "doi": "10.1158/1940-6207.CAPR-09-0127"
             }, 
             {
-                "article_title": "Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humans", 
-                "lpage": "1065", 
-                "doi": "10.1038/12502", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib14", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Campbell", 
-                        "given-names": "SS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SS Campbell", 
+                            "index": "Campbell, SS"
+                        }
                     }, 
                     {
-                        "surname": "Zone", 
-                        "given-names": "SE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Zone", 
+                            "index": "Zone, SE"
+                        }
                     }, 
                     {
-                        "surname": "Cooper", 
-                        "given-names": "F", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Cooper", 
+                            "index": "Cooper, F"
+                        }
                     }, 
                     {
-                        "surname": "DeSano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A DeSano", 
+                            "index": "DeSano, A"
+                        }
                     }, 
                     {
-                        "surname": "Murphy", 
-                        "given-names": "PJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PJ Murphy", 
+                            "index": "Murphy, PJ"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Jones", 
+                            "index": "Jones, B"
+                        }
                     }, 
                     {
-                        "surname": "Czajkowski", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Czajkowski", 
+                            "index": "Czajkowski, L"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humans", 
-                "publication-type": "journal", 
+                "articleTitle": "Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humans", 
+                "journal": {
+                    "name": [
+                        "Nature Medicine"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "Nature Medicine", 
-                "reference_id": "10.1038/12502", 
-                "fpage": "1062", 
-                "year": "1999", 
-                "position": 14, 
-                "ref": "JonesCRCampbellSSZoneSECooperFDeSanoAMurphyPJJonesBCzajkowskiLPt\u00e1cekLJ1999Familial advanced sleep-phase syndrome: A short-period circadian rhythm variant in humansNature Medicine51062106510.1038/12502", 
-                "id": "bib14"
+                "pages": {
+                    "first": "1062", 
+                    "last": "1065", 
+                    "range": "1062\u20131065"
+                }, 
+                "doi": "10.1038/12502"
             }, 
             {
-                "article_title": "Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clock", 
-                "lpage": "302", 
-                "doi": "10.1016/j.cmet.2012.12.017", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib15", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Kaasik", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kaasik", 
+                            "index": "Kaasik, K"
+                        }
                     }, 
                     {
-                        "surname": "Kivim\u00e4e", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kivim\u00e4e", 
+                            "index": "Kivim\u00e4e, S"
+                        }
                     }, 
                     {
-                        "surname": "Allen", 
-                        "given-names": "JJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JJ Allen", 
+                            "index": "Allen, JJ"
+                        }
                     }, 
                     {
-                        "surname": "Chalkley", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Chalkley", 
+                            "index": "Chalkley, RJ"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Huang", 
+                            "index": "Huang, Y"
+                        }
                     }, 
                     {
-                        "surname": "Baer", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Baer", 
+                            "index": "Baer, K"
+                        }
                     }, 
                     {
-                        "surname": "Kissel", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Kissel", 
+                            "index": "Kissel, H"
+                        }
                     }, 
                     {
-                        "surname": "Burlingame", 
-                        "given-names": "AL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Burlingame", 
+                            "index": "Burlingame, AL"
+                        }
                     }, 
                     {
-                        "surname": "Shokat", 
-                        "given-names": "KM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KM Shokat", 
+                            "index": "Shokat, KM"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1\u010dek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1\u010dek", 
+                            "index": "Pt\u00e1\u010dek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clock", 
+                "journal": {
+                    "name": [
+                        "Cell Metabolism"
+                    ]
+                }, 
                 "volume": "17", 
-                "source": "Cell Metabolism", 
-                "reference_id": "10.1016/j.cmet.2012.12.017", 
-                "fpage": "291", 
-                "year": "2013", 
-                "position": 15, 
-                "ref": "KaasikKKivim\u00e4eSAllenJJChalkleyRJHuangYBaerKKisselHBurlingameALShokatKMPt\u00e1\u010dekLJFuYH2013Glucose sensor O-GlcNAcylation coordinates with phosphorylation to regulate circadian clockCell Metabolism1729130210.1016/j.cmet.2012.12.017", 
-                "id": "bib15"
+                "pages": {
+                    "first": "291", 
+                    "last": "302", 
+                    "range": "291\u2013302"
+                }, 
+                "doi": "10.1016/j.cmet.2012.12.017"
             }, 
             {
-                "article_title": "CRY2 genetic variants associate with dysthymia", 
-                "doi": "10.1371/journal.pone.0071450", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e71450", 
+                "type": "journal", 
+                "id": "bib16", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Kovanen", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Kovanen", 
+                            "index": "Kovanen, L"
+                        }
                     }, 
                     {
-                        "surname": "Kaunisto", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Kaunisto", 
+                            "index": "Kaunisto, M"
+                        }
                     }, 
                     {
-                        "surname": "Donner", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Donner", 
+                            "index": "Donner, K"
+                        }
                     }, 
                     {
-                        "surname": "Saarikoski", 
-                        "given-names": "ST", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ST Saarikoski", 
+                            "index": "Saarikoski, ST"
+                        }
                     }, 
                     {
-                        "surname": "Partonen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Partonen", 
+                            "index": "Partonen, T"
+                        }
                     }
                 ], 
-                "full_article_title": "CRY2 genetic variants associate with dysthymia", 
-                "publication-type": "journal", 
+                "articleTitle": "CRY2 genetic variants associate with dysthymia", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "8", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0071450", 
-                "year": "2013", 
-                "position": 16, 
-                "ref": "KovanenLKaunistoMDonnerKSaarikoskiSTPartonenT2013CRY2 genetic variants associate with dysthymiaPLoS One8e7145010.1371/journal.pone.0071450", 
-                "id": "bib16"
+                "pages": "e71450", 
+                "doi": "10.1371/journal.pone.0071450"
             }, 
             {
-                "article_title": "mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loop", 
-                "lpage": "205", 
-                "doi": "10.1016/S0092-8674(00)81014-4", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib17", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Kume", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kume", 
+                            "index": "Kume, K"
+                        }
                     }, 
                     {
-                        "surname": "Zylka", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Zylka", 
+                            "index": "Zylka, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Sriram", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sriram", 
+                            "index": "Sriram, S"
+                        }
                     }, 
                     {
-                        "surname": "Shearman", 
-                        "given-names": "LP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LP Shearman", 
+                            "index": "Shearman, LP"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Weaver", 
+                            "index": "Weaver, DR"
+                        }
                     }, 
                     {
-                        "surname": "Jin", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Jin", 
+                            "index": "Jin, X"
+                        }
                     }, 
                     {
-                        "surname": "Maywood", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Maywood", 
+                            "index": "Maywood, ES"
+                        }
                     }, 
                     {
-                        "surname": "Hastings", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Hastings", 
+                            "index": "Hastings, MH"
+                        }
                     }, 
                     {
-                        "surname": "Reppert", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Reppert", 
+                            "index": "Reppert, SM"
+                        }
                     }
                 ], 
-                "full_article_title": "mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loop", 
-                "publication-type": "journal", 
+                "articleTitle": "mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loop", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "98", 
-                "source": "Cell", 
-                "reference_id": "10.1016/S0092-8674(00)81014-4", 
-                "fpage": "193", 
-                "year": "1999", 
-                "position": 17, 
-                "ref": "KumeKZylkaMJSriramSShearmanLPWeaverDRJinXMaywoodESHastingsMHReppertSM1999mCRY1 and mCRY2 are essential components of the negative limb of the circadian clock feedback loopCell9819320510.1016/S0092-8674(00)81014-4", 
-                "id": "bib17"
+                "pages": {
+                    "first": "193", 
+                    "last": "205", 
+                    "range": "193\u2013205"
+                }, 
+                "doi": "10.1016/S0092-8674(00)81014-4"
             }, 
             {
-                "article_title": "CRY2 is associated with depression", 
-                "doi": "10.1371/journal.pone.0009407", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e9407", 
+                "type": "journal", 
+                "id": "bib18", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Lavebratt", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lavebratt", 
+                            "index": "Lavebratt, C"
+                        }
                     }, 
                     {
-                        "surname": "Sj\u00f6holm", 
-                        "given-names": "LK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LK Sj\u00f6holm", 
+                            "index": "Sj\u00f6holm, LK"
+                        }
                     }, 
                     {
-                        "surname": "Soronen", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Soronen", 
+                            "index": "Soronen, P"
+                        }
                     }, 
                     {
-                        "surname": "Paunio", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Paunio", 
+                            "index": "Paunio, T"
+                        }
                     }, 
                     {
-                        "surname": "Vawter", 
-                        "given-names": "MP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MP Vawter", 
+                            "index": "Vawter, MP"
+                        }
                     }, 
                     {
-                        "surname": "Bunney", 
-                        "given-names": "WE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WE Bunney", 
+                            "index": "Bunney, WE"
+                        }
                     }, 
                     {
-                        "surname": "Adolfsson", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Adolfsson", 
+                            "index": "Adolfsson, R"
+                        }
                     }, 
                     {
-                        "surname": "Forsell", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Forsell", 
+                            "index": "Forsell, Y"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "JC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Wu", 
+                            "index": "Wu, JC"
+                        }
                     }, 
                     {
-                        "surname": "Kelsoe", 
-                        "given-names": "JR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JR Kelsoe", 
+                            "index": "Kelsoe, JR"
+                        }
                     }, 
                     {
-                        "surname": "Partonen", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Partonen", 
+                            "index": "Partonen, T"
+                        }
                     }, 
                     {
-                        "surname": "Schalling", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Schalling", 
+                            "index": "Schalling, M"
+                        }
                     }
                 ], 
-                "full_article_title": "CRY2 is associated with depression", 
-                "publication-type": "journal", 
+                "articleTitle": "CRY2 is associated with depression", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0009407", 
-                "year": "2010", 
-                "position": 18, 
-                "ref": "LavebrattCSj\u00f6holmLKSoronenPPaunioTVawterMPBunneyWEAdolfssonRForsellYWuJCKelsoeJRPartonenTSchallingM2010CRY2 is associated with depressionPLoS One5e940710.1371/journal.pone.0009407", 
-                "id": "bib18"
+                "pages": "e9407", 
+                "doi": "10.1371/journal.pone.0009407"
             }, 
             {
-                "article_title": "Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesia", 
-                "lpage": "518", 
-                "doi": "10.1172/JCI58470", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib19", 
+                "date": "2012", 
                 "authors": [
                     {
-                        "surname": "Lee", 
-                        "given-names": "HY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HY Lee", 
+                            "index": "Lee, HY"
+                        }
                     }, 
                     {
-                        "surname": "Nakayama", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Nakayama", 
+                            "index": "Nakayama, J"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Fan", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Fan", 
+                            "index": "Fan, X"
+                        }
                     }, 
                     {
-                        "surname": "Karouani", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Karouani", 
+                            "index": "Karouani, M"
+                        }
                     }, 
                     {
-                        "surname": "Shen", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Shen", 
+                            "index": "Shen, Y"
+                        }
                     }, 
                     {
-                        "surname": "Pothos", 
-                        "given-names": "EN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EN Pothos", 
+                            "index": "Pothos, EN"
+                        }
                     }, 
                     {
-                        "surname": "Hess", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ Hess", 
+                            "index": "Hess, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }, 
                     {
-                        "surname": "Edwards", 
-                        "given-names": "RH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RH Edwards", 
+                            "index": "Edwards, RH"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesia", 
-                "publication-type": "journal", 
+                "articleTitle": "Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesia", 
+                "journal": {
+                    "name": [
+                        "Journal of Clinical Investigation"
+                    ]
+                }, 
                 "volume": "122", 
-                "source": "Journal of Clinical Investigation", 
-                "reference_id": "10.1172/JCI58470", 
-                "fpage": "507", 
-                "year": "2012", 
-                "position": 19, 
-                "ref": "LeeHYNakayamaJXuYFanXKarouaniMShenYPothosENHessEJFuYHEdwardsRHPt\u00e1cekLJ2012Dopamine dysregulation in a mouse model of paroxysmal nonkinesigenic dyskinesiaJournal of Clinical Investigation12250751810.1172/JCI58470", 
-                "id": "bib19"
+                "pages": {
+                    "first": "507", 
+                    "last": "518", 
+                    "range": "507\u2013518"
+                }, 
+                "doi": "10.1172/JCI58470"
             }, 
             {
-                "article_title": "The cryptochromes", 
-                "doi": "10.1186/gb-2005-6-5-220", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "220", 
+                "type": "journal", 
+                "id": "bib20", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Lin", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lin", 
+                            "index": "Lin, C"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }
                 ], 
-                "full_article_title": "The cryptochromes", 
-                "publication-type": "journal", 
+                "articleTitle": "The cryptochromes", 
+                "journal": {
+                    "name": [
+                        "Genome Biology"
+                    ]
+                }, 
                 "volume": "6", 
-                "source": "Genome Biology", 
-                "reference_id": "10.1186/gb-2005-6-5-220", 
-                "year": "2005", 
-                "position": 20, 
-                "ref": "LinCTodoT2005The cryptochromesGenome Biology622010.1186/gb-2005-6-5-220", 
-                "id": "bib20"
+                "pages": "220", 
+                "doi": "10.1186/gb-2005-6-5-220"
             }, 
             {
-                "article_title": "Positional syntenic cloning and functional characterization of the mammalian circadian mutation tau", 
-                "lpage": "491", 
-                "doi": "10.1126/science.288.5465.483", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib21", 
+                "date": "2000", 
                 "authors": [
                     {
-                        "surname": "Lowrey", 
-                        "given-names": "PL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PL Lowrey", 
+                            "index": "Lowrey, PL"
+                        }
                     }, 
                     {
-                        "surname": "Shimomura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shimomura", 
+                            "index": "Shimomura, K"
+                        }
                     }, 
                     {
-                        "surname": "Antoch", 
-                        "given-names": "MP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MP Antoch", 
+                            "index": "Antoch, MP"
+                        }
                     }, 
                     {
-                        "surname": "Yamazaki", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Yamazaki", 
+                            "index": "Yamazaki, S"
+                        }
                     }, 
                     {
-                        "surname": "Zemenides", 
-                        "given-names": "PD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PD Zemenides", 
+                            "index": "Zemenides, PD"
+                        }
                     }, 
                     {
-                        "surname": "Ralph", 
-                        "given-names": "MR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Ralph", 
+                            "index": "Ralph, MR"
+                        }
                     }, 
                     {
-                        "surname": "Menaker", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Menaker", 
+                            "index": "Menaker, M"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Positional syntenic cloning and functional characterization of the mammalian circadian mutation tau", 
-                "publication-type": "journal", 
+                "articleTitle": "Positional syntenic cloning and functional characterization of the mammalian circadian mutation tau", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "288", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.288.5465.483", 
-                "fpage": "483", 
-                "year": "2000", 
-                "position": 21, 
-                "ref": "LowreyPLShimomuraKAntochMPYamazakiSZemenidesPDRalphMRMenakerMTakahashiJS2000Positional syntenic cloning and functional characterization of the mammalian circadian mutation tauScience28848349110.1126/science.288.5465.483", 
-                "id": "bib21"
+                "pages": {
+                    "first": "483", 
+                    "last": "491", 
+                    "range": "483\u2013491"
+                }, 
+                "doi": "10.1126/science.288.5465.483"
             }, 
             {
-                "article_title": "Mammalian circadian biology: elucidating genome-wide levels of temporal organization", 
-                "lpage": "441", 
-                "doi": "10.1146/annurev.genom.5.061903.175925", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib22", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Lowrey", 
-                        "given-names": "PL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PL Lowrey", 
+                            "index": "Lowrey, PL"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Mammalian circadian biology: elucidating genome-wide levels of temporal organization", 
-                "publication-type": "journal", 
+                "articleTitle": "Mammalian circadian biology: elucidating genome-wide levels of temporal organization", 
+                "journal": {
+                    "name": [
+                        "Annual Review of Genomics and Human Genetics"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "Annual Review of Genomics and Human Genetics", 
-                "reference_id": "10.1146/annurev.genom.5.061903.175925", 
-                "fpage": "407", 
-                "year": "2004", 
-                "position": 22, 
-                "ref": "LowreyPLTakahashiJS2004Mammalian circadian biology: elucidating genome-wide levels of temporal organizationAnnual Review of Genomics and Human Genetics540744110.1146/annurev.genom.5.061903.175925", 
-                "id": "bib22"
+                "pages": {
+                    "first": "407", 
+                    "last": "441", 
+                    "range": "407\u2013441"
+                }, 
+                "doi": "10.1146/annurev.genom.5.061903.175925"
             }, 
             {
-                "article_title": "Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligase", 
-                "lpage": "1419", 
-                "doi": "10.1038/cr.2013.136", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib23", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Nangle", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nangle", 
+                            "index": "Nangle, S"
+                        }
                     }, 
                     {
-                        "surname": "Xing", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Xing", 
+                            "index": "Xing, W"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Zheng", 
+                            "index": "Zheng, N"
+                        }
                     }
                 ], 
-                "full_article_title": "Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligase", 
-                "publication-type": "journal", 
+                "articleTitle": "Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligase", 
+                "journal": {
+                    "name": [
+                        "Cell Research"
+                    ]
+                }, 
                 "volume": "23", 
-                "source": "Cell Research", 
-                "reference_id": "10.1038/cr.2013.136", 
-                "fpage": "1417", 
-                "year": "2013", 
-                "position": 23, 
-                "ref": "NangleSXingWZhengN2013Crystal structure of mammalian cryptochrome in complex with a small molecule competitor of its ubiquitin ligaseCell Research231417141910.1038/cr.2013.136", 
-                "id": "bib23"
+                "pages": {
+                    "first": "1417", 
+                    "last": "1419", 
+                    "range": "1417\u20131419"
+                }, 
+                "doi": "10.1038/cr.2013.136"
             }, 
             {
-                "article_title": "Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clock", 
-                "lpage": "2534", 
-                "doi": "10.1126/science.286.5449.2531", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib24", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Okamura", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Okamura", 
+                            "index": "Okamura, H"
+                        }
                     }, 
                     {
-                        "surname": "Miyake", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Miyake", 
+                            "index": "Miyake, S"
+                        }
                     }, 
                     {
-                        "surname": "Sumi", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Sumi", 
+                            "index": "Sumi, Y"
+                        }
                     }, 
                     {
-                        "surname": "Yamaguchi", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Yamaguchi", 
+                            "index": "Yamaguchi, S"
+                        }
                     }, 
                     {
-                        "surname": "Yasui", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Yasui", 
+                            "index": "Yasui, A"
+                        }
                     }, 
                     {
-                        "surname": "Muijtjens", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Muijtjens", 
+                            "index": "Muijtjens, M"
+                        }
                     }, 
                     {
-                        "surname": "Hoeijmakers", 
-                        "given-names": "JH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JH Hoeijmakers", 
+                            "index": "Hoeijmakers, JH"
+                        }
                     }, 
                     {
-                        "surname": "van der Horst", 
-                        "given-names": "GT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GT van der Horst", 
+                            "index": "van der Horst, GT"
+                        }
                     }
                 ], 
-                "full_article_title": "Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clock", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "286", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.286.5449.2531", 
-                "fpage": "2531", 
-                "year": "1999", 
-                "position": 24, 
-                "ref": "OkamuraHMiyakeSSumiYYamaguchiSYasuiAMuijtjensMHoeijmakersJHvan der HorstGT1999Photic induction of mPer1 and mPer2 in cry-deficient mice lacking a biological clockScience2862531253410.1126/science.286.5449.2531", 
-                "id": "bib24"
+                "pages": {
+                    "first": "2531", 
+                    "last": "2534", 
+                    "range": "2531\u20132534"
+                }, 
+                "doi": "10.1126/science.286.5449.2531"
             }, 
             {
-                "article_title": "Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measures", 
-                "lpage": "604", 
-                "doi": "10.1111/jsr.12144", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib25", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "Parsons", 
-                        "given-names": "MJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Parsons", 
+                            "index": "Parsons, MJ"
+                        }
                     }, 
                     {
-                        "surname": "Lester", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Lester", 
+                            "index": "Lester, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Barclay", 
-                        "given-names": "NL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NL Barclay", 
+                            "index": "Barclay, NL"
+                        }
                     }, 
                     {
-                        "surname": "Archer", 
-                        "given-names": "SN", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SN Archer", 
+                            "index": "Archer, SN"
+                        }
                     }, 
                     {
-                        "surname": "Nolan", 
-                        "given-names": "PM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PM Nolan", 
+                            "index": "Nolan, PM"
+                        }
                     }, 
                     {
-                        "surname": "Eley", 
-                        "given-names": "TC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TC Eley", 
+                            "index": "Eley, TC"
+                        }
                     }, 
                     {
-                        "surname": "Gregory", 
-                        "given-names": "AM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AM Gregory", 
+                            "index": "Gregory, AM"
+                        }
                     }
                 ], 
-                "full_article_title": "Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measures", 
-                "publication-type": "journal", 
+                "articleTitle": "Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measures", 
+                "journal": {
+                    "name": [
+                        "Journal of Sleep Research"
+                    ]
+                }, 
                 "volume": "23", 
-                "source": "Journal of Sleep Research", 
-                "reference_id": "10.1111/jsr.12144", 
-                "fpage": "595", 
-                "year": "2014", 
-                "position": 25, 
-                "ref": "ParsonsMJLesterKJBarclayNLArcherSNNolanPMEleyTCGregoryAM2014Polymorphisms in the circadian expressed genes PER3 and ARNTL2 are associated with diurnal preference and GN\u03b23 with sleep measuresJournal of Sleep Research2359560410.1111/jsr.12144", 
-                "id": "bib25"
+                "pages": {
+                    "first": "595", 
+                    "last": "604", 
+                    "range": "595\u2013604"
+                }, 
+                "doi": "10.1111/jsr.12144"
             }, 
             {
-                "article_title": "Cryptochromes and circadian photoreception in animals", 
-                "lpage": "745", 
-                "doi": "10.1016/S0076-6879(05)93038-3", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib26", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Partch", 
-                        "given-names": "CL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CL Partch", 
+                            "index": "Partch, CL"
+                        }
                     }, 
                     {
-                        "surname": "Sancar", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sancar", 
+                            "index": "Sancar, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Cryptochromes and circadian photoreception in animals", 
-                "publication-type": "journal", 
+                "articleTitle": "Cryptochromes and circadian photoreception in animals", 
+                "journal": {
+                    "name": [
+                        "Methods in Enzymology"
+                    ]
+                }, 
                 "volume": "393", 
-                "source": "Methods in Enzymology", 
-                "reference_id": "10.1016/S0076-6879(05)93038-3", 
-                "fpage": "726", 
-                "year": "2005", 
-                "position": 26, 
-                "ref": "PartchCLSancarA2005Cryptochromes and circadian photoreception in animalsMethods in Enzymology39372674510.1016/S0076-6879(05)93038-3", 
-                "id": "bib26"
+                "pages": {
+                    "first": "726", 
+                    "last": "745", 
+                    "range": "726\u2013745"
+                }, 
+                "doi": "10.1016/S0076-6879(05)93038-3"
             }, 
             {
-                "article_title": "UCSF Chimera--a visualization system for exploratory research and analysis", 
-                "lpage": "1612", 
-                "doi": "10.1002/jcc.20084", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib27", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Pettersen", 
-                        "given-names": "EF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EF Pettersen", 
+                            "index": "Pettersen, EF"
+                        }
                     }, 
                     {
-                        "surname": "Goddard", 
-                        "given-names": "TD", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD Goddard", 
+                            "index": "Goddard, TD"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "CC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CC Huang", 
+                            "index": "Huang, CC"
+                        }
                     }, 
                     {
-                        "surname": "Couch", 
-                        "given-names": "GS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GS Couch", 
+                            "index": "Couch, GS"
+                        }
                     }, 
                     {
-                        "surname": "Greenblatt", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Greenblatt", 
+                            "index": "Greenblatt, DM"
+                        }
                     }, 
                     {
-                        "surname": "Meng", 
-                        "given-names": "EC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EC Meng", 
+                            "index": "Meng, EC"
+                        }
                     }, 
                     {
-                        "surname": "Ferrin", 
-                        "given-names": "TE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TE Ferrin", 
+                            "index": "Ferrin, TE"
+                        }
                     }
                 ], 
-                "full_article_title": "UCSF Chimera--a visualization system for exploratory research and analysis", 
-                "publication-type": "journal", 
+                "articleTitle": "UCSF Chimera--a visualization system for exploratory research and analysis", 
+                "journal": {
+                    "name": [
+                        "Journal of Computational Chemistry"
+                    ]
+                }, 
                 "volume": "25", 
-                "source": "Journal of Computational Chemistry", 
-                "reference_id": "10.1002/jcc.20084", 
-                "fpage": "1605", 
-                "year": "2004", 
-                "position": 27, 
-                "ref": "PettersenEFGoddardTDHuangCCCouchGSGreenblattDMMengECFerrinTE2004UCSF Chimera--a visualization system for exploratory research and analysisJournal of Computational Chemistry251605161210.1002/jcc.20084", 
-                "id": "bib27"
+                "pages": {
+                    "first": "1605", 
+                    "last": "1612", 
+                    "range": "1605\u20131612"
+                }, 
+                "doi": "10.1002/jcc.20084"
             }, 
             {
-                "article_title": "Circadian rhythm sleep disorders", 
-                "lpage": "473", 
-                "doi": "10.1016/j.pop.2005.02.002", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib28", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Reid", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Reid", 
+                            "index": "Reid, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Burgess", 
-                        "given-names": "HJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HJ Burgess", 
+                            "index": "Burgess, HJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Circadian rhythm sleep disorders", 
-                "publication-type": "journal", 
+                "articleTitle": "Circadian rhythm sleep disorders", 
+                "journal": {
+                    "name": [
+                        "Primary Care"
+                    ]
+                }, 
                 "volume": "32", 
-                "source": "Primary Care", 
-                "reference_id": "10.1016/j.pop.2005.02.002", 
-                "fpage": "449", 
-                "year": "2005", 
-                "position": 28, 
-                "ref": "ReidKJBurgessHJ2005Circadian rhythm sleep disordersPrimary Care3244947310.1016/j.pop.2005.02.002", 
-                "id": "bib28"
+                "pages": {
+                    "first": "449", 
+                    "last": "473", 
+                    "range": "449\u2013473"
+                }, 
+                "doi": "10.1016/j.pop.2005.02.002"
             }, 
             {
-                "article_title": "Familial advanced sleep phase syndrome", 
-                "lpage": "1094", 
-                "doi": "10.1001/archneur.58.7.1089", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib29", 
+                "date": "2001", 
                 "authors": [
                     {
-                        "surname": "Reid", 
-                        "given-names": "KJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Reid", 
+                            "index": "Reid, KJ"
+                        }
                     }, 
                     {
-                        "surname": "Chang", 
-                        "given-names": "AM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AM Chang", 
+                            "index": "Chang, AM"
+                        }
                     }, 
                     {
-                        "surname": "Dubocovich", 
-                        "given-names": "ML", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ML Dubocovich", 
+                            "index": "Dubocovich, ML"
+                        }
                     }, 
                     {
-                        "surname": "Turek", 
-                        "given-names": "FW", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FW Turek", 
+                            "index": "Turek, FW"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }, 
                     {
-                        "surname": "Zee", 
-                        "given-names": "PC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PC Zee", 
+                            "index": "Zee, PC"
+                        }
                     }
                 ], 
-                "full_article_title": "Familial advanced sleep phase syndrome", 
-                "publication-type": "journal", 
+                "articleTitle": "Familial advanced sleep phase syndrome", 
+                "journal": {
+                    "name": [
+                        "Archives of Neurology"
+                    ]
+                }, 
                 "volume": "58", 
-                "source": "Archives of Neurology", 
-                "reference_id": "10.1001/archneur.58.7.1089", 
-                "fpage": "1089", 
-                "year": "2001", 
-                "position": 29, 
-                "ref": "ReidKJChangAMDubocovichMLTurekFWTakahashiJSZeePC2001Familial advanced sleep phase syndromeArchives of Neurology581089109410.1001/archneur.58.7.1089", 
-                "id": "bib29"
+                "pages": {
+                    "first": "1089", 
+                    "last": "1094", 
+                    "range": "1089\u20131094"
+                }, 
+                "doi": "10.1001/archneur.58.7.1089"
             }, 
             {
-                "article_title": "Kinases and phosphatases in the mammalian circadian clock", 
-                "lpage": "1399", 
-                "doi": "10.1016/j.febslet.2011.02.038", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib30", 
+                "date": "2011", 
                 "authors": [
                     {
-                        "surname": "Reischl", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Reischl", 
+                            "index": "Reischl, S"
+                        }
                     }, 
                     {
-                        "surname": "Kramer", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kramer", 
+                            "index": "Kramer, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Kinases and phosphatases in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Kinases and phosphatases in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "FEBS Letters"
+                    ]
+                }, 
                 "volume": "585", 
-                "source": "FEBS Letters", 
-                "reference_id": "10.1016/j.febslet.2011.02.038", 
-                "fpage": "1393", 
-                "year": "2011", 
-                "position": 30, 
-                "ref": "ReischlSKramerA2011Kinases and phosphatases in the mammalian circadian clockFEBS Letters5851393139910.1016/j.febslet.2011.02.038", 
-                "id": "bib30"
+                "pages": {
+                    "first": "1393", 
+                    "last": "1399", 
+                    "range": "1393\u20131399"
+                }, 
+                "doi": "10.1016/j.febslet.2011.02.038"
             }, 
             {
-                "article_title": "Molecular analysis of mammalian circadian rhythms", 
-                "lpage": "676", 
-                "doi": "10.1146/annurev.physiol.63.1.647", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib31", 
+                "date": "2001", 
                 "authors": [
                     {
-                        "surname": "Reppert", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Reppert", 
+                            "index": "Reppert, SM"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Weaver", 
+                            "index": "Weaver, DR"
+                        }
                     }
                 ], 
-                "full_article_title": "Molecular analysis of mammalian circadian rhythms", 
-                "publication-type": "journal", 
+                "articleTitle": "Molecular analysis of mammalian circadian rhythms", 
+                "journal": {
+                    "name": [
+                        "Annual Review of Physiology"
+                    ]
+                }, 
                 "volume": "63", 
-                "source": "Annual Review of Physiology", 
-                "reference_id": "10.1146/annurev.physiol.63.1.647", 
-                "fpage": "647", 
-                "year": "2001", 
-                "position": 31, 
-                "ref": "ReppertSMWeaverDR2001Molecular analysis of mammalian circadian rhythmsAnnual Review of Physiology6364767610.1146/annurev.physiol.63.1.647", 
-                "id": "bib31"
+                "pages": {
+                    "first": "647", 
+                    "last": "676", 
+                    "range": "647\u2013676"
+                }, 
+                "doi": "10.1146/annurev.physiol.63.1.647"
             }, 
             {
-                "article_title": "A marker for the end of adolescence", 
-                "lpage": "R1039", 
-                "doi": "10.1016/j.cub.2004.11.039", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib32", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Roenneberg", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Roenneberg", 
+                            "index": "Roenneberg, T"
+                        }
                     }, 
                     {
-                        "surname": "Kuehnle", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Kuehnle", 
+                            "index": "Kuehnle, T"
+                        }
                     }, 
                     {
-                        "surname": "Pramstaller", 
-                        "given-names": "PP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PP Pramstaller", 
+                            "index": "Pramstaller, PP"
+                        }
                     }, 
                     {
-                        "surname": "Ricken", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Ricken", 
+                            "index": "Ricken, J"
+                        }
                     }, 
                     {
-                        "surname": "Havel", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Havel", 
+                            "index": "Havel, M"
+                        }
                     }, 
                     {
-                        "surname": "Guth", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Guth", 
+                            "index": "Guth, A"
+                        }
                     }, 
                     {
-                        "surname": "Merrow", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Merrow", 
+                            "index": "Merrow, M"
+                        }
                     }
                 ], 
-                "full_article_title": "A marker for the end of adolescence", 
-                "publication-type": "journal", 
+                "articleTitle": "A marker for the end of adolescence", 
+                "journal": {
+                    "name": [
+                        "Current Biology"
+                    ]
+                }, 
                 "volume": "14", 
-                "source": "Current Biology", 
-                "reference_id": "10.1016/j.cub.2004.11.039", 
-                "fpage": "R1038", 
-                "year": "2004", 
-                "position": 32, 
-                "ref": "RoennebergTKuehnleTPramstallerPPRickenJHavelMGuthAMerrowM2004A marker for the end of adolescenceCurrent Biology14R1038R103910.1016/j.cub.2004.11.039", 
-                "id": "bib32"
+                "pages": {
+                    "first": "R1038", 
+                    "last": "R1039", 
+                    "range": "R1038\u2013R1039"
+                }, 
+                "doi": "10.1016/j.cub.2004.11.039"
             }, 
             {
-                "article_title": "Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinase", 
-                "lpage": "708", 
-                "doi": "10.1111/j.1356-9597.2004.00758.x", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib33", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Sanada", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Sanada", 
+                            "index": "Sanada, K"
+                        }
                     }, 
                     {
-                        "surname": "Harada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Harada", 
+                            "index": "Harada, Y"
+                        }
                     }, 
                     {
-                        "surname": "Sakai", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Sakai", 
+                            "index": "Sakai, M"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinase", 
-                "publication-type": "journal", 
+                "articleTitle": "Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinase", 
+                "journal": {
+                    "name": [
+                        "Genes to Cells"
+                    ]
+                }, 
                 "volume": "9", 
-                "source": "Genes to Cells", 
-                "reference_id": "10.1111/j.1356-9597.2004.00758.x", 
-                "fpage": "697", 
-                "year": "2004", 
-                "position": 33, 
-                "ref": "SanadaKHaradaYSakaiMTodoTFukadaY2004Serine phosphorylation of mCRY1 and mCRY2 by mitogen-activated protein kinaseGenes to Cells969770810.1111/j.1356-9597.2004.00758.x", 
-                "id": "bib33"
+                "pages": {
+                    "first": "697", 
+                    "last": "708", 
+                    "range": "697\u2013708"
+                }, 
+                "doi": "10.1111/j.1356-9597.2004.00758.x"
             }, 
             {
-                "article_title": "Interacting molecular loops in the mammalian circadian clock", 
-                "lpage": "1019", 
-                "doi": "10.1126/science.288.5468.1013", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib34", 
+                "date": "2000", 
                 "authors": [
                     {
-                        "surname": "Shearman", 
-                        "given-names": "LP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LP Shearman", 
+                            "index": "Shearman, LP"
+                        }
                     }, 
                     {
-                        "surname": "Sriram", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Sriram", 
+                            "index": "Sriram, S"
+                        }
                     }, 
                     {
-                        "surname": "Weaver", 
-                        "given-names": "DR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DR Weaver", 
+                            "index": "Weaver, DR"
+                        }
                     }, 
                     {
-                        "surname": "Maywood", 
-                        "given-names": "ES", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ES Maywood", 
+                            "index": "Maywood, ES"
+                        }
                     }, 
                     {
-                        "surname": "Chaves", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Chaves", 
+                            "index": "Chaves, I"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "B", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zheng", 
+                            "index": "Zheng, B"
+                        }
                     }, 
                     {
-                        "surname": "Kume", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kume", 
+                            "index": "Kume, K"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "CC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CC Lee", 
+                            "index": "Lee, CC"
+                        }
                     }, 
                     {
-                        "surname": "van der Horst", 
-                        "given-names": "GT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GT van der Horst", 
+                            "index": "van der Horst, GT"
+                        }
                     }, 
                     {
-                        "surname": "Hastings", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Hastings", 
+                            "index": "Hastings, MH"
+                        }
                     }, 
                     {
-                        "surname": "Reppert", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Reppert", 
+                            "index": "Reppert, SM"
+                        }
                     }
                 ], 
-                "full_article_title": "Interacting molecular loops in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Interacting molecular loops in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "288", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.288.5468.1013", 
-                "fpage": "1013", 
-                "year": "2000", 
-                "position": 34, 
-                "ref": "ShearmanLPSriramSWeaverDRMaywoodESChavesIZhengBKumeKLeeCCvan der HorstGTHastingsMHReppertSM2000Interacting molecular loops in the mammalian circadian clockScience2881013101910.1126/science.288.5468.1013", 
-                "id": "bib34"
+                "pages": {
+                    "first": "1013", 
+                    "last": "1019", 
+                    "range": "1013\u20131019"
+                }, 
+                "doi": "10.1126/science.288.5468.1013"
             }, 
             {
-                "article_title": "Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clock", 
-                "lpage": "4755", 
-                "doi": "10.1073/pnas.1302560110", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib35", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Shi", 
-                        "given-names": "G", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Shi", 
+                            "index": "Shi, G"
+                        }
                     }, 
                     {
-                        "surname": "Xing", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Xing", 
+                            "index": "Xing, L"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Liu", 
+                            "index": "Liu, Z"
+                        }
                     }, 
                     {
-                        "surname": "Qu", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Qu", 
+                            "index": "Qu, Z"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Wu", 
+                            "index": "Wu, X"
+                        }
                     }, 
                     {
-                        "surname": "Dong", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Dong", 
+                            "index": "Dong, Z"
+                        }
                     }, 
                     {
-                        "surname": "Wang", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Wang", 
+                            "index": "Wang, X"
+                        }
                     }, 
                     {
-                        "surname": "Gao", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Gao", 
+                            "index": "Gao, X"
+                        }
                     }, 
                     {
-                        "surname": "Huang", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Huang", 
+                            "index": "Huang, M"
+                        }
                     }, 
                     {
-                        "surname": "Yan", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Yan", 
+                            "index": "Yan, J"
+                        }
                     }, 
                     {
-                        "surname": "Yang", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Yang", 
+                            "index": "Yang, L"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Liu", 
+                            "index": "Liu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Ptacek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Ptacek", 
+                            "index": "Ptacek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clock", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "110", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.1302560110", 
-                "fpage": "4750", 
-                "year": "2013", 
-                "position": 35, 
-                "ref": "ShiGXingLLiuZQuZWuXDongZWangXGaoXHuangMYanJYangLLiuYPtacekLJXuY2013Dual roles of FBXL3 in the mammalian circadian feedback loops are important for period determination and robustness of the clockPNAS1104750475510.1073/pnas.1302560110", 
-                "id": "bib35"
+                "pages": {
+                    "first": "4750", 
+                    "last": "4755", 
+                    "range": "4750\u20134755"
+                }, 
+                "doi": "10.1073/pnas.1302560110"
             }, 
             {
-                "article_title": "Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expression", 
-                "lpage": "1023", 
-                "doi": "10.1016/j.cell.2007.04.030", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib36", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Siepka", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Siepka", 
+                            "index": "Siepka, SM"
+                        }
                     }, 
                     {
-                        "surname": "Yoo", 
-                        "given-names": "SH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Yoo", 
+                            "index": "Yoo, SH"
+                        }
                     }, 
                     {
-                        "surname": "Park", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Park", 
+                            "index": "Park, J"
+                        }
                     }, 
                     {
-                        "surname": "Song", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Song", 
+                            "index": "Song, W"
+                        }
                     }, 
                     {
-                        "surname": "Kumar", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Kumar", 
+                            "index": "Kumar, V"
+                        }
                     }, 
                     {
-                        "surname": "Hu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Hu", 
+                            "index": "Hu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Lee", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lee", 
+                            "index": "Lee, C"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expression", 
-                "publication-type": "journal", 
+                "articleTitle": "Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expression", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "129", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2007.04.030", 
-                "fpage": "1011", 
-                "year": "2007", 
-                "position": 36, 
-                "ref": "SiepkaSMYooSHParkJSongWKumarVHuYLeeCTakahashiJS2007Circadian mutant overtime reveals F-box protein FBXL3 regulation of cryptochrome and period gene expressionCell1291011102310.1016/j.cell.2007.04.030", 
-                "id": "bib36"
+                "pages": {
+                    "first": "1011", 
+                    "last": "1023", 
+                    "range": "1011\u20131023"
+                }, 
+                "doi": "10.1016/j.cell.2007.04.030"
             }, 
             {
-                "article_title": "CRY2 is associated with rapid cycling in bipolar disorder patients", 
-                "doi": "10.1371/journal.pone.0012632", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "e12632", 
+                "type": "journal", 
+                "id": "bib37", 
+                "date": "2010", 
                 "authors": [
                     {
-                        "surname": "Sj\u00f6holm", 
-                        "given-names": "LK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LK Sj\u00f6holm", 
+                            "index": "Sj\u00f6holm, LK"
+                        }
                     }, 
                     {
-                        "surname": "Backlund", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Backlund", 
+                            "index": "Backlund, L"
+                        }
                     }, 
                     {
-                        "surname": "Cheteh", 
-                        "given-names": "EH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EH Cheteh", 
+                            "index": "Cheteh, EH"
+                        }
                     }, 
                     {
-                        "surname": "Ek", 
-                        "given-names": "IR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IR Ek", 
+                            "index": "Ek, IR"
+                        }
                     }, 
                     {
-                        "surname": "Fris\u00e9n", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Fris\u00e9n", 
+                            "index": "Fris\u00e9n, L"
+                        }
                     }, 
                     {
-                        "surname": "Schalling", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Schalling", 
+                            "index": "Schalling, M"
+                        }
                     }, 
                     {
-                        "surname": "Osby", 
-                        "given-names": "U", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Osby", 
+                            "index": "Osby, U"
+                        }
                     }, 
                     {
-                        "surname": "Lavebratt", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Lavebratt", 
+                            "index": "Lavebratt, C"
+                        }
                     }, 
                     {
-                        "surname": "Nikamo", 
-                        "given-names": "P", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Nikamo", 
+                            "index": "Nikamo, P"
+                        }
                     }
                 ], 
-                "full_article_title": "CRY2 is associated with rapid cycling in bipolar disorder patients", 
-                "publication-type": "journal", 
+                "articleTitle": "CRY2 is associated with rapid cycling in bipolar disorder patients", 
+                "journal": {
+                    "name": [
+                        "PLoS One"
+                    ]
+                }, 
                 "volume": "5", 
-                "source": "PLoS One", 
-                "reference_id": "10.1371/journal.pone.0012632", 
-                "year": "2010", 
-                "position": 37, 
-                "ref": "Sj\u00f6holmLKBacklundLChetehEHEkIRFris\u00e9nLSchallingMOsbyULavebrattCNikamoP2010CRY2 is associated with rapid cycling in bipolar disorder patientsPLoS One5e1263210.1371/journal.pone.0012632", 
-                "id": "bib37"
+                "pages": "e12632", 
+                "doi": "10.1371/journal.pone.0012632"
             }, 
             {
-                "article_title": "Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clock", 
-                "lpage": "2045", 
-                "doi": "10.1073/pnas.1323618111", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib38", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "St. John", 
-                        "given-names": "PC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PC St. John", 
+                            "index": "St. John, PC"
+                        }
                     }, 
                     {
-                        "surname": "Hirota", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Hirota", 
+                            "index": "Hirota, T"
+                        }
                     }, 
                     {
-                        "surname": "Kay", 
-                        "given-names": "SA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Kay", 
+                            "index": "Kay, SA"
+                        }
                     }, 
                     {
-                        "surname": "Doyle", 
-                        "given-names": "FJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FJ Doyle", 
+                            "index": "Doyle, FJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clock", 
-                "publication-type": "journal", 
+                "articleTitle": "Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clock", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "111", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.1323618111", 
-                "fpage": "2040", 
-                "year": "2014", 
-                "position": 38, 
-                "ref": "St. JohnPCHirotaTKaySADoyleFJ2014Spatiotemporal separation of PER and CRY posttranslational regulation in the mammalian circadian clockPNAS1112040204510.1073/pnas.1323618111", 
-                "id": "bib38"
+                "pages": {
+                    "first": "2040", 
+                    "last": "2045", 
+                    "range": "2040\u20132045"
+                }, 
+                "doi": "10.1073/pnas.1323618111"
             }, 
             {
-                "article_title": "A central role for ubiquitination within a circadian clock protein modification code", 
-                "doi": "10.3389/fnmol.2014.00069", 
-                "article_doi": "10.7554/eLife.16695", 
-                "elocation-id": "69", 
+                "type": "journal", 
+                "id": "bib39", 
+                "date": "2014", 
                 "authors": [
                     {
-                        "surname": "Stojkovic", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Stojkovic", 
+                            "index": "Stojkovic, K"
+                        }
                     }, 
                     {
-                        "surname": "Wing", 
-                        "given-names": "SS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SS Wing", 
+                            "index": "Wing, SS"
+                        }
                     }, 
                     {
-                        "surname": "Cermakian", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Cermakian", 
+                            "index": "Cermakian, N"
+                        }
                     }
                 ], 
-                "full_article_title": "A central role for ubiquitination within a circadian clock protein modification code", 
-                "publication-type": "journal", 
+                "articleTitle": "A central role for ubiquitination within a circadian clock protein modification code", 
+                "journal": {
+                    "name": [
+                        "Frontiers in Molecular Neuroscience"
+                    ]
+                }, 
                 "volume": "7", 
-                "source": "Frontiers in Molecular Neuroscience", 
-                "reference_id": "10.3389/fnmol.2014.00069", 
-                "year": "2014", 
-                "position": 39, 
-                "ref": "StojkovicKWingSSCermakianN2014A central role for ubiquitination within a circadian clock protein modification codeFrontiers in Molecular Neuroscience76910.3389/fnmol.2014.00069", 
-                "id": "bib39"
+                "pages": "69", 
+                "doi": "10.3389/fnmol.2014.00069"
             }, 
             {
-                "article_title": "Molecular neurobiology and genetics of circadian rhythms in mammals", 
-                "lpage": "553", 
-                "doi": "10.1146/annurev.ne.18.030195.002531", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib40", 
+                "date": "1995", 
                 "authors": [
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Molecular neurobiology and genetics of circadian rhythms in mammals", 
-                "publication-type": "journal", 
+                "articleTitle": "Molecular neurobiology and genetics of circadian rhythms in mammals", 
+                "journal": {
+                    "name": [
+                        "Annual Review of Neuroscience"
+                    ]
+                }, 
                 "volume": "18", 
-                "source": "Annual Review of Neuroscience", 
-                "reference_id": "10.1146/annurev.ne.18.030195.002531", 
-                "fpage": "531", 
-                "year": "1995", 
-                "position": 40, 
-                "ref": "TakahashiJS1995Molecular neurobiology and genetics of circadian rhythms in mammalsAnnual Review of Neuroscience1853155310.1146/annurev.ne.18.030195.002531", 
-                "id": "bib40"
+                "pages": {
+                    "first": "531", 
+                    "last": "553", 
+                    "range": "531\u2013553"
+                }, 
+                "doi": "10.1146/annurev.ne.18.030195.002531"
             }, 
             {
-                "article_title": "An hPer2 phosphorylation site mutation in familial advanced sleep phase syndrome", 
-                "lpage": "1043", 
-                "doi": "10.1126/science.1057499", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib41", 
+                "date": "2001", 
                 "authors": [
                     {
-                        "surname": "Toh", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Toh", 
+                            "index": "Toh, KL"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "He", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y He", 
+                            "index": "He, Y"
+                        }
                     }, 
                     {
-                        "surname": "Eide", 
-                        "given-names": "EJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EJ Eide", 
+                            "index": "Eide, EJ"
+                        }
                     }, 
                     {
-                        "surname": "Hinz", 
-                        "given-names": "WA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WA Hinz", 
+                            "index": "Hinz, WA"
+                        }
                     }, 
                     {
-                        "surname": "Virshup", 
-                        "given-names": "DM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Virshup", 
+                            "index": "Virshup, DM"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "An hPer2 phosphorylation site mutation in familial advanced sleep phase syndrome", 
-                "publication-type": "journal", 
+                "articleTitle": "An hPer2 phosphorylation site mutation in familial advanced sleep phase syndrome", 
+                "journal": {
+                    "name": [
+                        "Science"
+                    ]
+                }, 
                 "volume": "291", 
-                "source": "Science", 
-                "reference_id": "10.1126/science.1057499", 
-                "fpage": "1040", 
-                "year": "2001", 
-                "position": 41, 
-                "ref": "TohKLJonesCRHeYEideEJHinzWAVirshupDMPt\u00e1cekLJFuYH2001An hPer2 phosphorylation site mutation in familial advanced sleep phase syndromeScience2911040104310.1126/science.1057499", 
-                "id": "bib41"
+                "pages": {
+                    "first": "1040", 
+                    "last": "1043", 
+                    "range": "1040\u20131043"
+                }, 
+                "doi": "10.1126/science.1057499"
             }, 
             {
-                "article_title": "Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythms", 
-                "lpage": "630", 
-                "doi": "10.1038/19323", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib42", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "van der Horst", 
-                        "given-names": "GT", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GT van der Horst", 
+                            "index": "van der Horst, GT"
+                        }
                     }, 
                     {
-                        "surname": "Muijtjens", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Muijtjens", 
+                            "index": "Muijtjens, M"
+                        }
                     }, 
                     {
-                        "surname": "Kobayashi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kobayashi", 
+                            "index": "Kobayashi, K"
+                        }
                     }, 
                     {
-                        "surname": "Takano", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Takano", 
+                            "index": "Takano, R"
+                        }
                     }, 
                     {
-                        "surname": "Kanno", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Kanno", 
+                            "index": "Kanno, S"
+                        }
                     }, 
                     {
-                        "surname": "Takao", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Takao", 
+                            "index": "Takao, M"
+                        }
                     }, 
                     {
-                        "surname": "de Wit", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J de Wit", 
+                            "index": "de Wit, J"
+                        }
                     }, 
                     {
-                        "surname": "Verkerk", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Verkerk", 
+                            "index": "Verkerk, A"
+                        }
                     }, 
                     {
-                        "surname": "Eker", 
-                        "given-names": "AP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AP Eker", 
+                            "index": "Eker, AP"
+                        }
                     }, 
                     {
-                        "surname": "van Leenen", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D van Leenen", 
+                            "index": "van Leenen, D"
+                        }
                     }, 
                     {
-                        "surname": "Buijs", 
-                        "given-names": "R", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Buijs", 
+                            "index": "Buijs, R"
+                        }
                     }, 
                     {
-                        "surname": "Bootsma", 
-                        "given-names": "D", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Bootsma", 
+                            "index": "Bootsma, D"
+                        }
                     }, 
                     {
-                        "surname": "Hoeijmakers", 
-                        "given-names": "JH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JH Hoeijmakers", 
+                            "index": "Hoeijmakers, JH"
+                        }
                     }, 
                     {
-                        "surname": "Yasui", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Yasui", 
+                            "index": "Yasui, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythms", 
-                "publication-type": "journal", 
+                "articleTitle": "Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythms", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "398", 
-                "source": "Nature", 
-                "reference_id": "10.1038/19323", 
-                "fpage": "627", 
-                "year": "1999", 
-                "position": 42, 
-                "ref": "van der HorstGTMuijtjensMKobayashiKTakanoRKannoSTakaoMde WitJVerkerkAEkerAPvan LeenenDBuijsRBootsmaDHoeijmakersJHYasuiA1999Mammalian Cry1 and Cry2 are essential for maintenance of circadian rhythmsNature39862763010.1038/19323", 
-                "id": "bib42"
+                "pages": {
+                    "first": "627", 
+                    "last": "630", 
+                    "range": "627\u2013630"
+                }, 
+                "doi": "10.1038/19323"
             }, 
             {
-                "article_title": "Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2", 
-                "lpage": "12119", 
-                "doi": "10.1073/pnas.96.21.12114", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib43", 
+                "date": "1999", 
                 "authors": [
                     {
-                        "surname": "Vitaterna", 
-                        "given-names": "MH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Vitaterna", 
+                            "index": "Vitaterna, MH"
+                        }
                     }, 
                     {
-                        "surname": "Selby", 
-                        "given-names": "CP", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CP Selby", 
+                            "index": "Selby, CP"
+                        }
                     }, 
                     {
-                        "surname": "Todo", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Todo", 
+                            "index": "Todo, T"
+                        }
                     }, 
                     {
-                        "surname": "Niwa", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Niwa", 
+                            "index": "Niwa, H"
+                        }
                     }, 
                     {
-                        "surname": "Thompson", 
-                        "given-names": "C", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Thompson", 
+                            "index": "Thompson, C"
+                        }
                     }, 
                     {
-                        "surname": "Fruechte", 
-                        "given-names": "EM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Fruechte", 
+                            "index": "Fruechte, EM"
+                        }
                     }, 
                     {
-                        "surname": "Hitomi", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Hitomi", 
+                            "index": "Hitomi, K"
+                        }
                     }, 
                     {
-                        "surname": "Thresher", 
-                        "given-names": "RJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Thresher", 
+                            "index": "Thresher, RJ"
+                        }
                     }, 
                     {
-                        "surname": "Ishikawa", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Ishikawa", 
+                            "index": "Ishikawa, T"
+                        }
                     }, 
                     {
-                        "surname": "Miyazaki", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Miyazaki", 
+                            "index": "Miyazaki, J"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }, 
                     {
-                        "surname": "Sancar", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Sancar", 
+                            "index": "Sancar, A"
+                        }
                     }
                 ], 
-                "full_article_title": "Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2", 
-                "publication-type": "journal", 
+                "articleTitle": "Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "96", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.96.21.12114", 
-                "fpage": "12114", 
-                "year": "1999", 
-                "position": 43, 
-                "ref": "VitaternaMHSelbyCPTodoTNiwaHThompsonCFruechteEMHitomiKThresherRJIshikawaTMiyazakiJTakahashiJSSancarA1999Differential regulation of mammalian period genes and circadian rhythmicity by cryptochromes 1 and 2PNAS96121141211910.1073/pnas.96.21.12114", 
-                "id": "bib43"
+                "pages": {
+                    "first": "12114", 
+                    "last": "12119", 
+                    "range": "12114\u201312119"
+                }, 
+                "doi": "10.1073/pnas.96.21.12114"
             }, 
             {
-                "article_title": "SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocket", 
-                "lpage": "68", 
-                "doi": "10.1038/nature11964", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib44", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Xing", 
-                        "given-names": "W", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Xing", 
+                            "index": "Xing, W"
+                        }
                     }, 
                     {
-                        "surname": "Busino", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Busino", 
+                            "index": "Busino, L"
+                        }
                     }, 
                     {
-                        "surname": "Hinds", 
-                        "given-names": "TR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Hinds", 
+                            "index": "Hinds, TR"
+                        }
                     }, 
                     {
-                        "surname": "Marionni", 
-                        "given-names": "ST", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ST Marionni", 
+                            "index": "Marionni, ST"
+                        }
                     }, 
                     {
-                        "surname": "Saifee", 
-                        "given-names": "NH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NH Saifee", 
+                            "index": "Saifee, NH"
+                        }
                     }, 
                     {
-                        "surname": "Bush", 
-                        "given-names": "MF", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MF Bush", 
+                            "index": "Bush, MF"
+                        }
                     }, 
                     {
-                        "surname": "Pagano", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Pagano", 
+                            "index": "Pagano, M"
+                        }
                     }, 
                     {
-                        "surname": "Zheng", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Zheng", 
+                            "index": "Zheng, N"
+                        }
                     }
                 ], 
-                "full_article_title": "SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocket", 
-                "publication-type": "journal", 
+                "articleTitle": "SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocket", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "496", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature11964", 
-                "fpage": "64", 
-                "year": "2013", 
-                "position": 44, 
-                "ref": "XingWBusinoLHindsTRMarionniSTSaifeeNHBushMFPaganoMZhengN2013SCF(FBXL3) ubiquitin ligase targets cryptochromes at their cofactor pocketNature496646810.1038/nature11964", 
-                "id": "bib44"
+                "pages": {
+                    "first": "64", 
+                    "last": "68", 
+                    "range": "64\u201368"
+                }, 
+                "doi": "10.1038/nature11964"
             }, 
             {
-                "article_title": "Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndrome", 
-                "lpage": "644", 
-                "doi": "10.1038/nature03453", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib45", 
+                "date": "2005", 
                 "authors": [
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Padiath", 
-                        "given-names": "QS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "QS Padiath", 
+                            "index": "Padiath, QS"
+                        }
                     }, 
                     {
-                        "surname": "Shapiro", 
-                        "given-names": "RE", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RE Shapiro", 
+                            "index": "Shapiro, RE"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Wu", 
-                        "given-names": "SC", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Wu", 
+                            "index": "Wu, SC"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Saigoh", 
+                            "index": "Saigoh, N"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Saigoh", 
+                            "index": "Saigoh, K"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndrome", 
-                "publication-type": "journal", 
+                "articleTitle": "Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndrome", 
+                "journal": {
+                    "name": [
+                        "Nature"
+                    ]
+                }, 
                 "volume": "434", 
-                "source": "Nature", 
-                "reference_id": "10.1038/nature03453", 
-                "fpage": "640", 
-                "year": "2005", 
-                "position": 45, 
-                "ref": "XuYPadiathQSShapiroREJonesCRWuSCSaigohNSaigohKPt\u00e1cekLJFuYH2005Functional consequences of a CKIdelta mutation causing familial advanced sleep phase syndromeNature43464064410.1038/nature03453", 
-                "id": "bib45"
+                "pages": {
+                    "first": "640", 
+                    "last": "644", 
+                    "range": "640\u2013644"
+                }, 
+                "doi": "10.1038/nature03453"
             }, 
             {
-                "article_title": "Modeling of a human circadian mutation yields insights into clock regulation by PER2", 
-                "lpage": "70", 
-                "doi": "10.1016/j.cell.2006.11.043", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib46", 
+                "date": "2007", 
                 "authors": [
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Toh", 
-                        "given-names": "KL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Toh", 
+                            "index": "Toh, KL"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Shin", 
-                        "given-names": "JY", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JY Shin", 
+                            "index": "Shin, JY"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1cek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1cek", 
+                            "index": "Pt\u00e1cek, LJ"
+                        }
                     }
                 ], 
-                "full_article_title": "Modeling of a human circadian mutation yields insights into clock regulation by PER2", 
-                "publication-type": "journal", 
+                "articleTitle": "Modeling of a human circadian mutation yields insights into clock regulation by PER2", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "128", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2006.11.043", 
-                "fpage": "59", 
-                "year": "2007", 
-                "position": 46, 
-                "ref": "XuYTohKLJonesCRShinJYFuYHPt\u00e1cekLJ2007Modeling of a human circadian mutation yields insights into clock regulation by PER2Cell128597010.1016/j.cell.2006.11.043", 
-                "id": "bib46"
+                "pages": {
+                    "first": "59", 
+                    "last": "70", 
+                    "range": "59\u201370"
+                }, 
+                "doi": "10.1016/j.cell.2006.11.043"
             }, 
             {
-                "article_title": "Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasm", 
-                "lpage": "1105", 
-                "doi": "10.1016/j.cell.2013.01.055", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib47", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Yoo", 
-                        "given-names": "SH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Yoo", 
+                            "index": "Yoo, SH"
+                        }
                     }, 
                     {
-                        "surname": "Mohawk", 
-                        "given-names": "JA", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JA Mohawk", 
+                            "index": "Mohawk, JA"
+                        }
                     }, 
                     {
-                        "surname": "Siepka", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Siepka", 
+                            "index": "Siepka, SM"
+                        }
                     }, 
                     {
-                        "surname": "Shan", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Shan", 
+                            "index": "Shan, Y"
+                        }
                     }, 
                     {
-                        "surname": "Huh", 
-                        "given-names": "SK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SK Huh", 
+                            "index": "Huh, SK"
+                        }
                     }, 
                     {
-                        "surname": "Hong", 
-                        "given-names": "HK", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HK Hong", 
+                            "index": "Hong, HK"
+                        }
                     }, 
                     {
-                        "surname": "Kornblum", 
-                        "given-names": "I", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Kornblum", 
+                            "index": "Kornblum, I"
+                        }
                     }, 
                     {
-                        "surname": "Kumar", 
-                        "given-names": "V", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Kumar", 
+                            "index": "Kumar, V"
+                        }
                     }, 
                     {
-                        "surname": "Koike", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Koike", 
+                            "index": "Koike, N"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Xu", 
+                            "index": "Xu, M"
+                        }
                     }, 
                     {
-                        "surname": "Nussbaum", 
-                        "given-names": "J", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Nussbaum", 
+                            "index": "Nussbaum, J"
+                        }
                     }, 
                     {
-                        "surname": "Liu", 
-                        "given-names": "X", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "X Liu", 
+                            "index": "Liu, X"
+                        }
                     }, 
                     {
-                        "surname": "Chen", 
-                        "given-names": "Z", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Chen", 
+                            "index": "Chen, Z"
+                        }
                     }, 
                     {
-                        "surname": "Chen", 
-                        "given-names": "ZJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ZJ Chen", 
+                            "index": "Chen, ZJ"
+                        }
                     }, 
                     {
-                        "surname": "Green", 
-                        "given-names": "CB", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CB Green", 
+                            "index": "Green, CB"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasm", 
-                "publication-type": "journal", 
+                "articleTitle": "Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasm", 
+                "journal": {
+                    "name": [
+                        "Cell"
+                    ]
+                }, 
                 "volume": "152", 
-                "source": "Cell", 
-                "reference_id": "10.1016/j.cell.2013.01.055", 
-                "fpage": "1091", 
-                "year": "2013", 
-                "position": 47, 
-                "ref": "YooSHMohawkJASiepkaSMShanYHuhSKHongHKKornblumIKumarVKoikeNXuMNussbaumJLiuXChenZChenZJGreenCBTakahashiJS2013Competing E3 ubiquitin ligases govern circadian periodicity by degradation of CRY in nucleus and cytoplasmCell1521091110510.1016/j.cell.2013.01.055", 
-                "id": "bib47"
+                "pages": {
+                    "first": "1091", 
+                    "last": "1105", 
+                    "range": "1091\u20131105"
+                }, 
+                "doi": "10.1016/j.cell.2013.01.055"
             }, 
             {
-                "article_title": "PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissues", 
-                "lpage": "5346", 
-                "doi": "10.1073/pnas.0308709101", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib48", 
+                "date": "2004", 
                 "authors": [
                     {
-                        "surname": "Yoo", 
-                        "given-names": "S-H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S-H Yoo", 
+                            "index": "Yoo, S-H"
+                        }
                     }, 
                     {
-                        "surname": "Yamazaki", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Yamazaki", 
+                            "index": "Yamazaki, S"
+                        }
                     }, 
                     {
-                        "surname": "Lowrey", 
-                        "given-names": "PL", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PL Lowrey", 
+                            "index": "Lowrey, PL"
+                        }
                     }, 
                     {
-                        "surname": "Shimomura", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Shimomura", 
+                            "index": "Shimomura, K"
+                        }
                     }, 
                     {
-                        "surname": "Ko", 
-                        "given-names": "CH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CH Ko", 
+                            "index": "Ko, CH"
+                        }
                     }, 
                     {
-                        "surname": "Buhr", 
-                        "given-names": "ED", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ED Buhr", 
+                            "index": "Buhr, ED"
+                        }
                     }, 
                     {
-                        "surname": "Siepka", 
-                        "given-names": "SM", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Siepka", 
+                            "index": "Siepka, SM"
+                        }
                     }, 
                     {
-                        "surname": "Hong", 
-                        "given-names": "H-K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H-K Hong", 
+                            "index": "Hong, H-K"
+                        }
                     }, 
                     {
-                        "surname": "Oh", 
-                        "given-names": "WJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WJ Oh", 
+                            "index": "Oh, WJ"
+                        }
                     }, 
                     {
-                        "surname": "Yoo", 
-                        "given-names": "OJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "OJ Yoo", 
+                            "index": "Yoo, OJ"
+                        }
                     }, 
                     {
-                        "surname": "Menaker", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Menaker", 
+                            "index": "Menaker, M"
+                        }
                     }, 
                     {
-                        "surname": "Takahashi", 
-                        "given-names": "JS", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JS Takahashi", 
+                            "index": "Takahashi, JS"
+                        }
                     }
                 ], 
-                "full_article_title": "PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissues", 
-                "publication-type": "journal", 
+                "articleTitle": "PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissues", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "101", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.0308709101", 
-                "fpage": "5339", 
-                "year": "2004", 
-                "position": 48, 
-                "ref": "YooS-HYamazakiSLowreyPLShimomuraKKoCHBuhrEDSiepkaSMHongH-KOhWJYooOJMenakerMTakahashiJS2004PERIOD2::LUCIFERASE real-time reporting of circadian dynamics reveals persistent circadian oscillations in mouse peripheral tissuesPNAS1015339534610.1073/pnas.0308709101", 
-                "id": "bib48"
+                "pages": {
+                    "first": "5339", 
+                    "last": "5346", 
+                    "range": "5339\u20135346"
+                }, 
+                "doi": "10.1073/pnas.0308709101"
             }, 
             {
-                "article_title": "Roles of CLOCK phosphorylation in suppression of E-box-dependent transcription", 
-                "lpage": "3686", 
-                "doi": "10.1128/MCB.01864-08", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib49", 
+                "date": "2009", 
                 "authors": [
                     {
-                        "surname": "Yoshitane", 
-                        "given-names": "H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Yoshitane", 
+                            "index": "Yoshitane, H"
+                        }
                     }, 
                     {
-                        "surname": "Takao", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Takao", 
+                            "index": "Takao, T"
+                        }
                     }, 
                     {
-                        "surname": "Satomi", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Satomi", 
+                            "index": "Satomi, Y"
+                        }
                     }, 
                     {
-                        "surname": "Du", 
-                        "given-names": "NH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NH Du", 
+                            "index": "Du, NH"
+                        }
                     }, 
                     {
-                        "surname": "Okano", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Okano", 
+                            "index": "Okano, T"
+                        }
                     }, 
                     {
-                        "surname": "Fukada", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Fukada", 
+                            "index": "Fukada, Y"
+                        }
                     }
                 ], 
-                "full_article_title": "Roles of CLOCK phosphorylation in suppression of E-box-dependent transcription", 
-                "publication-type": "journal", 
+                "articleTitle": "Roles of CLOCK phosphorylation in suppression of E-box-dependent transcription", 
+                "journal": {
+                    "name": [
+                        "Molecular and Cellular Biology"
+                    ]
+                }, 
                 "volume": "29", 
-                "source": "Molecular and Cellular Biology", 
-                "reference_id": "10.1128/MCB.01864-08", 
-                "fpage": "3675", 
-                "year": "2009", 
-                "position": 49, 
-                "ref": "YoshitaneHTakaoTSatomiYDuNHOkanoTFukadaY2009Roles of CLOCK phosphorylation in suppression of E-box-dependent transcriptionMolecular and Cellular Biology293675368610.1128/MCB.01864-08", 
-                "id": "bib49"
+                "pages": {
+                    "first": "3675", 
+                    "last": "3686", 
+                    "range": "3675\u20133686"
+                }, 
+                "doi": "10.1128/MCB.01864-08"
             }, 
             {
-                "article_title": "A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood trait", 
-                "lpage": "E1544", 
-                "doi": "10.1073/pnas.1600039113", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib50", 
+                "date": "2016", 
                 "authors": [
                     {
-                        "surname": "Zhang", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Zhang", 
+                            "index": "Zhang, L"
+                        }
                     }, 
                     {
-                        "surname": "Hirano", 
-                        "given-names": "A", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Hirano", 
+                            "index": "Hirano, A"
+                        }
                     }, 
                     {
-                        "surname": "Hsu", 
-                        "given-names": "P-K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P-K Hsu", 
+                            "index": "Hsu, P-K"
+                        }
                     }, 
                     {
-                        "surname": "Jones", 
-                        "given-names": "CR", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Jones", 
+                            "index": "Jones, CR"
+                        }
                     }, 
                     {
-                        "surname": "Sakai", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Sakai", 
+                            "index": "Sakai, N"
+                        }
                     }, 
                     {
-                        "surname": "Okuro", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Okuro", 
+                            "index": "Okuro, M"
+                        }
                     }, 
                     {
-                        "surname": "McMahon", 
-                        "given-names": "T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T McMahon", 
+                            "index": "McMahon, T"
+                        }
                     }, 
                     {
-                        "surname": "Yamazaki", 
-                        "given-names": "M", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Yamazaki", 
+                            "index": "Yamazaki, M"
+                        }
                     }, 
                     {
-                        "surname": "Xu", 
-                        "given-names": "Y", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Xu", 
+                            "index": "Xu, Y"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "N", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Saigoh", 
+                            "index": "Saigoh, N"
+                        }
                     }, 
                     {
-                        "surname": "Saigoh", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Saigoh", 
+                            "index": "Saigoh, K"
+                        }
                     }, 
                     {
-                        "surname": "Lin", 
-                        "given-names": "S-T", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S-T Lin", 
+                            "index": "Lin, S-T"
+                        }
                     }, 
                     {
-                        "surname": "Kaasik", 
-                        "given-names": "K", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Kaasik", 
+                            "index": "Kaasik, K"
+                        }
                     }, 
                     {
-                        "surname": "Nishino", 
-                        "given-names": "S", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nishino", 
+                            "index": "Nishino, S"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1\u010dek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1\u010dek", 
+                            "index": "Pt\u00e1\u010dek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "Y-H", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y-H Fu", 
+                            "index": "Fu, Y-H"
+                        }
                     }
                 ], 
-                "full_article_title": "A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood trait", 
-                "publication-type": "journal", 
+                "articleTitle": "A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood trait", 
+                "journal": {
+                    "name": [
+                        "PNAS"
+                    ]
+                }, 
                 "volume": "113", 
-                "source": "PNAS", 
-                "reference_id": "10.1073/pnas.1600039113", 
-                "fpage": "E1536", 
-                "year": "2016", 
-                "position": 50, 
-                "ref": "ZhangLHiranoAHsuP-KJonesCRSakaiNOkuroMMcMahonTYamazakiMXuYSaigohNSaigohKLinS-TKaasikKNishinoSPt\u00e1\u010dekLJFuY-H2016A PERIOD3 variant causes a circadian phenotype and is associated with a seasonal mood traitPNAS113E1536E154410.1073/pnas.1600039113", 
-                "id": "bib50"
+                "pages": {
+                    "first": "E1536", 
+                    "last": "E1544", 
+                    "range": "E1536\u2013E1544"
+                }, 
+                "doi": "10.1073/pnas.1600039113"
             }, 
             {
-                "article_title": "Diversity of human clock genotypes and consequences", 
-                "lpage": "81", 
-                "doi": "10.1016/B978-0-12-396971-2.00003-8", 
-                "article_doi": "10.7554/eLife.16695", 
+                "type": "journal", 
+                "id": "bib51", 
+                "date": "2013", 
                 "authors": [
                     {
-                        "surname": "Zhang", 
-                        "given-names": "L", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Zhang", 
+                            "index": "Zhang, L"
+                        }
                     }, 
                     {
-                        "surname": "Pt\u00e1\u010dek", 
-                        "given-names": "LJ", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ Pt\u00e1\u010dek", 
+                            "index": "Pt\u00e1\u010dek, LJ"
+                        }
                     }, 
                     {
-                        "surname": "Fu", 
-                        "given-names": "YH", 
-                        "group-type": "author"
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YH Fu", 
+                            "index": "Fu, YH"
+                        }
                     }
                 ], 
-                "full_article_title": "Diversity of human clock genotypes and consequences", 
-                "publication-type": "journal", 
+                "articleTitle": "Diversity of human clock genotypes and consequences", 
+                "journal": {
+                    "name": [
+                        "Progress in Molecular Biology and Translational Science"
+                    ]
+                }, 
                 "volume": "119", 
-                "source": "Progress in Molecular Biology and Translational Science", 
-                "reference_id": "10.1016/B978-0-12-396971-2.00003-8", 
-                "fpage": "51", 
-                "year": "2013", 
-                "position": 51, 
-                "ref": "ZhangLPt\u00e1\u010dekLJFuYH2013Diversity of human clock genotypes and consequencesProgress in Molecular Biology and Translational Science119518110.1016/B978-0-12-396971-2.00003-8", 
-                "id": "bib51"
+                "pages": {
+                    "first": "51", 
+                    "last": "81", 
+                    "range": "51\u201381"
+                }, 
+                "doi": "10.1016/B978-0-12-396971-2.00003-8"
+            }
+        ], 
+        "acknowledgements": [
+            {
+                "type": "paragraph", 
+                "text": "This work was funded by NIH grant GM079180 and HL059596 to LJP and Y-HF and by the William Bowes Neurogenetics Fund. The initial sequencing and analysis were performed at Lawrence Berkeley National Laboratory and at the United States Department of Energy Joint Genome Institute (Department of Energy Contract DE-AC02-05CH11231, University of California). The authors wish to thank Drs. Philip Kurien and Pei-Ken Hsu and Mr. David Wu for suggestions and critical reading of the manuscript. We thank Dr. Yoshitaka Fukada (University of Tokyo) for providing anti-CRY2 antibody and 0.3 kbp-m<italic>Bmal1</italic>-luc construct. LJP is an investigator of the Howard Hughes Medical Institute. AH was supported by the Japanese Society for the Promotion of Science (JSPS) and the Uehara Memorial Foundation (Japan)."
             }
         ], 
         "decisionLetter": {

--- a/src/publisher/tests/test_article.py
+++ b/src/publisher/tests/test_article.py
@@ -2,7 +2,7 @@ from publisher import models, logic
 from publisher import api_v1_views as views
 from base import BaseCase
 import logging
-
+from datetime import datetime, timedelta
 from django.test import Client
 from django.core.urlresolvers import reverse
 
@@ -30,20 +30,27 @@ class ArticleLogic(BaseCase):
         "when version is not specified, `logic.article` returns the latest"
         self.assertEqual(0, models.Article.objects.count())
         doi = "10.7554/eLife.01234"
+        now = datetime.now()
+        one_ago = now - timedelta(days=1)
+        two_ago = now - timedelta(days=2)
+        three_ago = now - timedelta(days=3)
         article_data_list = [
             {'title': 'foo',
              'version': 1,
              'doi': doi,
+             'pub-date': three_ago,
              'journal': self.journal},
 
             {'title': 'bar',
              'version': 2,
              'doi': doi,
+             'update': two_ago,
              'journal': self.journal},
 
             {'title': 'baz',
              'version': 3,
              'doi': doi,
+             'update': one_ago,
              'journal': self.journal},
         ]
         [logic.add_or_update_article(**article_data) for article_data in article_data_list]
@@ -100,20 +107,27 @@ class ArticleInfoViaApi(BaseCase):
     def test_article_info_version_grouping(self):
         "an article with multiple versions is returned"
         doi = "10.7554/eLife.01234"
+        now = datetime.now()
+        one_ago = now - timedelta(days=1)
+        two_ago = now - timedelta(days=2)
+        three_ago = now - timedelta(days=3)
         article_data_list = [
             {'title': 'foo',
              'version': 1,
              'doi': doi,
+             'pub-date': three_ago,
              'journal': self.journal},
 
             {'title': 'bar',
              'version': 2,
              'doi': doi,
+             'update': two_ago,
              'journal': self.journal},
 
             {'title': 'baz',
              'version': 3,
              'doi': doi,
+             'update': one_ago,
              'journal': self.journal},
         ]
         [logic.add_or_update_article(**article_data) for article_data in article_data_list]
@@ -181,6 +195,7 @@ class ArticleInfoViaApi(BaseCase):
     # corpus
     #
 
+    '''
     def test_article_corpus_api(self):
         self.assertEqual(0, models.Article.objects.count())
         resp = self.c.get(reverse("api-corpus-info"))
@@ -191,3 +206,4 @@ class ArticleInfoViaApi(BaseCase):
         resp = self.c.get(reverse("api-corpus-info"))
         self.assertEqual(resp.data, {'article-count': 1,
                                      'research-article-count': 0})
+    '''

--- a/src/publisher/tests/test_fragment_logic.py
+++ b/src/publisher/tests/test_fragment_logic.py
@@ -116,6 +116,6 @@ class FragmentMerge(BaseCase):
 
     def test_merge_sets_status_date_correctly(self):
         pass
-        
+
     def test_merge_ignores_unpublished_vor_when_setting_status_date(self):
         pass


### PR DESCRIPTION
lax used to assume all content it was given was published but this is no longer the case. updated fixtures included.

v1 corpus api endpoint disabled as well. was never used, cbf updating it's code