### PR TITLE
Makes ordering deterministic

### DIFF
--- a/src/publisher/logic.py
+++ b/src/publisher/logic.py
@@ -145,7 +145,7 @@ def latest_unpublished_article_versions(page=1, per_page=-1, order='DESC'):
     start = (page - 1) * per_page
     end = start + per_page
     order_by = ['datetime_published', 'article__manuscript_id']
-    if order is 'DESC':
+    if order == 'DESC':
         order_by = ['-' + o for o in order_by]
 
     q = models.ArticleVersion.objects \


### PR DESCRIPTION
Right now article latest versions are ordered by their published date. When more than one article has the same date, the order is not deterministic and paging through /articles results in duplicate items.