### PR TITLE
feature: fragment DELETE endpoint

### DIFF
--- a/src/publisher/api_v2_urls.py
+++ b/src/publisher/api_v2_urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     url(r'^articles/(?P<id>\d+)/related$', views.article_related, name='article-relations'),
 
     # not part of Public API
-    url(r'^articles/(?P<art_id>\d+)/fragments/(?P<fragment_id>[\-\w]{3,25})$', views.article_fragment, name='article-fragment'),
+    url(r'^articles/(?P<art_id>\d+)/fragments/(?P<fragment_id>[>\-\w]{3,25})$', views.article_fragment, name='article-fragment'),
 ]

--- a/src/publisher/api_v2_views.py
+++ b/src/publisher/api_v2_views.py
@@ -7,6 +7,7 @@ from rest_framework.renderers import StaticHTMLRenderer
 from rest_framework.response import Response
 from django.shortcuts import Http404, get_object_or_404
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from .models import POA, XML2JSON
 from et3.extract import path as p
 from et3.render import render_item
@@ -160,6 +161,6 @@ def article_fragment(request, art_id, fragment_id):
         # client broke business rules somehow
         return Response(err.message, status=status.HTTP_400_BAD_REQUEST)
 
-    except (models.Article.DoesNotExist, models.ArticleVersion.DoesNotExist):
-        # article with given ID doesn't exist
+    except ObjectDoesNotExist:
+        # article/articleversion/fragment with given ID doesn't exist
         raise Http404()

--- a/src/publisher/tests/test_api_v2_views.py
+++ b/src/publisher/tests/test_api_v2_views.py
@@ -38,6 +38,31 @@ class Fragments(base.BaseCase):
         self.assertEqual(200, resp.status_code)
         self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments - 1)
 
+    def test_delete_fragment_not_authenticated(self):
+        expected_fragments = 2 # XML2JSON + 'test-frag'
+        self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments)
+        url = reverse('v2:article-fragment', kwargs={'art_id': self.msid, 'fragment_id': self.key})
+        resp = self.c.delete(url) # .c vs .ac
+        self.assertEqual(403, resp.status_code)
+        self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments)
+
+    def test_delete_fragment_doesnt_exist(self):
+        expected_fragments = 2 # XML2JSON + 'test-frag'
+        self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments)
+        url = reverse('v2:article-fragment', kwargs={'art_id': self.msid, 'fragment_id': 'pants-party'})
+        resp = self.ac.delete(url)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments)
+
+    def test_delete_protected_fragment(self):
+        expected_fragments = 2 # XML2JSON + 'test-frag'
+        self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments)
+        url = reverse('v2:article-fragment', kwargs={'art_id': self.msid, 'fragment_id': models.XML2JSON})
+        resp = self.ac.delete(url)
+        self.assertEqual(resp.status_code, 400) # client error, bad request
+        self.assertEqual(models.ArticleFragment.objects.count(), expected_fragments)
+
+
 class V2ContentTypes(base.BaseCase):
     def setUp(self):
         self.c = Client()


### PR DESCRIPTION
uses the same interface as the POST endpoint to add a fragment, just behaves differently on the DELETE method.

