### PR TITLE
Disable New Relic C extensions to favor stability

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,5 +25,5 @@ if [ ! -e app.cfg ]; then
     echo "* no app.cfg found! using the example settings (elife.cfg) by default."
     ln -s elife.cfg app.cfg
 fi
-pip install -r requirements.txt
+NEW_RELIC_EXTENSIONS=false pip install -r requirements.txt
 python src/manage.py migrate --no-input


### PR DESCRIPTION
https://github.com/Mobeye/NewRelic/issues/1

Since Lax does not freeze its dependencies, I think we need to do this every time we install with pip