### PR TITLE
reports, removed the json fields from the results 

### DIFF
--- a/src/publisher/logic.py
+++ b/src/publisher/logic.py
@@ -91,9 +91,11 @@ def latest_article_versions(page=1, per_page=-1, order='DESC', only_published=Tr
 
     if only_published:
         sql = """
-        SELECT pav1.*
+        SELECT
+           pav.id, pav.article_id, pav.title, pav.version, pav.status, pav.datetime_published,
+           pav.datetime_record_created, pav.datetime_record_updated
 
-        FROM publisher_articleversion pav1,
+        FROM publisher_articleversion pav,
 
           (SELECT pav2.article_id,
                   max(version) AS max_ver
@@ -102,7 +104,7 @@ def latest_article_versions(page=1, per_page=-1, order='DESC', only_published=Tr
            GROUP BY pav2.article_id) as pav2
 
         WHERE
-           pav1.article_id = pav2.article_id AND pav1.version = pav2.max_ver
+           pav.article_id = pav2.article_id AND pav.version = pav2.max_ver
 
         ORDER BY %s %s""" % (order_by, order)
 

--- a/src/publisher/rss.py
+++ b/src/publisher/rss.py
@@ -83,6 +83,7 @@ class SpecificArticleFeed(AbstractArticleFeed):
     def items(self, obj):
         return models.ArticleVersion.objects \
             .select_related('article') \
+            .defer('article_json_v1', 'article_json_v1_snippet') \
             .filter(article__doi__in=obj['doi_list']) \
             .order_by('-datetime_published', 'version')
 


### PR DESCRIPTION
these fields were causing a huge amount of data to be handled by the ORM and crash both prod and end2end machines.