### PR TITLE
Annotating APIs as New Relic transactions

### DIFF
--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -1,0 +1,13 @@
+import rest_framework.decorators
+import newrelic.agent
+
+def api_view(*args, **kwargs):
+    def decorator(func):
+        label = "%s.%s" % (func.__module__, func.__name__)
+        framework_decorator = rest_framework.decorators.api_view(*args, **kwargs)
+        def labelled_func(*args, **kwargs):
+            newrelic.agent.set_transaction_name(label)
+            return func(*args, **kwargs)
+        return framework_decorator(labelled_func)
+
+    return decorator

--- a/src/publisher/api_v2_views.py
+++ b/src/publisher/api_v2_views.py
@@ -3,7 +3,8 @@ from django.db import transaction
 from . import models, logic, fragment_logic
 from .utils import ensure, isint, lmap
 from rest_framework import status
-from rest_framework.decorators import api_view
+#from rest_framework.decorators import api_view
+from monitoring import api_view
 from rest_framework.response import Response
 from django.shortcuts import Http404
 from django.conf import settings
@@ -59,6 +60,7 @@ def is_authenticated(request):
 @api_view(['GET'])
 def article_list(request):
     "returns a list of snippets"
+
     authenticated = is_authenticated(request)
     try:
         kwargs = request_args(request)


### PR DESCRIPTION
This should be automated, but some newer version of Python/Django broke it. Currently all transactions appear as `WrappedAPIView` without categories.

This machinery is to go from this too broad categorization:
![lax_old](https://cloud.githubusercontent.com/assets/160299/23859910/28b74894-07fd-11e7-8eec-385d9cbf1f16.png)
to this precise one:
![lax_new](https://cloud.githubusercontent.com/assets/160299/23859932/3bd63818-07fd-11e7-8946-bbcc54275e56.png)

