### PR TITLE
Feature: trigger article update events from admin

### DIFF
--- a/src/publisher/admin.py
+++ b/src/publisher/admin.py
@@ -29,7 +29,6 @@ class ArticleAdmin(admin.ModelAdmin):
         super(ArticleAdmin, self).delete_model(request, art)
         aws_events.notify(art)
 
-    # this may cause multiple events to be sent
     def save_related(self, request, form, formsets, change):
         super(ArticleAdmin, self).save_related(request, form, formsets, change)
         art = form.instance

--- a/src/publisher/admin.py
+++ b/src/publisher/admin.py
@@ -21,9 +21,9 @@ class ArticleAdmin(admin.ModelAdmin):
         ArticleVersionAdmin,
     ]
 
-    def save_model(self, request, art, form, change):
-        super(ArticleAdmin, self).save_model(request, art, form, change)
-        aws_events.notify(art)
+    # def save_model(self, request, art, form, change):
+    #    super(ArticleAdmin, self).save_model(request, art, form, change)
+    #    #aws_events.notify(art) # called in save_related, which is called after save_model()
 
     def delete_model(self, request, art):
         super(ArticleAdmin, self).delete_model(request, art)

--- a/src/publisher/admin.py
+++ b/src/publisher/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from . import models, aws_events
+from . import models, aws_events, fragment_logic
 
 class ArticleVersionAdmin(admin.TabularInline):
     list_select_related = ('article',)
@@ -27,11 +27,13 @@ class ArticleAdmin(admin.ModelAdmin):
 
     def delete_model(self, request, art):
         super(ArticleAdmin, self).delete_model(request, art)
+        fragment_logic.set_all_article_json(art, quiet=True)
         aws_events.notify(art)
 
     def save_related(self, request, form, formsets, change):
         super(ArticleAdmin, self).save_related(request, form, formsets, change)
         art = form.instance
+        fragment_logic.set_all_article_json(art, quiet=True)
         aws_events.notify(art)
 
 admin_list = [

--- a/src/publisher/admin.py
+++ b/src/publisher/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from . import models
+from . import models, aws_events
 
 class ArticleVersionAdmin(admin.TabularInline):
     list_select_related = ('article',)
@@ -20,6 +20,20 @@ class ArticleAdmin(admin.ModelAdmin):
     inlines = [
         ArticleVersionAdmin,
     ]
+
+    def save_model(self, request, art, form, change):
+        super(ArticleAdmin, self).save_model(request, art, form, change)
+        aws_events.notify(art)
+
+    def delete_model(self, request, art):
+        super(ArticleAdmin, self).delete_model(request, art)
+        aws_events.notify(art)
+
+    # this may cause multiple events to be sent
+    def save_related(self, request, form, formsets, change):
+        super(ArticleAdmin, self).save_related(request, form, formsets, change)
+        art = form.instance
+        aws_events.notify(art)
 
 admin_list = [
     (models.Publisher,),

--- a/src/publisher/aws_events.py
+++ b/src/publisher/aws_events.py
@@ -116,10 +116,9 @@ def notify(art, **overrides):
         return
     try:
         msg = {"type": "article", "id": art.manuscript_id}
-        #msg_json = json.dumps({'default': msg})
         msg_json = json.dumps(msg)
         LOG.debug("writing message to event bus", extra={'bus-message': msg_json})
-        event_bus_conn(**overrides).publish(Message=msg_json)  # , MessageStructure='json')
+        event_bus_conn(**overrides).publish(Message=msg_json)
     except ValueError as err:
         # probably serializing value
         LOG.error("failed to serialize event bus payload %s", err, extra={'bus-message': msg_json})

--- a/src/publisher/tests/test_aws_events.py
+++ b/src/publisher/tests/test_aws_events.py
@@ -1,0 +1,104 @@
+import json
+from unittest.mock import patch, Mock
+from publisher import ajson_ingestor
+from .base import BaseCase
+from os.path import join
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
+from django.test import Client, override_settings
+
+def formsubgen(art):
+    # tweaked from an actual POST that was captured
+    avl = list(art.articleversion_set.all())
+    artf = {
+        "journal": art.journal.id,
+        "manuscript_id": art.manuscript_id,
+        "doi": art.doi,
+        "date_received": art.date_received,
+        "date_accepted": art.date_accepted,
+        "date_initial_qc": "",
+        "date_initial_decision": "",
+        "initial_decision": "EF",
+        "date_full_qc": "",
+        "date_full_decision": "",
+        "decision": "RVF",
+        "date_rev1_qc": "",
+        "date_rev1_decision": "",
+        "rev1_decision": "AF",
+        "date_rev2_qc":"",
+        "date_rev2_decision":"",
+        "rev2_decision":"",
+        "date_rev3_qc":"",
+        "date_rev3_decision":"",
+        "rev3_decision":"",
+        "date_rev4_qc":"",
+        "date_rev4_decision":"",
+        "rev4_decision":"",
+        "volume": 4,
+        "type": "research-article",
+        "ejp_type": "RA",
+        "articleversion_set-TOTAL_FORMS": len(avl),
+        "articleversion_set-INITIAL_FORMS": len(avl),
+        "articleversion_set-MIN_NUM_FORMS": 0,
+        "articleversion_set-MAX_NUM_FORMS": 0,
+
+        # ?
+        # new av stub?
+        
+        "articleversion_set-__prefix__-id":"",
+        "articleversion_set-__prefix__-article": art.id,
+        "articleversion_set-__prefix__-datetime_published_0":"",
+        "articleversion_set-__prefix__-datetime_published_1": ""
+    }
+    for i, av in enumerate(avl):
+        artf.update({
+            "articleversion_set-%s-id" % i: av.id,
+            "articleversion_set-%s-article" % i: av.article.id,
+            "articleversion_set-%s-datetime_published_0" % i: av.datetime_published.strftime("%Y-%m-%d"),
+            "articleversion_set-%s-datetime_published_1" % i: "00:00:00",
+        })
+    return artf
+
+class One(BaseCase):
+    def setUp(self):
+        self.ac = Client()
+        
+        user = User.objects.create_superuser('john', 'john@example.org', 'password')
+        # https://docs.djangoproject.com/en/1.11/topics/testing/tools/#django.test.Client.force_login
+        self.ac.force_login(user) 
+
+        ingest_these = [
+            "elife-16695-v1.xml.json",
+            #"elife-16695-v2.xml.json",
+            #"elife-16695-v3.xml.json",
+        ]
+        ajson_dir = join(self.fixture_dir, 'ajson')
+        self.avs = []
+        for ingestable in ingest_these:
+            data = self.load_ajson(join(ajson_dir, ingestable))
+            self.avs.append(ajson_ingestor.ingest_publish(data))
+
+        self.msid = 16695
+        self.art = self.avs[-1].article
+            
+    def tearDown(self):
+        pass
+
+    @override_settings(DEBUG=False) # get past the early return in aws_events
+    def test_admin_save_sends_event(self):
+        "saving an article through the admin sends an update event to aws"
+
+        # we just need a successful form submission to test if an event is sent
+        payload = formsubgen(self.art)
+            
+        # https://docs.djangoproject.com/en/1.10/ref/contrib/admin/#admin-reverse-urls
+        url = reverse("admin:publisher_article_change", args=(self.art.id,))
+
+        expected_event = json.dumps({"type": "article", "id": self.msid})
+        mock = Mock()
+        with patch('publisher.aws_events.event_bus_conn', return_value=mock):
+            resp = self.ac.post(url, payload, follow=False)
+            self.assertEqual(resp.status_code, 302) # temp redirect after successful submission
+            print(mock.publish.__dict__)
+            mock.publish.assert_called_with(Message=expected_event)
+            mock.publish.assert_called_once_with(Message=expected_event)


### PR DESCRIPTION
this PR:
* sends article update events to aws if articles or articleversions are changed or deleted via Django's admin interface
* sends article update events to aws if fragments are added or deleted via the fragment API
* re-generates the article-json after a change to the article or it's versions via the admin interface
