### PR TITLE
These tests cover both configurations

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -236,8 +236,8 @@ EVENT_BUS = {
 
 # Lax settings
 
-# when ingesting an article, if an article says it's related to an article that doesn't exist, should an Article stub be created? default, False.
-RELATED_ARTICLE_STUBS = cfg('general.related-article-stubs', False)
+# when ingesting an article, if an article says it's related to an article that doesn't exist, should an Article stub be created? default, True.
+RELATED_ARTICLE_STUBS = cfg('general.related-article-stubs', True)
 
 # when ingesting an article version and the EIF has no 'update' value,
 # should we fail and raise an error? if not, the article pub-date is used instead.


### PR DESCRIPTION
But they need to work without relying on a particular value of the configuration, being it true or false

When the configuration was switched to True in `ci`, tests started to fail but now will be agnostic.