### PR TITLE
Adds empty [] response to /articles/:id/related

### DIFF
--- a/src/publisher/api_v2_urls.py
+++ b/src/publisher/api_v2_urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     url(r'articles/(?P<id>\d+)$', views.article, name='article'),
     url(r'articles/(?P<id>\d+)/versions$', views.article_version_list, name='article-version-list'),
     url(r'articles/(?P<id>\d+)/versions/(?P<version>\d+)$', views.article_version, name='article-version'),
+    url(r'articles/(?P<id>\d+)/related$', views.article_related, name='article-related'),
 
     # not part of Public API
     url(r'articles/(?P<art_id>\d+)/fragments/(?P<fragment_id>[\-\w]{3,25})$', views.article_fragment, name='article-fragment'),

--- a/src/publisher/api_v2_views.py
+++ b/src/publisher/api_v2_views.py
@@ -92,6 +92,7 @@ def article_version_list(request, id):
     except models.Article.DoesNotExist:
         raise Http404()
 
+
 @api_view(['GET'])
 def article_version(request, id, version):
     "returns the article-json for a specific version of the given article ID"
@@ -104,6 +105,17 @@ def article_version(request, id, version):
     except models.ArticleVersion.DoesNotExist:
         raise Http404()
 
+# TODO: test Content-Type
+# TODO: test 404
+@api_view(['GET'])
+def article_related(request, id):
+    "return the related articles for a given article ID"
+    authenticated = is_authenticated(request)
+    try:
+        av = logic.most_recent_article_version(id, only_published=not authenticated)
+        return Response([], content_type="application/vnd.elife.article-related+json;version=1")
+    except models.Article.DoesNotExist:
+        raise Http404()
 #
 # not part of public api
 #

--- a/src/publisher/api_v2_views.py
+++ b/src/publisher/api_v2_views.py
@@ -112,7 +112,8 @@ def article_related(request, id):
     "return the related articles for a given article ID"
     authenticated = is_authenticated(request)
     try:
-        av = logic.most_recent_article_version(id, only_published=not authenticated)
+        # exception if the article id cannot be found
+        logic.most_recent_article_version(id, only_published=not authenticated)
         return Response([], content_type="application/vnd.elife.article-related+json;version=1")
     except models.Article.DoesNotExist:
         raise Http404()

--- a/src/publisher/tests/test_api_v2_views.py
+++ b/src/publisher/tests/test_api_v2_views.py
@@ -313,6 +313,16 @@ class V2Content(base.BaseCase):
         resp = self.c.get(reverse('v2:article-related', kwargs={'id': 42}))
         self.assertEqual(resp.status_code, 404)
 
+    def test_article_related_articles_on_unpublished_article(self):
+        self.unpublish(self.msid2, version=3)
+        self.unpublish(self.msid2, version=2)
+        self.unpublish(self.msid2, version=1)
+
+        resp = self.ac.get(reverse('v2:article-related', kwargs={'id': self.msid2}))
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.c.get(reverse('v2:article', kwargs={'id': self.msid2}))
+        self.assertEqual(resp.status_code, 404)
 
 class V2PostContent(base.BaseCase):
     def setUp(self):

--- a/src/publisher/tests/test_api_v2_views.py
+++ b/src/publisher/tests/test_api_v2_views.py
@@ -56,6 +56,7 @@ class V2ContentTypes(base.BaseCase):
         art_poa_type = 'application/vnd.elife.article-poa+json;version=1'
         art_vor_type = 'application/vnd.elife.article-vor+json;version=1'
         art_history_type = 'application/vnd.elife.article-history+json;version=1'
+        art_related_type = 'application/vnd.elife.article-related+json;version=1'
 
         case_list = {
             reverse('v2:article-list'): art_list_type,
@@ -63,6 +64,7 @@ class V2ContentTypes(base.BaseCase):
             reverse('v2:article-version-list', kwargs={'id': self.msid}): art_history_type,
             reverse('v2:article-version', kwargs={'id': self.msid, 'version': 1}): art_poa_type,
             reverse('v2:article-version', kwargs={'id': self.msid, 'version': 2}): art_vor_type,
+            reverse('v2:article-related', kwargs={'id': self.msid}): art_related_type,
         }
 
         # test
@@ -300,6 +302,15 @@ class V2Content(base.BaseCase):
     def test_article_version_artver_does_not_exist(self):
         "returns 404 when a version of the article doesn't exist for the article-version endpoint"
         resp = self.c.get(reverse('v2:article-version', kwargs={'id': self.msid2, 'version': 9}))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_article_related_articles(self):
+        resp = self.c.get(reverse('v2:article-related', kwargs={'id': self.msid1}))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(utils.json_loads(resp.content), [])
+
+    def test_article_related_articles_of_an_article_that_does_not_exist(self):
+        resp = self.c.get(reverse('v2:article-related', kwargs={'id': 42}))
         self.assertEqual(resp.status_code, 404)
 
 


### PR DESCRIPTION
At least dependent clients like recommendations will not break, even if we do not have these data yet.