### PR TITLE
bugfix, article list now returns the correct title in the results.

### DIFF
--- a/src/publisher/api_v2_views.py
+++ b/src/publisher/api_v2_views.py
@@ -62,9 +62,9 @@ def article_list(request):
     try:
         kwargs = request_args(request)
         kwargs['only_published'] = not authenticated
-        results = logic.latest_article_versions(**kwargs)
+        total, results = logic.latest_article_version_list(**kwargs)
         struct = {
-            'total': len(results), # TODO: probably wrong now.
+            'total': total,
             'items': map(logic.article_snippet_json, results),
         }
         return Response(struct, content_type='application/vnd.elife.article-list+json;version=1')

--- a/src/publisher/rss.py
+++ b/src/publisher/rss.py
@@ -121,7 +121,7 @@ class RecentArticleFeed(AbstractArticleFeed):
         def published_since(row):
             return row.datetime_published >= obj['since']
 
-        results = logic.latest_article_versions()
+        total, results = logic.latest_article_version_list()
         return filter(compfilter([status_in, published_since]), results)
 
 class AbstractReportFeed(AbstractArticleFeed):

--- a/src/publisher/tests/test_api_v2_views.py
+++ b/src/publisher/tests/test_api_v2_views.py
@@ -391,7 +391,8 @@ class RequestArgs(base.BaseCase):
 
     def test_article_list_paginated_page1(self):
         "a list of articles are returned, paginated by 1"
-        resp = self.c.get(reverse('v2:article-list') + "?per-page=1")
+        url = reverse('v2:article-list') + "?per-page=1"
+        resp = self.c.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content_type, 'application/vnd.elife.article-list+json;version=1')
         data = json.loads(resp.content)
@@ -401,7 +402,7 @@ class RequestArgs(base.BaseCase):
 
         # correct data
         self.assertEqual(len(data['items']), 1) # ONE result, [msid1]
-        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['total'], 2)
         self.assertEqual(data['items'][0]['id'], str(self.msid1))
 
     def test_article_list_paginated_page2(self):
@@ -416,19 +417,20 @@ class RequestArgs(base.BaseCase):
 
         # correct data
         self.assertEqual(len(data['items']), 1) # ONE result, [msid2]
-        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['total'], 2)
         self.assertEqual(data['items'][0]['id'], str(self.msid2))
 
     def test_article_list_page_no_per_page(self):
         "defaults for per-page and page parameters kick in when not specified"
-        resp = self.c.get(reverse('v2:article-list') + "?page=2")
+        url = reverse('v2:article-list') + "?page=2"
+        resp = self.c.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content_type, 'application/vnd.elife.article-list+json;version=1')
         data = json.loads(resp.content)
 
         # correct data (too few to hit next page)
         self.assertEqual(len(data['items']), 0)
-        self.assertEqual(data['total'], 0)
+        self.assertEqual(data['total'], 2) # 100 per page, we asked for page 2, 2 results total
 
     def test_article_list_ordering_asc(self):
         resp = self.c.get(reverse('v2:article-list') + "?order=asc")

--- a/src/publisher/tests/test_rss.py
+++ b/src/publisher/tests/test_rss.py
@@ -63,7 +63,8 @@ class TestLatest(BaseCase):
         self.assertEqual(models.Article.objects.count(), 3)
         self.assertEqual(models.ArticleVersion.objects.count(), 6)
 
-        avlist = logic.latest_article_versions()
+        total, avlist = logic.latest_article_version_list()
+        self.assertEqual(total, 3)
         self.assertEqual(len(avlist), 3)
 
         expected_version_order = [


### PR DESCRIPTION
took the opportunity to split the `logic.latest_article_versions` function into two smaller functions. original function interface has been preserved as a simple wrapper