### PR TITLE
lax now stores the article-json returned from validation

### DIFF
--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -66,8 +66,7 @@ def valid(merge_result, quiet=True):
     try:
         schema_key = merge_result['status'] # poa or vor
         schema = settings.SCHEMA_IDX[schema_key]
-        utils.validate(merge_result, schema)
-        return merge_result
+        return utils.validate(merge_result, schema)
 
     except KeyError:
         msg = "merging %s returned a data structure that couldn't be used to determine validation"
@@ -80,12 +79,6 @@ def valid(merge_result, quiet=True):
         LOG.exception("validating %s failed to load schema file %s", msid, schema, extra=log_context)
         # this is a legitimate error and needs to break things
         raise
-
-    except StateError as err:
-        msg = "article is in a state where it can't be validated: %s" % err
-        LOG.warn(msg, extra=log_context)
-        if not quiet:
-            raise
 
     except ValidationError as err:
         # definitely not valid ;)
@@ -146,9 +139,7 @@ def merge_if_valid(av, quiet=True):
     if the result is valid, returns the merge result.
     if invalid, returns nothing.
     if invalid and quiet=False, a ValidationError will be raised"""
-    result = merge_and_preprocess(av)
-    if valid(result, quiet=quiet):
-        return result
+    return valid(merge_and_preprocess(av), quiet=quiet)
 
 def set_article_json(av, quiet):
     """updates the article with the result of the merge operation.

--- a/src/publisher/tests/test_utils.py
+++ b/src/publisher/tests/test_utils.py
@@ -20,7 +20,7 @@ class TestUtils(base.BaseCase):
         ]
         for given, expected in cases:
             self.assertEqual(utils.mk_dxdoi_link(given), expected)
-    
+
     def test_json_dumps_rfc3339(self):
         dt = datetime(year=2001, month=1, day=1, hour=23, minute=59, second=59, microsecond=123, tzinfo=pytz.utc)
         struct = {'dt': dt}

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -256,9 +256,8 @@ def load_schema(schema_path):
     return json.load(open(schema_path, 'r'))
 
 def validate(struct, schema_path):
-    # if given a string, assume it's json and try to load it
-    # if given a data, assume it's serializable, dump it and load it
     try:
+        # this has the effect of converting any datetime objects to rfc3339 formatted strings
         struct = json.loads(json_dumps(struct))
     except ValueError as err:
         LOG.error("struct is not serializable: %s", err.message)


### PR DESCRIPTION
... (with formatted dates) rather than the one sent to validation