### PR TITLE
Do not install on article ingests

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -2,5 +2,9 @@
 # @description convenience wrapper around Django's runserver command
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
-source install.sh > /dev/null
+
+# this starts to reinstall everything in production everytime an article is ingested:
+#source install.sh > /dev/null
+
+source venv/bin/activate
 ./src/manage.py $@


### PR DESCRIPTION
Today article ingests got stuck in end2end (possibly also prod) when pulling stuff down from the Internet:
```
  808 ?        Ssl    0:03 python src/adaptor.py --type sqs
 1795 ?        S      0:00  \_ /bin/bash /srv/lax/manage.sh ingest --ingest --id 2258964234223315893 --version 1
 1813 ?        S      0:00      \_ /srv/lax/venv/bin/python3.5 /srv/lax/venv/bin/pip install -r requirements.txt
 1820 ?        S      0:00          \_ /usr/bin/python /usr/bin/hg clone --noupdate -q https://bitbucket.org/lskibinski/rfc3339 /tmp/pip-6cj82ib7-build
```