### PR TITLE
strict iso8601 dates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ python-slugify==1.2.1
 pytz==2016.7
 PyYAML==3.12
 requests==2.11.1
+rfc3339==5
 Scrapy==1.2.1
 unittest-xml-reporting==2.1.0
 # sql-explorer optional deps

--- a/src/publisher/ajson_ingestor.py
+++ b/src/publisher/ajson_ingestor.py
@@ -199,17 +199,20 @@ def _publish(msid, version, force=False):
             if av.published() and force:
                 # this article version is already published and a force publish request has been sent
                 if 'versionDate' in raw_data:
-                    # when a 'versionDate' value is present in the article-json, use that.
-                    # as of 2016-10-21 version history isn't captured in the xml, it won't be parsed by the bot-lax-adaptor and
+                    # FUTURE CASE: when a 'versionDate' value is present in the article-json, use that.
+                    # as of 2016-10-21 version history IS NOT captured in the xml,
+                    # it won't be parsed by the bot-lax-adaptor and it
                     # won't find it's way here. this is a future-case only.
                     datetime_published = utils.todt(raw_data['versionDate'])
                     if not datetime_published:
                         raise StateError("found 'versionDate' value in article-json, but it's either null or unparseable as a datetime")
                 else:
+                    # CURRENT CASE
                     # preserve the existing pubdate set by lax.
                     # if the pubdate for an article is to change, it must come from the xml (see above case)
                     datetime_published = av.datetime_published
             else:
+                # CURRENT CASE
                 # this article version hasn't been published yet. use a value of RIGHT NOW as the published date.
                 datetime_published = utils.utcnow()
 
@@ -225,7 +228,7 @@ def _publish(msid, version, force=False):
         return av
 
     except models.ArticleFragment.DoesNotExist:
-        raise StateError("could not find ingested article-json!")
+        raise StateError("no 'xml->json' fragment found. being strict and failing this publish. please INGEST!")
 
     except models.ArticleVersion.DoesNotExist:
         # attempted to publish an article that doesn't exist ...

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -101,7 +101,7 @@ def pre_process(av, result):
     v1vor = av.article.earliest_vor()
     if v1vor and v1vor.datetime_published:
         # article has a published vor in it's version history! use it's version date
-        result['statusDate'] = v1vor.datetime_published.isoformat()
+        result['statusDate'] = utils.ymdhms(v1vor.datetime_published)
 
     if av.datetime_published:
         result['stage'] = 'published'

--- a/src/publisher/management/commands/ingest.py
+++ b/src/publisher/management/commands/ingest.py
@@ -189,7 +189,7 @@ class Command(ModCommand):
     def invalid_args(self, message):
         self.parser.error(message)
         sys.exit(1)
-        
+
     def handle(self, *args, **options):
         action = options['action']
         force = options['force']
@@ -220,7 +220,7 @@ class Command(ModCommand):
 
                 if not os.path.isdir(path):
                     self.invalid_args("the 'dir' option must point to a directory. got %r" % path)
-                
+
                 handle_many(print_queue, action, path, force, dry_run)
 
             else:

--- a/src/publisher/rss.py
+++ b/src/publisher/rss.py
@@ -21,7 +21,7 @@ class RSSArticleFeedGenerator(Rss201rev2Feed):
         super(RSSArticleFeedGenerator, self).add_item_elements(handler, item)
         pubdate = item['pubdate']
         if pubdate:
-            handler.addQuickElement("dc:date", pubdate.isoformat())
+            handler.addQuickElement("dc:date", utils.ymdhms(pubdate))
         else:
             LOG.warn("no pubdate, skipping added a 'dc:date' element to rss feed", extra=item)
 

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -424,7 +424,7 @@ class CLI(BaseCase):
         self.assertTrue(utils.has_all_keys(result, ['status', 'id', 'datetime']))
         self.assertEqual(result['status'], 'ingested')
         # the date and time is roughly the same as right now, ignoring microseconds
-        expected_datetime = utils.utcnow().isoformat()
+        expected_datetime = utils.ymdhms(utils.utcnow())
         self.assertEqual(result['datetime'][:20], expected_datetime[:20])
         self.assertEqual(result['datetime'][-6:], expected_datetime[-6:])
 
@@ -456,7 +456,7 @@ class CLI(BaseCase):
         self.assertTrue(utils.has_all_keys(result, ['status', 'id', 'datetime']))
         # ensure response data is correct
         self.assertEqual(result['status'], 'published')
-        self.assertEqual(result['datetime'], av.datetime_published.isoformat())
+        self.assertEqual(result['datetime'], utils.ymdhms(av.datetime_published))
 
     def test_ingest_publish_dry_run_from_cli(self):
         # ensure nothing exists

--- a/src/publisher/tests/test_rss.py
+++ b/src/publisher/tests/test_rss.py
@@ -3,7 +3,7 @@ from base import BaseCase
 from django.test import Client
 from django.core.urlresolvers import reverse
 from publisher import logic, models, utils
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest import skip
 
 class TestLatest(BaseCase):
@@ -17,43 +17,44 @@ class TestLatest(BaseCase):
     def test_only_most_recent_article_versions_returned(self):
         an_hour_ago = utils.utcnow() - timedelta(hours=1)
         many_hours_ago = an_hour_ago - timedelta(hours=999)
+        fmt = utils.ymdhms
         article_data_list = [
             {'title': 'foo',
              'version': 1,
              'doi': "10.7554/eLife.00001",
-             'pub-date': an_hour_ago.isoformat(),
+             'pub-date': fmt(an_hour_ago),
              },
 
 
             {'title': 'bar',
              'version': 1,
              'doi': "10.7554/eLife.00002",
-             'pub-date': many_hours_ago.isoformat(),
+             'pub-date': fmt(many_hours_ago),
              },
             {'title': 'bar',
              'version': 2,
              'doi': "10.7554/eLife.00002",
-             'pub-date': (many_hours_ago - timedelta(hours=1)).isoformat(),
-             'update': (many_hours_ago - timedelta(hours=1)).isoformat(),
+             'pub-date': fmt(many_hours_ago - timedelta(hours=1)),
+             'update': fmt(many_hours_ago - timedelta(hours=1)),
              },
             {'title': 'bar',
              'version': 3,
              'doi': "10.7554/eLife.00002",
-             'pub-date': (many_hours_ago - timedelta(hours=2)).isoformat(),
-             'update': (many_hours_ago - timedelta(hours=2)).isoformat(),
+             'pub-date': fmt(many_hours_ago - timedelta(hours=2)),
+             'update': fmt(many_hours_ago - timedelta(hours=2)),
              },
 
 
             {'title': 'baz',
              'version': 1,
              'doi': "10.7554/eLife.00003",
-             'pub-date': (an_hour_ago + timedelta(minutes=5)).isoformat(),
+             'pub-date': fmt(an_hour_ago + timedelta(minutes=5)),
              },
             {'title': 'baz',
              'version': 2,
              'doi': "10.7554/eLife.00003",
-             'pub-date': (an_hour_ago + timedelta(minutes=10)).isoformat(),
-             'update': (an_hour_ago + timedelta(minutes=10)).isoformat(),
+             'pub-date': fmt(an_hour_ago + timedelta(minutes=10)),
+             'update': fmt(an_hour_ago + timedelta(minutes=10)),
              }
 
         ]
@@ -80,15 +81,16 @@ class RSSViews(BaseCase):
     def setUp(self):
         self.c = Client()
         self.journal = logic.journal()
-        an_hour_ago = datetime.now() - timedelta(hours=1)
+        an_hour_ago = utils.utcnow() - timedelta(hours=1)
         many_hours_ago = an_hour_ago - timedelta(hours=999)
+        fmt = utils.ymdhms
         self.article_data_list = [
             {'title': 'foo',
              'status': 'vor',
              'version': 1,
              'doi': "10.7554/eLife.00001",
              'journal': self.journal,
-             'pub-date': an_hour_ago.isoformat(),
+             'pub-date': fmt(an_hour_ago),
              },
 
             {'title': 'bar',
@@ -96,7 +98,7 @@ class RSSViews(BaseCase):
              'version': 1,
              'doi': "10.7554/eLife.00002",
              'journal': self.journal,
-             'pub-date': many_hours_ago.isoformat(),
+             'pub-date': fmt(many_hours_ago),
              },
 
             {'title': 'baz',
@@ -104,7 +106,7 @@ class RSSViews(BaseCase):
              'status': 'poa', # **
              'doi': "10.7554/eLife.00003",
              'journal': self.journal,
-             'pub-date': an_hour_ago.isoformat(),
+             'pub-date': fmt(an_hour_ago),
              }
         ]
         [logic.add_or_update_article(**article_data) for article_data in self.article_data_list]

--- a/src/publisher/tests/test_utils.py
+++ b/src/publisher/tests/test_utils.py
@@ -14,6 +14,12 @@ class TestUtils(base.BaseCase):
     def tearDown(self):
         pass
 
+    def test_json_dumps_rfc3339(self):
+        dt = datetime(year=2001, month=1, day=1, hour=23, minute=59, second=59, microsecond=123, tzinfo=pytz.utc)
+        struct = {'dt': dt}
+        expected = '{"dt": "2001-01-01T23:59:59Z"}'
+        self.assertEqual(utils.json_dumps(struct), expected)
+    
     def test_resolve_paths(self):
         tests_dir = join(settings.SRC_DIR, 'publisher', 'tests', 'fixtures')
         cases = [

--- a/src/publisher/tests/test_utils.py
+++ b/src/publisher/tests/test_utils.py
@@ -20,6 +20,13 @@ class TestUtils(base.BaseCase):
         expected = '{"dt": "2001-01-01T23:59:59Z"}'
         self.assertEqual(utils.json_dumps(struct), expected)
 
+    def test_json_dumps_rfc3339_on_non_utc(self):
+        tz = pytz.timezone('Australia/Adelaide') # +9.5 hours ahead, but pytz thinks it's only +9
+        dt = datetime(year=2001, month=1, day=1, hour=9, minute=59, second=59, microsecond=123, tzinfo=tz)
+        struct = {'dt': dt}
+        expected = '{"dt": "2001-01-01T00:59:59Z"}'
+        self.assertEqual(utils.json_dumps(struct), expected)
+
     def test_resolve_paths(self):
         tests_dir = join(settings.SRC_DIR, 'publisher', 'tests', 'fixtures')
         cases = [

--- a/src/publisher/tests/test_utils.py
+++ b/src/publisher/tests/test_utils.py
@@ -19,7 +19,7 @@ class TestUtils(base.BaseCase):
         struct = {'dt': dt}
         expected = '{"dt": "2001-01-01T23:59:59Z"}'
         self.assertEqual(utils.json_dumps(struct), expected)
-    
+
     def test_resolve_paths(self):
         tests_dir = join(settings.SRC_DIR, 'publisher', 'tests', 'fixtures')
         cases = [

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -105,6 +105,7 @@ def todt(val):
     dt = val
     if not isinstance(dt, datetime):
         dt = parser.parse(val, fuzzy=False)
+    dt.replace(microsecond=0) # not useful, never been useful, will never be useful.
 
     if not dt.tzinfo:
         # no timezone (naive), assume UTC and make it explicit
@@ -119,6 +120,8 @@ def todt(val):
     return dt
 
 def utcnow():
+    "returns a UTC datetime stamp with a UTC timezone object attached"
+    # there is a datetime.utcnow(), but it doesn't attach a timezone object 
     return datetime.now(pytz.utc).replace(microsecond=0)
 
 def filldict(ddict, keys, default):

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -89,19 +89,10 @@ def ymd(dt):
     if dt:
         return dt.strftime("%Y-%m-%d")
 
-def ymdhms(dt):
-    "returns an rfc3339 representation of a datetime object"
-    if dt:
-        if not dt.tzinfo or not dt.tzinfo == pytz.utc:
-            LOG.exception("given a naive or non-utc datetime object to format as rfc3339")
-            raise ValueError("I don't format naive or non-utc datetime objects. fix your data.")
-        return rfc3339(dt, utc=True)
-
 def todt(val):
     "turn almost any formatted datetime string into a UTC datetime object"
     if val is None:
         return None
-
     dt = val
     if not isinstance(dt, datetime):
         dt = parser.parse(val, fuzzy=False)
@@ -123,6 +114,12 @@ def utcnow():
     "returns a UTC datetime stamp with a UTC timezone object attached"
     # there is a datetime.utcnow(), but it doesn't attach a timezone object
     return datetime.now(pytz.utc).replace(microsecond=0)
+
+def ymdhms(dt):
+    "returns an rfc3339 representation of a datetime object"
+    if dt:
+        dt = todt(dt) # convert to utc, etc
+        return rfc3339(dt, utc=True)
 
 def filldict(ddict, keys, default):
     def filldictslot(ddict, key, val):

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -121,7 +121,7 @@ def todt(val):
 
 def utcnow():
     "returns a UTC datetime stamp with a UTC timezone object attached"
-    # there is a datetime.utcnow(), but it doesn't attach a timezone object 
+    # there is a datetime.utcnow(), but it doesn't attach a timezone object
     return datetime.now(pytz.utc).replace(microsecond=0)
 
 def filldict(ddict, keys, default):


### PR DESCRIPTION
* utils.json_dumps now formats dates with a terminating 'Z' for utc.