### PR TITLE
Installing newrelic without extensions, for real 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,5 +25,6 @@ if [ ! -e app.cfg ]; then
     echo "* no app.cfg found! using the example settings (elife.cfg) by default."
     ln -s elife.cfg app.cfg
 fi
-NEW_RELIC_EXTENSIONS=false pip install -r requirements.txt
+pip install -r requirements.txt
+NEW_RELIC_EXTENSIONS=false pip install --no-binary :all: newrelic==2.78.0.57
 python src/manage.py migrate --no-input

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ joblib==0.10.3
 jsonschema==2.5.1
 kids.cache==0.0.4
 netaddr==0.7.19
-newrelic==2.78.0.57
 prospector==0.12.4
 psycopg2==2.6.2
 pyflakes==1.5.0


### PR DESCRIPTION
Turns out it was using a wheel which contained everything already, so its setup.py was not executed.