### PR TITLE
Sending events on related articles

### DIFF
--- a/src/publisher/aws_events.py
+++ b/src/publisher/aws_events.py
@@ -117,7 +117,7 @@ def notify(art, **overrides):
     try:
         msg = {"type": "article", "id": art.manuscript_id}
         msg_json = json.dumps(msg)
-        LOG.debug("writing message to event bus", extra={'bus-message': msg_json})
+        LOG.info("writing message to event bus", extra={'bus-message': msg_json})
         event_bus_conn(**overrides).publish(Message=msg_json)
     except ValueError as err:
         # probably serializing value

--- a/src/publisher/aws_events.py
+++ b/src/publisher/aws_events.py
@@ -1,6 +1,8 @@
 import json
 from django.conf import settings
 import boto3
+from publisher import relation_logic as relationships
+from publisher.utils import lmap
 
 import logging
 
@@ -16,112 +18,35 @@ def sns_topic_arn(**overrides):
     LOG.info("using topic arn: %s", arn)
     return arn
 
-#
-#
-#
-
 def event_bus_conn(**overrides):
     sns = boto3.resource('sns')
     return sns.Topic(sns_topic_arn(**overrides))
 
-'''
-# works, but no tests
-import uuid
-def _create_queue():
-    sqs = boto3.resource('sqs')
-    queue_name = "lax-temp-listener-" + str(uuid.uuid4())
-    LOG.info("attempting to create queue %r", queue_name)
-    return sqs.create_queue(QueueName=queue_name)
-
-def get_message(queue):
-    messages = []
-    while not messages:
-        messages = queue.receive_messages(
-            MaxNumberOfMessages=1,
-            VisibilityTimeout=60, # time allowed to call delete, can be increased
-            WaitTimeSeconds=20 # maximum setting for long polling
-        )
-    message = messages[0]
-    return message
-
-def listen(env):
-    "creates a temporary queue and subscription to topic (event bus) for given region. destroyed afterwards"
-    queue = subscription = perm_label = None
-    try:
-        topic = event_bus_conn(env=env)
-        queue = _create_queue()
-        queue_arn = queue.attributes['QueueArn']
-        _bits = queue_arn.split(':')
-        acc_id, qname = _bits[4], _bits[5]
-
-        # queue can receive messages from topic
-        # this attaches a Policy to the queue that we can modify
-        queue.add_permission(**{
-            'Label': 'perm-%s-to-sns' % qname,
-            'AWSAccountIds': [acc_id],
-            'Actions': [
-                '*',
-            ]
-        })
-
-        # policy ll:
-        # {"Version":"2008-10-17","Id":"arn:aws:sqs:us-east-1:512686554592:lax-temp-listener-b37e2179-3b83-4c00-853d-ee541893ce8e/SQSDefaultPolicy","Statement":[{"Sid":"perm-lax-temp-listener-b37e2179-3b83-4c00-853d-ee541893ce8e-to-sns","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::512686554592:root"},"Action":"SQS:*","Resource":"arn:aws:sqs:us-east-1:512686554592:lax-temp-listener-b37e2179-3b83-4c00-853d-ee541893ce8e"}]}
-        policy = json.loads(queue.attributes['Policy'])
-        policy['Statement'][0]["Principal"] = {"AWS": "*"}
-        queue.set_attributes(Attributes={'Policy': json.dumps(policy)})
-
-        # topic allows subscription
-        perm_label = 'perm-for-%s' % qname
-        topic.add_permission(**{
-            'Label': perm_label,
-            'AWSAccountId': [acc_id],
-            'ActionName': [
-                'subscribe',
-                'receive',
-                'publish'
-            ]})
-
-        subscription = topic.subscribe(Protocol='sqs', Endpoint=queue_arn)
-
-        message = get_message(queue)
-        print 'message:', message
-
-        body = json.loads(message.body)
-        print 'message body:', body
-
-        body_message = json.loads(body['Message'])
-        print 'message body decoded:', body_message
-
-    except KeyboardInterrupt:
-        pass
-
-    finally:
-        # destroy subscription
-        # destroy queue
-        LOG.info("deleting queue")
-        if queue:
-            queue.delete()
-
-        if subscription:
-            subscription.delete()
-
-        if perm_label:
-            topic.remove_permission(Label=perm_label)
-'''
+#
+#
+#
 
 def notify(art, **overrides):
-    "notify the event bus when this article or one of it's versions has been changed in some way"
+    "notify event bus when this article or one of it's versions has been changed in some way"
     if settings.DEBUG:
-        LOG.debug("application is in DEBUG mode, not notifying anyone")
+        LOG.debug("application is in DEBUG mode, no notifications will be sent")
         return
     try:
         msg = {"type": "article", "id": art.manuscript_id}
         msg_json = json.dumps(msg)
-        LOG.info("writing message to event bus", extra={'bus-message': msg_json})
+        LOG.debug("writing message to event bus", extra={'bus-message': msg_json})
         event_bus_conn(**overrides).publish(Message=msg_json)
     except ValueError as err:
         # probably serializing value
         LOG.error("failed to serialize event bus payload %s", err, extra={'bus-message': msg_json})
 
-    except Exception as err:
-        LOG.error("unhandled error attempting to notify event bus of article change: %s", err)
+    except BaseException as err:
+        LOG.exception("unhandled error attempting to notify event bus of article change: %s", err)
+
+def notify_relations(av, **overrides):
+    "notify event bus of changes to an article version's related articles"
+    lmap(notify, relationships.internal_relationships_for_article_version(av))
+
+def notify_all(av, **overrides):
+    notify(av.article, **overrides)
+    notify_relations(av, **overrides)

--- a/src/publisher/tests/base.py
+++ b/src/publisher/tests/base.py
@@ -1,10 +1,11 @@
 from io import StringIO
 import os, json
-from django.test import TestCase
+from django.test import TestCase as DjangoTestCase, TransactionTestCase
 from publisher import models, utils
 from django.core.management import call_command
+import unittest
 
-class BaseCase(TestCase):
+class SimpleBaseCase(unittest.TestCase):
     this_dir = os.path.dirname(os.path.realpath(__file__))
     fixture_dir = os.path.join(this_dir, 'fixtures')
     maxDiff = None
@@ -42,3 +43,13 @@ class BaseCase(TestCase):
         except SystemExit as err:
             return err.code, stdout.getvalue()
         self.fail("ingest script should always throw a systemexit()")
+
+#
+#
+#
+
+class BaseCase(SimpleBaseCase, DjangoTestCase):
+    pass
+
+class TransactionBaseCase(SimpleBaseCase, TransactionTestCase):
+    pass

--- a/src/publisher/tests/fixtures/ajson/elife-09560-v1.xml.json
+++ b/src/publisher/tests/fixtures/ajson/elife-09560-v1.xml.json
@@ -1,0 +1,10606 @@
+{
+    "journal": {
+        "id": "eLife", 
+        "title": "eLife", 
+        "issn": "2050-084X"
+    }, 
+    "snippet": {
+        "-meta": {
+            "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/2b1a280ca981a56053d1cd399b529c8e1b30ad4e/articles/elife-09560-v1.xml"
+        }, 
+        "-history": {
+            "received": "2015-06-19T00:00:00Z", 
+            "accepted": "2015-08-04T00:00:00Z"
+        }, 
+        "status": "vor", 
+        "id": "09560", 
+        "version": 1, 
+        "type": "research-article", 
+        "doi": "10.7554/eLife.09560", 
+        "authorLine": "Lee R Berger et al", 
+        "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa", 
+        "published": "2015-09-10T00:00:00Z", 
+        "versionDate": "2015-09-10T00:00:00Z", 
+        "volume": 4, 
+        "elocationId": "e09560", 
+        "pdf": "https://cdn.elifesciences.org/articles/09560/elife-09560-v1.pdf", 
+        "subjects": [
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "abstract": {
+            "doi": "10.7554/eLife.09560.001", 
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "<i>Homo naledi</i> is a previously-unknown species of extinct hominin discovered within the Dinaledi Chamber of the Rising Star cave system, Cradle of Humankind, South Africa. This species is characterized by body mass and stature similar to small-bodied human populations but a small endocranial volume similar to australopiths. Cranial morphology of <i>H. naledi</i> is unique, but most similar to early <i>Homo</i> species including <i>Homo erectus</i>, <i>Homo habilis</i> or <i>Homo rudolfensis</i>. While primitive, the dentition is generally small and simple in occlusal morphology. <i>H. naledi</i> has humanlike manipulatory adaptations of the hand and wrist. It also exhibits a humanlike foot and lower limb. These humanlike aspects are contrasted in the postcrania with a more primitive or australopith-like trunk, shoulder, pelvis and proximal femur. Representing at least 15 individuals with most skeletal elements repeated multiple times, this is the largest assemblage of a single species of hominins yet discovered in Africa."
+                }
+            ]
+        }, 
+        "copyright": {
+            "license": "CC-BY-4.0", 
+            "holder": "Berger et al", 
+            "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a>, which permits unrestricted use and redistribution provided that the original author and source are credited."
+        }, 
+        "authors": [
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Lee R Berger", 
+                    "index": "Berger, Lee R"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Geosciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "Lee.Berger@wits.ac.za"
+                ], 
+                "contribution": "LRB, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "John Hawks", 
+                    "index": "Hawks, John"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JH, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Darryl J de Ruiter", 
+                    "index": "de Ruiter, Darryl J"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Texas A&M University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "College Station", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "College Station"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DJR, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Steven E Churchill", 
+                    "index": "Churchill, Steven E"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Evolutionary Anthropology", 
+                            "Duke University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Durham", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Durham"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SEC, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Peter Schmid", 
+                    "index": "Schmid, Peter"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Anthropological Institute and Museum", 
+                            "University of Zurich"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Zurich", 
+                                "Switzerland"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Zurich"
+                                ], 
+                                "country": "Switzerland"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "PS, Conception and design, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Lucas K Delezene", 
+                    "index": "Delezene, Lucas K"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Arkansas"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Fayetteville", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Fayetteville"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "LKD, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Tracy L Kivell", 
+                    "index": "Kivell, Tracy L"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School", 
+                            "University of Kent"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Canterbury", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Canterbury"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Human Evolution", 
+                            "Max Planck Institute for Evolutionary Anthropology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Leipzig", 
+                                "Germany"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Leipzig"
+                                ], 
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "TLK, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Heather M Garvin", 
+                    "index": "Garvin, Heather M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology/Archaeology and Department of Applied Forensic Sciences", 
+                            "Mercyhurst University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Erie", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Erie"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "HMG, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Scott A Williams", 
+                    "index": "Williams, Scott A"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Center for the Study of Human Origins, Department of Anthropology", 
+                            "New York University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "New York Consortium in Evolutionary Primatology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SAW, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Jeremy M DeSilva", 
+                    "index": "DeSilva, Jeremy M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Dartmouth College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Hanover", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Hanover"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JMDS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Matthew M Skinner", 
+                    "index": "Skinner, Matthew M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School", 
+                            "University of Kent"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Canterbury", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Canterbury"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Human Evolution", 
+                            "Max Planck Institute for Evolutionary Anthropology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Leipzig", 
+                                "Germany"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Leipzig"
+                                ], 
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MMS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Charles M Musiba", 
+                    "index": "Musiba, Charles M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Colorado Denver"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Denver", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Denver"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CMM, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Noel Cameron", 
+                    "index": "Cameron, Noel"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Sport, Exercise and Health Sciences", 
+                            "Loughborough University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Loughborough", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Loughborough"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "NC, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Trenton W Holliday", 
+                    "index": "Holliday, Trenton W"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Tulane University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Orleans", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New Orleans"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "TWH, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "William Harcourt-Smith", 
+                    "index": "Harcourt-Smith, William"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Lehman College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Bronx", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Bronx"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Division of Paleontology", 
+                            "American Museum of Natural History"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "WH-S, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Rebecca R Ackermann", 
+                    "index": "Ackermann, Rebecca R"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Archaeology", 
+                            "University of Cape Town"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Rondebosch", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Rondebosch"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "RRA, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Markus Bastir", 
+                    "index": "Bastir, Markus"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Paleoanthropology Group", 
+                            "Museo Nacional de Ciencias Naturales"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madrid", 
+                                "Spain"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madrid"
+                                ], 
+                                "country": "Spain"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Barry Bogin", 
+                    "index": "Bogin, Barry"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Sport, Exercise and Health Sciences", 
+                            "Loughborough University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Loughborough", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Loughborough"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "BB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Debra Bolter", 
+                    "index": "Bolter, Debra"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Modesto Junior College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Modesto", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Modesto"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Juliet Brophy", 
+                    "index": "Brophy, Juliet"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Geography and Anthropology", 
+                            "Louisiana State University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Baton Rouge", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Baton Rouge"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Zachary D Cofran", 
+                    "index": "Cofran, Zachary D"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Humanities and Social Sciences", 
+                            "Nazarbayev University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Astana", 
+                                "Kazakhstan"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Astana"
+                                ], 
+                                "country": "Kazakhstan"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "ZDC, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Kimberly A Congdon", 
+                    "index": "Congdon, Kimberly A"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Pathology and Anatomical Sciences", 
+                            "University of Missouri"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Columbia", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Columbia"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "KAC, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Andrew S Deane", 
+                    "index": "Deane, Andrew S"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anatomy and Neurobiology", 
+                            "University of Kentucky College of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Lexington", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Lexington"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "ASD, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Mana Dembo", 
+                    "index": "Dembo, Mana"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Human Evolutionary Studies Program and Department of Archaeology", 
+                            "Simon Fraser University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Burnaby", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Burnaby"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MD, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Michelle Drapeau", 
+                    "index": "Drapeau, Michelle"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department d'Anthropologie", 
+                            "Universit\u00e9 de Montr\u00e9al"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Montr\u00e9al", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Montr\u00e9al"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MD, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Marina C Elliott", 
+                    "index": "Elliott, Marina C"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Human Evolutionary Studies Program and Department of Archaeology", 
+                            "Simon Fraser University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Burnaby", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Burnaby"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MCE, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Elen M Feuerriegel", 
+                    "index": "Feuerriegel, Elen M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Archaeology and Anthropology", 
+                            "Australian National University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Canberra", 
+                                "Australia"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Canberra"
+                                ], 
+                                "country": "Australia"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EMF, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Daniel Garcia-Martinez", 
+                    "index": "Garcia-Martinez, Daniel"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Paleoanthropology Group", 
+                            "Museo Nacional de Ciencias Naturales"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madrid", 
+                                "Spain"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madrid"
+                                ], 
+                                "country": "Spain"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Faculty of Sciences", 
+                            "Biology Department, Universidad Aut\u00f2noma de Madrid"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madrid", 
+                                "Spain"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madrid"
+                                ], 
+                                "country": "Spain"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DG-M, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "David J Green", 
+                    "index": "Green, David J"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anatomy", 
+                            "Midwestern University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Downers Grove", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Downers Grove"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DJG, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Alia Gurtov", 
+                    "index": "Gurtov, Alia"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "AG, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Joel D Irish", 
+                    "index": "Irish, Joel D"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Research Centre in Evolutionary Anthropology and Palaeoecology", 
+                            "Liverpool John Moores University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Liverpool", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Liverpool"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JDI, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Ashley Kruger", 
+                    "index": "Kruger, Ashley"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "AK, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Myra F Laird", 
+                    "index": "Laird, Myra F"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Center for the Study of Human Origins, Department of Anthropology", 
+                            "New York University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "New York Consortium in Evolutionary Primatology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MFL, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Damiano Marchi", 
+                    "index": "Marchi, Damiano"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Biology", 
+                            "University of Pisa"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Pisa", 
+                                "Italy"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Pisa"
+                                ], 
+                                "country": "Italy"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DM, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Marc R Meyer", 
+                    "index": "Meyer, Marc R"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Chaffey College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Rancho Cucamonga", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Rancho Cucamonga"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MRM, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Shahed Nalla", 
+                    "index": "Nalla, Shahed"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Human Anatomy and Physiology", 
+                            "University of Johannesburg"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SN, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Enquye W Negash", 
+                    "index": "Negash, Enquye W"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Center for the Advanced Study of Human Paleobiology", 
+                            "George Washington University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Washington", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Washington"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EWN, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Caley M Orr", 
+                    "index": "Orr, Caley M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Cell and Developmental Biology", 
+                            "University of Colorado School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Aurora", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Aurora"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CMO, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Davorka Radovcic", 
+                    "index": "Radovcic, Davorka"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Geology and Paleontology", 
+                            "Croatian Natural History Museum"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Zagreb", 
+                                "Croatia"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Zagreb"
+                                ], 
+                                "country": "Croatia"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DR, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Lauren Schroeder", 
+                    "index": "Schroeder, Lauren"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Archaeology", 
+                            "University of Cape Town"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Rondebosch", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Rondebosch"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "LS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Jill E Scott", 
+                    "index": "Scott, Jill E"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Iowa"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Iowa City", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Iowa City"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JES, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Zachary Throckmorton", 
+                    "index": "Throckmorton, Zachary"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anatomy, DeBusk College of Osteopathic Medicine", 
+                            "Lincoln Memorial University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Harrogate", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Harrogate"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "ZT, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Matthew W Tocheri", 
+                    "index": "Tocheri, Matthew W"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Human Origins Program, Department of Anthropology, National Museum of Natural History", 
+                            "Smithsonian Institution"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Washington", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Washington"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology, Lakehead University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Thunder Bay", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Thunder Bay"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MWT, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Caroline VanSickle", 
+                    "index": "VanSickle, Caroline"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Gender and Women's Studies", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CVS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Christopher S Walker", 
+                    "index": "Walker, Christopher S"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Evolutionary Anthropology", 
+                            "Duke University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Durham", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Durham"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CSW, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Pianpian Wei", 
+                    "index": "Wei, Pianpian"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Paleoanthropology", 
+                            "Institute of Vertebrate Paleontology and Paleoanthropology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Beijing", 
+                                "China"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Beijing"
+                                ], 
+                                "country": "China"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "PW, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Bernhard Zipfel", 
+                    "index": "Zipfel, Bernhard"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "BZ, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }
+        ], 
+        "reviewers": [
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Johannes Krause", 
+                    "index": "Krause, Johannes"
+                }, 
+                "role": "Reviewing Editor", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "University of T\u00fcbingen"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Germany"
+                            ], 
+                            "components": {
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ]
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Nicholas J Conard", 
+                    "index": "Conard, Nicholas J"
+                }, 
+                "role": "Reviewing Editor", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "University of T\u00fcbingen"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Germany"
+                            ], 
+                            "components": {
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ]
+            }
+        ], 
+        "funding": {
+            "awards": [
+                {
+                    "id": "par-1", 
+                    "source": {
+                        "funderId": "10.13039/100006363", 
+                        "name": [
+                            "National Geographic Society"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-2", 
+                    "source": {
+                        "funderId": "10.13039/501100001321", 
+                        "name": [
+                            "The National Research Foundation of South Africa"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-3", 
+                    "source": {
+                        "name": [
+                            "The Palaeontological Scientific Trust"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-4", 
+                    "source": {
+                        "funderId": "10.13039/100007423", 
+                        "name": [
+                            "Lyda Hill Foundation"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-5", 
+                    "source": {
+                        "funderId": "10.13039/100001395", 
+                        "name": [
+                            "Wisconsin Alumni Research Foundation (WARF)"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "John Hawks", 
+                                "index": "Hawks, John"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-6", 
+                    "source": {
+                        "funderId": "10.13039/100007904", 
+                        "name": [
+                            "Texas A and M University"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Darryl J de Ruiter", 
+                                "index": "de Ruiter, Darryl J"
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "statement": "The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+        }, 
+        "additionalFiles": [
+            {
+                "doi": "10.7554/eLife.09560.028", 
+                "id": "SD1-data", 
+                "label": "Supplementary file 1", 
+                "title": "Holotype and paratype specimens and referred materials.", 
+                "mediaType": "application/docx", 
+                "uri": "https://cdn.elifesciences.org/articles/09560/elife-09560-supp1-v1.docx", 
+                "filename": "elife-09560-supp1-v1.docx"
+            }, 
+            {
+                "doi": "10.7554/eLife.09560.029", 
+                "id": "SD2-data", 
+                "label": "Supplementary file 2", 
+                "title": "Traits of <i>H</i>. <i>naledi</i> and comparative species.", 
+                "mediaType": "application/docx", 
+                "uri": "https://cdn.elifesciences.org/articles/09560/elife-09560-supp2-v1.docx", 
+                "filename": "elife-09560-supp2-v1.docx"
+            }
+        ], 
+        "impactStatement": "A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa."
+    }, 
+    "article": {
+        "-meta": {
+            "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/2b1a280ca981a56053d1cd399b529c8e1b30ad4e/articles/elife-09560-v1.xml", 
+            "patched": true
+        }, 
+        "-history": {
+            "received": "2015-06-19T00:00:00Z", 
+            "accepted": "2015-08-04T00:00:00Z"
+        }, 
+        "status": "vor", 
+        "id": "09560", 
+        "version": 1, 
+        "type": "research-article", 
+        "doi": "10.7554/eLife.09560", 
+        "authorLine": "Lee R Berger et al", 
+        "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa", 
+        "published": "2015-09-10T00:00:00Z", 
+        "versionDate": "2015-09-10T00:00:00Z", 
+        "volume": 4, 
+        "elocationId": "e09560", 
+        "pdf": "https://cdn.elifesciences.org/articles/09560/elife-09560-v1.pdf", 
+        "subjects": [
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "abstract": {
+            "doi": "10.7554/eLife.09560.001", 
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "<i>Homo naledi</i> is a previously-unknown species of extinct hominin discovered within the Dinaledi Chamber of the Rising Star cave system, Cradle of Humankind, South Africa. This species is characterized by body mass and stature similar to small-bodied human populations but a small endocranial volume similar to australopiths. Cranial morphology of <i>H. naledi</i> is unique, but most similar to early <i>Homo</i> species including <i>Homo erectus</i>, <i>Homo habilis</i> or <i>Homo rudolfensis</i>. While primitive, the dentition is generally small and simple in occlusal morphology. <i>H. naledi</i> has humanlike manipulatory adaptations of the hand and wrist. It also exhibits a humanlike foot and lower limb. These humanlike aspects are contrasted in the postcrania with a more primitive or australopith-like trunk, shoulder, pelvis and proximal femur. Representing at least 15 individuals with most skeletal elements repeated multiple times, this is the largest assemblage of a single species of hominins yet discovered in Africa."
+                }
+            ]
+        }, 
+        "copyright": {
+            "license": "CC-BY-4.0", 
+            "holder": "Berger et al", 
+            "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a>, which permits unrestricted use and redistribution provided that the original author and source are credited."
+        }, 
+        "authors": [
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Lee R Berger", 
+                    "index": "Berger, Lee R"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Geosciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "Lee.Berger@wits.ac.za"
+                ], 
+                "contribution": "LRB, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "John Hawks", 
+                    "index": "Hawks, John"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JH, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Darryl J de Ruiter", 
+                    "index": "de Ruiter, Darryl J"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Texas A&M University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "College Station", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "College Station"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DJR, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Steven E Churchill", 
+                    "index": "Churchill, Steven E"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Evolutionary Anthropology", 
+                            "Duke University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Durham", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Durham"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SEC, Conception and design, Acquisition of data, Analysis and interpretation of data, Drafting or revising the article, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Peter Schmid", 
+                    "index": "Schmid, Peter"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Anthropological Institute and Museum", 
+                            "University of Zurich"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Zurich", 
+                                "Switzerland"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Zurich"
+                                ], 
+                                "country": "Switzerland"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "PS, Conception and design, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Lucas K Delezene", 
+                    "index": "Delezene, Lucas K"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Arkansas"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Fayetteville", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Fayetteville"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "LKD, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Tracy L Kivell", 
+                    "index": "Kivell, Tracy L"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School", 
+                            "University of Kent"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Canterbury", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Canterbury"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Human Evolution", 
+                            "Max Planck Institute for Evolutionary Anthropology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Leipzig", 
+                                "Germany"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Leipzig"
+                                ], 
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "TLK, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Heather M Garvin", 
+                    "index": "Garvin, Heather M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology/Archaeology and Department of Applied Forensic Sciences", 
+                            "Mercyhurst University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Erie", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Erie"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "HMG, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Scott A Williams", 
+                    "index": "Williams, Scott A"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Center for the Study of Human Origins, Department of Anthropology", 
+                            "New York University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "New York Consortium in Evolutionary Primatology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SAW, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Jeremy M DeSilva", 
+                    "index": "DeSilva, Jeremy M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Dartmouth College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Hanover", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Hanover"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JMDS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Matthew M Skinner", 
+                    "index": "Skinner, Matthew M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School", 
+                            "University of Kent"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Canterbury", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Canterbury"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Human Evolution", 
+                            "Max Planck Institute for Evolutionary Anthropology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Leipzig", 
+                                "Germany"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Leipzig"
+                                ], 
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MMS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Charles M Musiba", 
+                    "index": "Musiba, Charles M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Colorado Denver"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Denver", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Denver"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CMM, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Noel Cameron", 
+                    "index": "Cameron, Noel"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Sport, Exercise and Health Sciences", 
+                            "Loughborough University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Loughborough", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Loughborough"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "NC, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Trenton W Holliday", 
+                    "index": "Holliday, Trenton W"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Tulane University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New Orleans", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New Orleans"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "TWH, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "William Harcourt-Smith", 
+                    "index": "Harcourt-Smith, William"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Lehman College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Bronx", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Bronx"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Division of Paleontology", 
+                            "American Museum of Natural History"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "WH-S, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Rebecca R Ackermann", 
+                    "index": "Ackermann, Rebecca R"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Archaeology", 
+                            "University of Cape Town"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Rondebosch", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Rondebosch"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "RRA, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Markus Bastir", 
+                    "index": "Bastir, Markus"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Paleoanthropology Group", 
+                            "Museo Nacional de Ciencias Naturales"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madrid", 
+                                "Spain"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madrid"
+                                ], 
+                                "country": "Spain"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Barry Bogin", 
+                    "index": "Bogin, Barry"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Sport, Exercise and Health Sciences", 
+                            "Loughborough University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Loughborough", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Loughborough"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "BB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Debra Bolter", 
+                    "index": "Bolter, Debra"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Modesto Junior College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Modesto", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Modesto"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Juliet Brophy", 
+                    "index": "Brophy, Juliet"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Geography and Anthropology", 
+                            "Louisiana State University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Baton Rouge", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Baton Rouge"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JB, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Zachary D Cofran", 
+                    "index": "Cofran, Zachary D"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Humanities and Social Sciences", 
+                            "Nazarbayev University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Astana", 
+                                "Kazakhstan"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Astana"
+                                ], 
+                                "country": "Kazakhstan"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "ZDC, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Kimberly A Congdon", 
+                    "index": "Congdon, Kimberly A"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Pathology and Anatomical Sciences", 
+                            "University of Missouri"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Columbia", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Columbia"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "KAC, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Andrew S Deane", 
+                    "index": "Deane, Andrew S"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anatomy and Neurobiology", 
+                            "University of Kentucky College of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Lexington", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Lexington"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "ASD, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Mana Dembo", 
+                    "index": "Dembo, Mana"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Human Evolutionary Studies Program and Department of Archaeology", 
+                            "Simon Fraser University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Burnaby", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Burnaby"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MD, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Michelle Drapeau", 
+                    "index": "Drapeau, Michelle"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department d'Anthropologie", 
+                            "Universit\u00e9 de Montr\u00e9al"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Montr\u00e9al", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Montr\u00e9al"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MD, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Marina C Elliott", 
+                    "index": "Elliott, Marina C"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Human Evolutionary Studies Program and Department of Archaeology", 
+                            "Simon Fraser University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Burnaby", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Burnaby"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MCE, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Elen M Feuerriegel", 
+                    "index": "Feuerriegel, Elen M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "School of Archaeology and Anthropology", 
+                            "Australian National University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Canberra", 
+                                "Australia"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Canberra"
+                                ], 
+                                "country": "Australia"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EMF, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Daniel Garcia-Martinez", 
+                    "index": "Garcia-Martinez, Daniel"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Paleoanthropology Group", 
+                            "Museo Nacional de Ciencias Naturales"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madrid", 
+                                "Spain"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madrid"
+                                ], 
+                                "country": "Spain"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Faculty of Sciences", 
+                            "Biology Department, Universidad Aut\u00f2noma de Madrid"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madrid", 
+                                "Spain"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madrid"
+                                ], 
+                                "country": "Spain"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DG-M, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "David J Green", 
+                    "index": "Green, David J"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anatomy", 
+                            "Midwestern University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Downers Grove", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Downers Grove"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DJG, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Alia Gurtov", 
+                    "index": "Gurtov, Alia"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "AG, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Joel D Irish", 
+                    "index": "Irish, Joel D"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Research Centre in Evolutionary Anthropology and Palaeoecology", 
+                            "Liverpool John Moores University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Liverpool", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Liverpool"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JDI, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Ashley Kruger", 
+                    "index": "Kruger, Ashley"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "AK, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Myra F Laird", 
+                    "index": "Laird, Myra F"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Center for the Study of Human Origins, Department of Anthropology", 
+                            "New York University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "New York Consortium in Evolutionary Primatology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "New York", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "New York"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MFL, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Damiano Marchi", 
+                    "index": "Marchi, Damiano"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Biology", 
+                            "University of Pisa"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Pisa", 
+                                "Italy"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Pisa"
+                                ], 
+                                "country": "Italy"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DM, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Marc R Meyer", 
+                    "index": "Meyer, Marc R"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "Chaffey College"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Rancho Cucamonga", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Rancho Cucamonga"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MRM, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Shahed Nalla", 
+                    "index": "Nalla, Shahed"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Human Anatomy and Physiology", 
+                            "University of Johannesburg"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "SN, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Enquye W Negash", 
+                    "index": "Negash, Enquye W"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Center for the Advanced Study of Human Paleobiology", 
+                            "George Washington University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Washington", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Washington"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "EWN, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Caley M Orr", 
+                    "index": "Orr, Caley M"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Cell and Developmental Biology", 
+                            "University of Colorado School of Medicine"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Aurora", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Aurora"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CMO, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Davorka Radovcic", 
+                    "index": "Radovcic, Davorka"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Geology and Paleontology", 
+                            "Croatian Natural History Museum"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Zagreb", 
+                                "Croatia"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Zagreb"
+                                ], 
+                                "country": "Croatia"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "DR, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Lauren Schroeder", 
+                    "index": "Schroeder, Lauren"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Archaeology", 
+                            "University of Cape Town"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Rondebosch", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Rondebosch"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "LS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Jill E Scott", 
+                    "index": "Scott, Jill E"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Iowa"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Iowa City", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Iowa City"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "JES, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Zachary Throckmorton", 
+                    "index": "Throckmorton, Zachary"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anatomy, DeBusk College of Osteopathic Medicine", 
+                            "Lincoln Memorial University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Harrogate", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Harrogate"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "ZT, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Matthew W Tocheri", 
+                    "index": "Tocheri, Matthew W"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Human Origins Program, Department of Anthropology, National Museum of Natural History", 
+                            "Smithsonian Institution"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Washington", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Washington"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology, Lakehead University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Thunder Bay", 
+                                "Canada"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Thunder Bay"
+                                ], 
+                                "country": "Canada"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "MWT, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Caroline VanSickle", 
+                    "index": "VanSickle, Caroline"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Anthropology", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Gender and Women's Studies", 
+                            "University of Wisconsin-Madison"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Madison", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Madison"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CVS, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Christopher S Walker", 
+                    "index": "Walker, Christopher S"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Evolutionary Anthropology", 
+                            "Duke University"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Durham", 
+                                "United States"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Durham"
+                                ], 
+                                "country": "United States"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "CSW, Acquisition of data, Analysis and interpretation of data, Contributed unpublished essential data or reagents", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Pianpian Wei", 
+                    "index": "Wei, Pianpian"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }, 
+                    {
+                        "name": [
+                            "Department of Paleoanthropology", 
+                            "Institute of Vertebrate Paleontology and Paleoanthropology"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Beijing", 
+                                "China"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Beijing"
+                                ], 
+                                "country": "China"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "PW, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Bernhard Zipfel", 
+                    "index": "Zipfel, Bernhard"
+                }, 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Evolutionary Studies Institute and Centre of Excellence in PalaeoSciences", 
+                            "University of the Witwatersrand"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Johannesburg", 
+                                "South Africa"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "Johannesburg"
+                                ], 
+                                "country": "South Africa"
+                            }
+                        }
+                    }
+                ], 
+                "contribution": "BZ, Acquisition of data, Analysis and interpretation of data", 
+                "competingInterests": "The authors declare that no competing interests exist."
+            }
+        ], 
+        "reviewers": [
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Johannes Krause", 
+                    "index": "Krause, Johannes"
+                }, 
+                "role": "Reviewing Editor", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "University of T\u00fcbingen"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Germany"
+                            ], 
+                            "components": {
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ]
+            }, 
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Nicholas J Conard", 
+                    "index": "Conard, Nicholas J"
+                }, 
+                "role": "Reviewing Editor", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "University of T\u00fcbingen"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "Germany"
+                            ], 
+                            "components": {
+                                "country": "Germany"
+                            }
+                        }
+                    }
+                ]
+            }
+        ], 
+        "funding": {
+            "awards": [
+                {
+                    "id": "par-1", 
+                    "source": {
+                        "funderId": "10.13039/100006363", 
+                        "name": [
+                            "National Geographic Society"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-2", 
+                    "source": {
+                        "funderId": "10.13039/501100001321", 
+                        "name": [
+                            "The National Research Foundation of South Africa"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-3", 
+                    "source": {
+                        "name": [
+                            "The Palaeontological Scientific Trust"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-4", 
+                    "source": {
+                        "funderId": "10.13039/100007423", 
+                        "name": [
+                            "Lyda Hill Foundation"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Lee R Berger", 
+                                "index": "Berger, Lee R"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-5", 
+                    "source": {
+                        "funderId": "10.13039/100001395", 
+                        "name": [
+                            "Wisconsin Alumni Research Foundation (WARF)"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "John Hawks", 
+                                "index": "Hawks, John"
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "id": "par-6", 
+                    "source": {
+                        "funderId": "10.13039/100007904", 
+                        "name": [
+                            "Texas A and M University"
+                        ]
+                    }, 
+                    "recipients": [
+                        {
+                            "type": "person", 
+                            "name": {
+                                "preferred": "Darryl J de Ruiter", 
+                                "index": "de Ruiter, Darryl J"
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "statement": "The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+        }, 
+        "additionalFiles": [
+            {
+                "doi": "10.7554/eLife.09560.028", 
+                "id": "SD1-data", 
+                "label": "Supplementary file 1", 
+                "title": "Holotype and paratype specimens and referred materials.", 
+                "mediaType": "application/docx", 
+                "uri": "https://cdn.elifesciences.org/articles/09560/elife-09560-supp1-v1.docx", 
+                "filename": "elife-09560-supp1-v1.docx"
+            }, 
+            {
+                "doi": "10.7554/eLife.09560.029", 
+                "id": "SD2-data", 
+                "label": "Supplementary file 2", 
+                "title": "Traits of <i>H</i>. <i>naledi</i> and comparative species.", 
+                "mediaType": "application/docx", 
+                "uri": "https://cdn.elifesciences.org/articles/09560/elife-09560-supp2-v1.docx", 
+                "filename": "elife-09560-supp2-v1.docx"
+            }
+        ], 
+        "impactStatement": "A new hominin species has been unearthed in the Dinaledi Chamber of the Rising Star cave system in the largest assemblage of a single species of hominins yet discovered in Africa.", 
+        "keywords": [
+            "<i>Homo naledi</i>", 
+            "hominin", 
+            "Dinaledi Chamber", 
+            "paleoanthropology"
+        ], 
+        "-related-articles-internal": [
+            "09561"
+        ], 
+        "-related-articles-external": [], 
+        "digest": {
+            "doi": "10.7554/eLife.09560.002", 
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "Modern humans, or <i>Homo sapiens</i>, are now the only living species in their genus. But as recently as 100,000 years ago, there were several other species that belonged to the genus <i>Homo</i>. Together with modern humans, these extinct human species, our immediate ancestors and their close relatives, are collectively referred to as \u2018hominins\u2019."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "Now Berger et al. report the recent discovery of an extinct species from the genus <i>Homo</i> that was unearthed from deep underground in what has been named the Dinaledi Chamber, in the Rising Star cave system in South Africa. The species was named <i>Homo naledi;</i> \u2018naledi\u2019 means \u2018star\u2019 in Sotho (also called Sesotho), which is one of the languages spoken in South Africa."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "The unearthed fossils were from at least 15 individuals and include multiple examples of most of the bones in the skeleton. Based on this wide range of specimens from a single site, Berger et al. describe <i>Homo naledi</i> as being similar in size and weight to a small modern human, with human-like hands and feet. Furthermore, while the skull had several unique features, it had a small braincase that was most similar in size to other early hominin species that lived between four million and two million years ago. <i>Homo naledi</i>'s ribcage, shoulders and pelvis also more closely resembled those of earlier hominin species than those of modern humans."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "The <i>Homo naledi</i> fossils are the largest collection of a single species of hominin that has been discovered in Africa so far and, in a related study, Dirks et al. describe the setting and context for these fossils. However, since the age of the fossils remains unclear, one of the next challenges will be to date the remains to provide more information about the early evolution of humans and their close relatives."
+                }
+            ]
+        }, 
+        "body": [
+            {
+                "type": "section", 
+                "id": "s1", 
+                "title": "Introduction", 
+                "content": [
+                    {
+                        "type": "paragraph", 
+                        "text": "Fossil hominins were first recognized in the Dinaledi Chamber in the Rising Star cave system in October 2013. During a relatively short excavation, our team recovered an extensive collection of 1550 hominin specimens, representing nearly every element of the skeleton multiple times (<a href=\"#fig1\">Figure 1</a>), including many complete elements and morphologically informative fragments, some in articulation, as well as smaller fragments many of which could be refit into more complete elements. The collection is a morphologically homogeneous sample that can be attributed to no previously-known hominin species. Here we describe this new species, <i>Homo naledi</i>. We have not defined <i>H. naledi</i> narrowly based on a single jaw or skull because the entire body of material has informed our understanding of its biology."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "doi": "10.7554/eLife.09560.003", 
+                                "id": "fig1", 
+                                "label": "Figure 1", 
+                                "title": "Dinaledi skeletal specimens.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The figure includes approximately all of the material incorporated in this diagnosis, including the holotype specimen, paratypes and referred material. These make up 737 partial or complete anatomical elements, many of which consist of several refitted specimens. Specimens not identified to element, such as non-diagnostic long bone or cranial fragments, and a subset of fragile specimens are not shown here. The \u2018skeleton\u2019 layout in the center of the photo is a composite of elements that represent multiple individuals. This view is foreshortened; the table upon which the bones are arranged is 120-cm wide for scale."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig1-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-09560-fig1-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig1-v1.tif", 
+                                    "size": {
+                                        "width": 4194, 
+                                        "height": 4714
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Order Primates LINNAEUS 1758"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Suborder Anthropoidea MIVART 1864"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Superfamily Hominoidea GRAY 1825"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Family Hominidae GRAY 1825"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Tribe Hominini GRAY 1825"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Genus <i>Homo</i> LINNAEUS 1758"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "<i>Homo naledi</i> sp. nov. <a href=\"http://zoobank.org/References/00D1E81A-6E08-4A01-BD98-79A2CEAE2411\">urn:lsid:zoobank.org:pub:00D1E81A-6E08-4A01-BD98-79A2CEAE2411</a>"
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s1-1", 
+                        "title": "Etymology", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The word <i>naledi</i> means \u2018star\u2019 in the Sotho language and refers to the Dinaledi Chamber's location within the Rising Star cave system."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s1-2", 
+                        "title": "Locality", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The Dinaledi chamber is located approximately 30 meters underground, within the Rising Star cave system at about 26\u00b01\u203213\u2032\u2032 S; 27\u00b042\u203243\u2032\u2032 E. The system lies within the Malmani dolomites, approximately 800 meters southwest of the well-known site of Swartkrans in the Cradle of Humankind World Heritage Site, Gauteng Province, South Africa."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s1-3", 
+                        "title": "Horizon and associations", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The present sample of skeletal material from the Dinaledi Chamber was recovered during two field expeditions, in November 2013 and March 2014."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "Six specimens from an ex situ context can be identified as bird bones, and few fragmentary rodent remains have been recovered within the excavation area. Neither of these faunal constituents can presently be associated with the hominin fossil collection (<a href=\"#bib17\">Dirks et al., 2015</a>)."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "Aside from these limited faunal materials, the Dinaledi collection is entirely composed of hominin skeletal and dental remains. The collection so far comprises 1550 fossil hominin specimens, this number includes 1413 bone specimens and 137 isolated dental specimens; an additional 53 teeth are present in mandibular or maxillary bone specimens. Aside from the fragmentary rodent teeth, all dental crowns (n = 179) are hominin, recovered both from surface collection and excavation. Likewise, aside from the few bird elements, all morphologically informative bone specimens are clearly hominin. In all cases where elements are repeated in the sample, they are morphologically homogeneous, with variation consistent with body size and sex differences within a single population. These remains represent a minimum of 15 hominin individuals, as indicated by the repetition and presence of deciduous and adult dental elements."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The geological age of the fossils is not yet known. Excavations have thus far recovered hominin material from Unit 2 and Unit 3 in the chamber (<a href=\"#bib17\">Dirks et al., 2015</a>). Surface-collected hominin material from the present top of Unit 3, which includes material derived from both Unit 2 and Unit 3, represents a minority of the assemblage, and is morphologically indistinguishable from material excavated from in situ within Unit 3. In addition to general morphological homogeneity including cranial shape, distinctive morphological configurations of all the recovered first metacarpals, femora, molars, lower premolars and lower canines, are identical in both surface-collected and excavated specimens (see Figure 14 later in the text). These include traits not found in any other hominin species yet described. These considerations strongly indicate that this material represents a single species, and not a commingled assemblage."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s1-4", 
+                        "title": "Holotype, paratypes, and referred materials", 
+                        "content": [
+                            {
+                                "type": "section", 
+                                "id": "s1-4-1", 
+                                "title": "Holotype", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Dinaledi Hominin 1 (DH1) comprises the partial calvaria, partial maxilla, and nearly complete mandible of a presumed male individual, based on size and morphology within the sample (<a href=\"#fig2\">Figure 2</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). The holotype was recovered in situ during excavations within the Dinaledi Chamber in March of 2014, embedded in unconsolidated fine clay matrix (<a href=\"#bib17\">Dirks et al., 2015</a>). The holotype is housed in the Evolutionary Studies Institute at the University of the Witwatersrand, Johannesburg, South Africa."
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.019", 
+                                                "id": "fig2", 
+                                                "label": "Figure 2", 
+                                                "title": "Holotype specimen of <i>Homo naledi</i>, Dinaledi Hominin 1 (DH1).", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "U.W. 101-1473 cranium in (<b>A</b>) posterior and (<b>B</b>) frontal views (frontal view minus the frontal fragment to show calvaria interior). U.W. 101-1277 maxilla in (<b>C</b>) medial, (<b>D</b>) frontal, (<b>E</b>) superior, and (<b>F</b>) occlusal views. (<b>G</b>) U.W. 101-1473 cranium in anatomical alignment with occluded U.W. 101-1277 maxilla and U.W. 101-1261 mandible in left lateral view. U.W. 101-1277 mandible in (<b>H</b>) occlusal, (<b>I</b>) basal, (<b>J</b>) right lateral, and (<b>K</b>) anterior views. Scale bar = 10 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig2-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig2-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig2-v1.tif", 
+                                                    "size": {
+                                                        "width": 2750, 
+                                                        "height": 2095
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s1-4-2", 
+                                "title": "Paratypes", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Dinaledi Hominin 2 (DH2) is a partial calvaria that preserves parts of the frontal, left and right parietals, right temporal, and occipital (<a href=\"#fig3\">Figure 3</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). Dinaledi Hominin 3 (DH3) is a partial calvaria of a presumed female individual that preserves parts of the frontal, left parietal, left temporal, and sphenoid (<a href=\"#fig4\">Figure 4</a>, <a href=\"#SD1-data\">Supplementary file 1</a>). Dinaledi Hominin 4 (DH4) is a partial calvaria that preserves parts of the right temporal, right parietal, and occipital (<a href=\"#fig3\">Figure 3</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). Dinaledi Hominin 5 (DH5) is a partial calvaria that preserves part of the left temporal and occipital (<a href=\"#fig3\">Figure 3</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). U.W. 101-377 is a mandibular fragment that preserves dental anatomy in an unworn state; at present it cannot be definitively associated with any of these Dinaledi Hominin (DH) individuals, and indeed might represent another individual (<a href=\"#fig5\">Figure 5</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). These cranial specimens agree closely in nearly all morphological details where they overlap in areas preserved except those we interpret as related to sex."
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.005", 
+                                                "id": "fig3", 
+                                                "label": "Figure 3", 
+                                                "title": "Cranial paratypes.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "(<b>A</b>) DH2, right lateral view. (<b>B</b>) DH5, left lateral view. (<b>C</b>) DH4, right lateral view. (<b>D</b>) DH4, posterior view. Scale bar = 10 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig3-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig3-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig3-v1.tif", 
+                                                    "size": {
+                                                        "width": 1415, 
+                                                        "height": 1388
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.006", 
+                                                "id": "fig4", 
+                                                "label": "Figure 4", 
+                                                "title": "Paratype DH3.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "(<b>A</b>) Frontal view. (<b>B</b>) Left lateral view, with calvaria in articulation with the mandible (U.W. 101-361). (<b>C</b>) Basal view. Mandible in (<b>D</b>) medial view; (<b>E</b>) occlusal view; (<b>F</b>) basal view. DH3 was a relatively old individual at time of death, with extreme tooth wear. Scale bar = 10 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig4-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig4-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig4-v1.tif", 
+                                                    "size": {
+                                                        "width": 2750, 
+                                                        "height": 2022
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.007", 
+                                                "id": "fig5", 
+                                                "label": "Figure 5", 
+                                                "title": "U.W. 101-377 mandible.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "(<b>A</b>) Lateral view; (<b>B</b>) medial view; (<b>C</b>) basal view; (<b>D</b>) occlusal view. (<b>D</b>) The distinctive mandibular premolar morphology with elongated talonids in unworn state. Scale bar = 2 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig5-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig5-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig5-v1.tif", 
+                                                    "size": {
+                                                        "width": 1415, 
+                                                        "height": 1415
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Dinaledi hand 1 (H1) is a nearly complete (missing only the pisiform) right hand, found articulated in association, comprising specimens U.W. 101-1308 to \u22121311, \u22121318 to \u22121321, \u22121325 to \u22121329, \u22121351, \u22121464, and \u22121721 to \u22121732 (<a href=\"#fig6\">Figure 6</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). U.W. 101-1391 is a proximal right femur preserving part of the head, the neck, some of the lesser and greater trochanter, and the proximal shaft (<a href=\"#fig7\">Figure 7</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). U.W. 101-484 is a right tibial diaphysis missing only the proximal end (<a href=\"#fig8\">Figure 8</a>; <a href=\"#SD1-data\">Supplementary file 1</a>). Dinaledi foot 1 (F1) is a partial foot skeleton missing only the medial cuneiform and the phalanges of rays II\u2013V. Foot 1 is composed of specimens U.W. 101-1322, \u22121417 to \u22121419, \u22121439, \u22121443, \u22121456 to \u22121458, \u22121551, \u22121553, \u22121562, and \u22121698 (<a href=\"#fig9\">Figure 9</a>; <a href=\"#SD1-data\">Supplementary file 1</a>)."
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.008", 
+                                                "id": "fig6", 
+                                                "label": "Figure 6", 
+                                                "title": "Hand 1.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "Palmar view on left; dorsal view on right. This hand was discovered in articulation and all bones are represented except for the pisiform. The proportions of digits are humanlike and visually apparent, as are the expanded distal apical tufts on all digits, the robust pollical ray, and the unique first metacarpal morphology."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig6-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig6-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig6-v1.tif", 
+                                                    "size": {
+                                                        "width": 2750, 
+                                                        "height": 1782
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.009", 
+                                                "id": "fig7", 
+                                                "label": "Figure 7", 
+                                                "title": "U.W. 101-1391 paratype femur.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "(<b>A</b>) Medial view; (<b>B</b>) posterior view; (<b>C</b>) lateral view; (<b>D</b>) anterior view. The femur neck is relatively long and anteroposteriorly compressed. The anteversion of the neck is evident in medial view. Scale bar = 2 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig7-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig7-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig7-v1.tif", 
+                                                    "size": {
+                                                        "width": 2750, 
+                                                        "height": 1835
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.010", 
+                                                "id": "fig8", 
+                                                "label": "Figure 8", 
+                                                "title": "U.W. 101-484 paratype tibia.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "(<b>A</b>) Anterior view; (<b>B</b>) medial view; (<b>C</b>) posterior view; (<b>D</b>) lateral view. The tibiae are notably slender for their length. Scale bar = 10 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig8-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig8-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig8-v1.tif", 
+                                                    "size": {
+                                                        "width": 1415, 
+                                                        "height": 2055
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "type": "figure", 
+                                        "assets": [
+                                            {
+                                                "type": "image", 
+                                                "doi": "10.7554/eLife.09560.011", 
+                                                "id": "fig9", 
+                                                "label": "Figure 9", 
+                                                "title": "Foot 1 in (<b>A</b>) dorsal view; and (<b>B</b>) medial view.", 
+                                                "caption": [
+                                                    {
+                                                        "type": "paragraph", 
+                                                        "text": "(<b>C</b>) Proximal articular surfaces of the metatarsals of Foot 1, shown in articulation to illustrate transverse arch structure. Scale bar = 10 cm."
+                                                    }
+                                                ], 
+                                                "image": {
+                                                    "source": {
+                                                        "mediaType": "image/jpeg", 
+                                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig9-v1.tif/full/full/0/default.jpg", 
+                                                        "filename": "elife-09560-fig9-v1.jpg"
+                                                    }, 
+                                                    "alt": "", 
+                                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig9-v1.tif", 
+                                                    "size": {
+                                                        "width": 1415, 
+                                                        "height": 1122
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s1-4-3", 
+                                "title": "Referred material", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Referred material is also listed in <a href=\"#SD1-data\">Supplementary file 1</a>. We refer to <i>H. naledi</i> all hominin material from the Dinaledi collection that can be identified to element; in total, the holotypes, paratypes and referred material comprise 737 partial or complete anatomical elements."
+                                    }, 
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Specimen numbers in the collection are assigned at the point of excavation. Later laboratory analyses allowed us to refit specimens into more complete elements, which we have used as units of anatomical study. Here we refer to refitted elements by only a single specimen number; either the number of the most constitutive specimen, or the first diagnostic part to be discovered. DH designations are reserved for clearly associated individuals; at this time these are limited to the five partial crania designated above. Future excavation and analyses will certainly uncover more refits among specimens. As refits are found, all numbers assigned to refitted elements will remain stable, and all numbers in <a href=\"#SD1-data\">Supplementary file 1</a> will be retained."
+                                    }, 
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The collection is morphologically homogeneous in all duplicated elements, except for those anatomical features that normally reflect body size or sex differences in other primate taxa. Therefore, although we refer to the holotype and the paratypes for differential diagnoses; the section describing the overall anatomy encompasses all morphologically informative specimens."
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }, 
+            {
+                "type": "section", 
+                "id": "s2", 
+                "title": "Differential diagnosis", 
+                "content": [
+                    {
+                        "type": "paragraph", 
+                        "text": "This comprehensive differential diagnosis is based upon cranial, dental and postcranial characters. The hypodigms used for other species are detailed in the \u2018Materials and methods\u2019. We examined original specimens for most species, except where indicated in the \u2018Materials and methods\u2019; when we relied on other sources for anatomical observations we indicate this. A summary of traits of <i>H. naledi</i> in comparison to other species is presented in <a href=\"#SD2-data\">Supplementary file 2</a>. Comparative cranial and mandibular measures are presented in <a href=\"#tbl1\">Table 1</a>, and comparative dental measures are provided in <a href=\"#tbl2\">Table 2</a>."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "table", 
+                                "doi": "10.7554/eLife.09560.012", 
+                                "id": "tbl1", 
+                                "label": "Table 1", 
+                                "title": "Cranial and mandibular measurements for <i>H. naledi</i>, early hominins, and modern humans", 
+                                "tables": [
+                                    "<table><thead><tr><th></th><th>Measurement definitions as in <a href=\"#bib70\">Wood (1991)</a></th><th><i>P. aethiopicus</i></th><th><i>P. boisei</i></th><th><i>P. robustus</i></th><th><i>Au. afarensis</i></th><th><i>Au. africanus</i></th><th><i>Au. sediba</i></th><th><i>H. naledi</i></th><th><i>H. habilis</i></th><th><i>H. rudolfensis</i></th><th><i>H. erectus</i></th><th>MP <i>Homo</i></th><th><i>H. sapiens</i></th></tr></thead><tbody><tr><td colspan=\"14\">Cranium</td></tr><tr><td>\u2003Cranial capacity</td><td>\u2013</td><td>410</td><td>485</td><td>493</td><td>457</td><td>467</td><td>420</td><td>513</td><td>610</td><td>776</td><td>865</td><td>1266</td><td>1330</td></tr><tr><td>\u2003Porion height</td><td>6</td><td>72</td><td>74</td><td>\u2013</td><td>86</td><td>70</td><td>67</td><td>81</td><td>77</td><td>90</td><td>94</td><td>101</td><td>112</td></tr><tr><td>\u2003Posterior cranial length</td><td>3</td><td>58</td><td>47</td><td>54</td><td>60</td><td>44</td><td>\u2013</td><td>65</td><td>60</td><td>70</td><td>79</td><td>99</td><td>81</td></tr><tr><td>\u2003Bi-parietal breadth</td><td>9</td><td>94</td><td>98</td><td>\u2013</td><td>90</td><td>99</td><td>100</td><td>103</td><td>107</td><td>118</td><td>129</td><td>142</td><td>132</td></tr><tr><td>\u2003Bi-temporal breadth</td><td>10</td><td>110</td><td>109</td><td>108</td><td>115</td><td>104</td><td>101</td><td>107</td><td>112</td><td>126</td><td>131</td><td>146</td><td>127</td></tr><tr><td>\u2003Closest approach of temporal lines</td><td>\u2013</td><td>crest<a href=\"#tblfn1\">*</a></td><td>crest<a href=\"#tblfn1\">*</a></td><td>crest<a href=\"#tblfn1\">*</a></td><td>crest<a href=\"#tblfn1\">*</a></td><td>21</td><td>56</td><td>52</td><td>35</td><td>51</td><td>72</td><td>101</td><td>96</td></tr><tr><td>\u2003Supraorbital height index</td><td>\u2013</td><td>46</td><td>53</td><td>50</td><td>51</td><td>60</td><td>56</td><td>56</td><td>64</td><td>59</td><td>56</td><td>62</td><td>71</td></tr><tr><td>\u2003Minimum post-orbital breadth</td><td>\u2013</td><td>62</td><td>66</td><td>70</td><td>77</td><td>67</td><td>70</td><td>68</td><td>75</td><td>78</td><td>89</td><td>96</td><td>97</td></tr><tr><td>\u2003Superior facial breadth</td><td>49</td><td>100</td><td>107</td><td>109</td><td>\u2013</td><td>95</td><td>86</td><td>86</td><td>97</td><td>113</td><td>110</td><td>124</td><td>107</td></tr><tr><td>\u2003Post-orbital constriction index<a href=\"#tblfn2\">\u2020</a></td><td>\u2013</td><td>62</td><td>61</td><td>64</td><td>\u2013</td><td>69</td><td>81</td><td>79</td><td>72</td><td>74</td><td>81</td><td>80</td><td>91</td></tr><tr><td>\u2003EAM area (as an ellipse)<a href=\"#tblfn3\">\u2021</a></td><td>\u2013</td><td>77</td><td>80</td><td>103</td><td>70</td><td>96</td><td>\u2013</td><td>38</td><td>76</td><td>\u2013</td><td>95</td><td>85</td><td>61</td></tr><tr><td>\u2003Root of zygomatic process origin</td><td>\u2013</td><td>P4</td><td>P4</td><td>P3 to M1</td><td>P4 to M1</td><td>P4 to M1</td><td>P4</td><td>P3 to P4</td><td>P4 to M1</td><td>P4 to M1</td><td>P4 to M1</td><td>M1</td><td>M1</td></tr><tr><td>\u2003Petromedian angle</td><td>137</td><td>50</td><td>45</td><td>50</td><td>31</td><td>33</td><td>\u2013</td><td>55</td><td>48</td><td>\u2013</td><td>52</td><td>55</td><td>46</td></tr><tr><td colspan=\"14\">Maxilloalveolar process</td></tr><tr><td>\u2003Maxilloalveolar length</td><td>87</td><td>94</td><td>78</td><td>69</td><td>67</td><td>71</td><td>63</td><td>57</td><td>65</td><td>68</td><td>66</td><td>69</td><td>55</td></tr><tr><td>\u2003Maxilloalveolar breadth</td><td>88</td><td>83</td><td>76</td><td>69</td><td>68</td><td>66</td><td>63</td><td>71</td><td>68</td><td>72</td><td>70</td><td>72</td><td>62</td></tr><tr><td>\u2003Palate breadth</td><td>91</td><td>32</td><td>40</td><td>35</td><td>30</td><td>36</td><td>29</td><td>44</td><td>38</td><td>40</td><td>38</td><td>56</td><td>40</td></tr><tr><td>\u2003Palate depth at incisive fossa</td><td>\u2013</td><td>3</td><td>11</td><td>10</td><td>10</td><td>9</td><td>10</td><td>5</td><td>10</td><td>13</td><td>11</td><td>10</td><td>9</td></tr><tr><td>\u2003Palate depth at M1</td><td>103</td><td>7</td><td>18</td><td>11</td><td>11</td><td>13</td><td>10</td><td>10</td><td>12</td><td>16</td><td>15</td><td>18</td><td>13</td></tr><tr><td colspan=\"14\">Mandible</td></tr><tr><td>\u2003Symphysis height</td><td>141</td><td>37</td><td>49</td><td>42</td><td>39</td><td>37</td><td>32</td><td>33</td><td>31</td><td>37</td><td>35</td><td>34</td><td>34</td></tr><tr><td>\u2003Symphysis width</td><td>142</td><td>26</td><td>28</td><td>25</td><td>20</td><td>21</td><td>18</td><td>18</td><td>20</td><td>24</td><td>18</td><td>17</td><td>14</td></tr><tr><td>\u2003Symphysis area at M1 (as an ellipse)<a href=\"#tblfn3\">\u2021</a></td><td>146</td><td>757</td><td>1114</td><td>835</td><td>623</td><td>606</td><td>452</td><td>467</td><td>393</td><td>723</td><td>519</td><td>474</td><td>365</td></tr><tr><td>\u2003Corpus height at M1</td><td>150</td><td>38</td><td>42</td><td>36</td><td>34</td><td>32</td><td>30</td><td>26</td><td>29</td><td>36</td><td>31</td><td>31</td><td>28</td></tr><tr><td>\u2003Corpus breadth at M1</td><td>151</td><td>25</td><td>29</td><td>26</td><td>20</td><td>21</td><td>18</td><td>16</td><td>20</td><td>22</td><td>19</td><td>19</td><td>13</td></tr><tr><td>\u2003Corpus area at M1 (as an ellipse)<a href=\"#tblfn3\">\u2021</a></td><td>152</td><td>742</td><td>955</td><td>736</td><td>540</td><td>539</td><td>405</td><td>326</td><td>425</td><td>631</td><td>458</td><td>469</td><td>296</td></tr><tr><td>\u2003Mental foramen height index<a href=\"#tblfn4\">\u00a7</a></td><td>\u2013</td><td>51</td><td>50</td><td>54</td><td>58</td><td>53</td><td>50</td><td>40</td><td>46</td><td>49</td><td>48</td><td>48</td><td>50</td></tr></tbody></table>"
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "id": "tblfn1", 
+                                        "label": "*", 
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "At least in presumed males."
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "id": "tblfn2", 
+                                        "label": "\u2020", 
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "Post-orbital breadth/superior facial breadth \u00d7 100."
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "id": "tblfn3", 
+                                        "label": "\u2021", 
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "Following the formula (\u03c0 \u00d7 (corpus height/2) \u00d7 (corpus breadth/2))."
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "id": "tblfn4", 
+                                        "label": "\u00a7", 
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "Height of mental foramen from alveolar border relative to corpus height at the mental foramen."
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "MP, Middle Pleistocene."
+                                            }
+                                        ]
+                                    }, 
+                                    {
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "Unless otherwise indicated measurements are defined as in <a href=\"#bib70\">Wood (1991)</a>. Chord distances are in mm. Data for <i>H. naledi</i> collected from original fossils or laser scans by DJdeR and HMG; comparative data collected by DJdeR on original fossils and casts and supplemented by data from <a href=\"#bib70\">Wood (1991)</a>."
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "table", 
+                                "doi": "10.7554/eLife.09560.013", 
+                                "id": "tbl2", 
+                                "label": "Table 2", 
+                                "title": "Dental measures for <i>H. naledi</i> and comparative hominin species", 
+                                "tables": [
+                                    "<table><thead><tr><th colspan=\"18\">Maxillary</th></tr><tr><th></th><th></th><th colspan=\"2\">I<sup>1</sup></th><th colspan=\"2\">I<sup>2</sup></th><th colspan=\"2\">C</th><th colspan=\"2\">P<sup>3</sup></th><th colspan=\"2\">P<sup>4</sup></th><th colspan=\"2\">M<sup>1</sup></th><th colspan=\"2\">M<sup>2</sup></th><th colspan=\"2\">M<sup>3</sup></th></tr><tr><th></th><th></th><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th></tr></thead><tbody><tr><td rowspan=\"3\"><i>Au. anamensis</i></td><td>n</td><td>3</td><td>5</td><td>\u2013</td><td>2</td><td>6</td><td>7</td><td>7</td><td>6</td><td>5</td><td>3</td><td>12</td><td>10</td><td>10</td><td>8</td><td>9</td><td>8</td></tr><tr><td>mean</td><td>10.8</td><td>8.7</td><td>\u2013</td><td>7.3</td><td>11.0</td><td>10.6</td><td>9.9</td><td>12.6</td><td>8.9</td><td>13.6</td><td>11.5</td><td>12.9</td><td>13.0</td><td>14.4</td><td>12.5</td><td>14.2</td></tr><tr><td>range</td><td>9.1\u201312.4</td><td>8.2\u20139.3</td><td>\u2013</td><td>7.0\u20137.5</td><td>9.9\u201312.3</td><td>9.1\u201311.8</td><td>8.2\u201311.8</td><td>10.1\u201314.3</td><td>7.2\u201312.1</td><td>12.6\u201314.2</td><td>7.8\u201314.3</td><td>9.0\u201316.7</td><td>10.9\u201316.3</td><td>12.9\u201316.1</td><td>11.1\u201315.7</td><td>13.0\u201315.7</td></tr><tr><td rowspan=\"3\"><i>Au. afarensis</i></td><td>n</td><td>7</td><td>8</td><td>9</td><td>9</td><td>15</td><td>15</td><td>12</td><td>10</td><td>18</td><td>12</td><td>16</td><td>13</td><td>10</td><td>11</td><td>11</td><td>11</td></tr><tr><td>mean</td><td>10.7</td><td>8.4</td><td>7.5</td><td>7.2</td><td>9.9</td><td>10.8</td><td>8.8</td><td>12.4</td><td>9.1</td><td>12.4</td><td>12.0</td><td>13.4</td><td>12.9</td><td>14.6</td><td>12.7</td><td>14.5</td></tr><tr><td>range</td><td>9.9\u201311.8</td><td>7.1\u20139.7</td><td>6.6\u20138.2</td><td>6.2\u20138.1</td><td>8.8\u201311.6</td><td>9.3\u201312.5</td><td>7.7\u20139.7</td><td>11.3\u201313.4</td><td>7.6\u201310.8</td><td>11.1\u201314.5</td><td>10.5\u201313.8</td><td>12.0\u201315.0</td><td>12.1\u201313.6</td><td>13.4\u201315.2</td><td>10.9\u201314.8</td><td>13.1\u201316.3</td></tr><tr><td rowspan=\"3\"><i>Au. africanus</i></td><td>n</td><td>15</td><td>15</td><td>11</td><td>10</td><td>16</td><td>13</td><td>26</td><td>25</td><td>20</td><td>20</td><td>21</td><td>20</td><td>23</td><td>24</td><td>27</td><td>28</td></tr><tr><td>mean</td><td>10.7</td><td>8.3</td><td>6.9</td><td>6.8</td><td>9.9</td><td>10.3</td><td>9.2</td><td>12.7</td><td>9.5</td><td>13.4</td><td>12.9</td><td>13.9</td><td>14.1</td><td>15.7</td><td>14.2</td><td>16.0</td></tr><tr><td>range</td><td>9.4\u201312.5</td><td>7.4\u20139.1</td><td>5.8\u20138.0</td><td>5.6\u20137.9</td><td>8.8\u201311.0</td><td>8.7\u201312.0</td><td>8.5\u201310.2</td><td>10.7\u201314.5</td><td>7.2\u201311.0</td><td>12.4\u201315.3</td><td>11.7\u201314.4</td><td>12.9\u201315.3</td><td>12.1\u201316.3</td><td>12.8\u201317.9</td><td>11.2\u201316.9</td><td>13.1\u201318.6</td></tr><tr><td rowspan=\"3\"><i>Au. sediba</i></td><td>n</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>2</td><td>2</td></tr><tr><td>mean</td><td>10.1</td><td>6.9</td><td>7.2</td><td>6.6</td><td>9.0</td><td>8.8</td><td>9.0</td><td>11.2</td><td>9.3</td><td>12.1</td><td>12.9</td><td>12.0</td><td>12.9</td><td>13.7</td><td>13.0</td><td>13.5</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>12.6\u201313.3</td><td>12.9\u201314.1</td></tr><tr><td rowspan=\"3\"><i>H. naledi</i></td><td>n</td><td>\u2013</td><td>5</td><td>4</td><td>8</td><td>10</td><td>9</td><td>10</td><td>10</td><td>7</td><td>7</td><td>12</td><td>13</td><td>11</td><td>9</td><td>7</td><td>7</td></tr><tr><td>mean</td><td>9.4</td><td>6.5</td><td>6.6</td><td>6.2</td><td>8.1</td><td>8.6</td><td>8.0</td><td>10.5</td><td>8.1</td><td>11.0</td><td>11.6</td><td>11.7</td><td>12.2</td><td>12.8</td><td>11.6</td><td>12.4</td></tr><tr><td>range</td><td>8.8\u20139.8</td><td>6.3\u20137.0</td><td>6.3\u20137.0</td><td>5.8\u20136.6</td><td>7.3\u20138.9</td><td>8.0\u20139.6</td><td>7.7\u20138.4</td><td>9.8\u201311.0</td><td>7.7\u20138.7</td><td>10.5\u201311.2</td><td>10.5\u201312.4</td><td>11.2\u201312.4</td><td>11.0\u201313.0</td><td>11.9\u201313.6</td><td>11.0\u201312.7</td><td>11.4\u201313.4</td></tr><tr><td rowspan=\"3\"><i>H. habilis</i></td><td>n</td><td>2</td><td>2</td><td>4</td><td>4</td><td>2</td><td>3</td><td>7</td><td>7</td><td>8</td><td>8</td><td>13</td><td>13</td><td>7</td><td>7</td><td>7</td><td>7</td></tr><tr><td>mean</td><td>10.6</td><td>8.0</td><td>7.4</td><td>6.6</td><td>9.0</td><td>9.8</td><td>9.0</td><td>11.9</td><td>9.2</td><td>12.1</td><td>12.7</td><td>13.0</td><td>12.7</td><td>14.3</td><td>12.3</td><td>14.7</td></tr><tr><td>range</td><td>10.1\u201311.1</td><td>7.3\u20138.7</td><td>6.7\u20138.1</td><td>6.0\u20137.9</td><td>8.5\u20139.4</td><td>8.5\u201311.6</td><td>8.1\u20139.6</td><td>11.0\u201312.7</td><td>8.5\u20139.9</td><td>11.0\u201313.1</td><td>11.6\u201313.9</td><td>12.1\u201314.1</td><td>11.8\u201313.5</td><td>13.5\u201316.2</td><td>11.3\u201313.9</td><td>13.2\u201316.6</td></tr><tr><td rowspan=\"3\"><i>H. rudolfensis</i></td><td>n</td><td>1</td><td>1</td><td>\u2013</td><td>\u2013</td><td>1</td><td>1</td><td>1</td><td>1</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td><td>1</td><td>1</td></tr><tr><td>mean</td><td>12.3</td><td>7.7</td><td>\u2013</td><td>\u2013</td><td>11.5</td><td>12.5</td><td>10.5</td><td>13.6</td><td>10.2</td><td>12.5</td><td>14.0</td><td>14.0</td><td>14.3</td><td>15.8</td><td>13.3</td><td>13.5</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>9.7\u201310.7</td><td>11.1\u201313.8</td><td>13.9\u201314.2</td><td>13.3\u201314.8</td><td>14.1\u201314.6</td><td>14.1\u201317.6</td><td>\u2013</td><td>\u2013</td></tr><tr><td rowspan=\"3\"><i>H. erectus</i></td><td>n</td><td>11</td><td>12</td><td>6</td><td>6</td><td>12</td><td>12</td><td>27</td><td>27</td><td>30</td><td>29</td><td>34</td><td>32</td><td>22</td><td>22</td><td>16</td><td>16</td></tr><tr><td>mean</td><td>10.3</td><td>8.1</td><td>7.7</td><td>8.0</td><td>9.5</td><td>10.0</td><td>8.5</td><td>11.8</td><td>8.1</td><td>11.6</td><td>12.2</td><td>13.2</td><td>12.0</td><td>13.3</td><td>10.5</td><td>12.8</td></tr><tr><td>range</td><td>8.1\u201312.6</td><td>7.0\u201311.7</td><td>6.0\u20138.3</td><td>6.9\u20138.5</td><td>8.5\u201311.1</td><td>9.0\u201311.8</td><td>7.1\u201310.1</td><td>9.5\u201313.8</td><td>7.0\u20139.4</td><td>9.9\u201313.4</td><td>10.1\u201314.6</td><td>11.0\u201315.9</td><td>10.3\u201313.6</td><td>10.9\u201315.5</td><td>8.7\u201314.7</td><td>10.4\u201315.8</td></tr><tr><td rowspan=\"3\"><i>H. neanderthalensis</i></td><td>n</td><td>28</td><td>37</td><td>35</td><td>41</td><td>28</td><td>29</td><td>16</td><td>17</td><td>21</td><td>19</td><td>23</td><td>24</td><td>27</td><td>28</td><td>22</td><td>21</td></tr><tr><td>mean</td><td>9.7</td><td>8.5</td><td>8.0</td><td>8.4</td><td>8.8</td><td>10.1</td><td>8.0</td><td>10.6</td><td>7.8</td><td>10.6</td><td>11.6</td><td>12.3</td><td>10.9</td><td>12.5</td><td>9.9</td><td>12.3</td></tr><tr><td>range</td><td>8.2\u201311.8</td><td>7.3\u20139.9</td><td>5.8\u20139.3</td><td>5.8\u20139.9</td><td>7.2\u201310.0</td><td>7.6\u201311.4</td><td>6.6\u20139.3</td><td>8.4\u201311.8</td><td>5.9\u201311.5</td><td>8.3\u201311.7</td><td>9.5\u201313.5</td><td>11.0\u201314.2</td><td>8.9\u201315.9</td><td>10.8\u201314.6</td><td>8.2\u201311.4</td><td>9.8\u201314.6</td></tr><tr><td rowspan=\"3\"><i>H. heidelbergensis</i></td><td>n</td><td>21</td><td>23</td><td>19</td><td>21</td><td>27</td><td>29</td><td>25</td><td>25</td><td>22</td><td>23</td><td>25</td><td>24</td><td>24</td><td>23</td><td>26</td><td>27</td></tr><tr><td>mean</td><td>9.6</td><td>7.8</td><td>7.7</td><td>7.8</td><td>8.8</td><td>9.8</td><td>7.9</td><td>10.6</td><td>7.6</td><td>10.3</td><td>11.2</td><td>11.9</td><td>10.2</td><td>12.3</td><td>8.9</td><td>11.6</td></tr><tr><td>range</td><td>8.7\u201310.7</td><td>7.1\u20139.9</td><td>7.2\u20138.4</td><td>7.3\u20138.6</td><td>8.1\u201311.0</td><td>8.8\u201311.8</td><td>7.1\u20139.0</td><td>9.2\u201312.2</td><td>7.0\u20138.8</td><td>9.1\u201311.5</td><td>9.9\u201312.3</td><td>10.3\u201313.2</td><td>8.1\u201312.1</td><td>11.1\u201313.8</td><td>7.6\u201311.0</td><td>10.0\u201313.2</td></tr><tr><td rowspan=\"3\">MP/LP African Homo</td><td>n</td><td>6</td><td>6</td><td>7</td><td>8</td><td>4</td><td>4</td><td>6</td><td>6</td><td>10</td><td>10</td><td>14</td><td>14</td><td>20</td><td>20</td><td>9</td><td>9</td></tr><tr><td>mean</td><td>9.0</td><td>7.8</td><td>7.4</td><td>7.2</td><td>8.9</td><td>9.7</td><td>8.4</td><td>10.8</td><td>8.1</td><td>10.8</td><td>12.3</td><td>13.2</td><td>11.0</td><td>12.9</td><td>9.2</td><td>11.7</td></tr><tr><td>range</td><td>6.3\u201310.9</td><td>6.6\u20138.7</td><td>6.0\u20139.3</td><td>6.1\u20138.5</td><td>8.2\u20139.5</td><td>8.8\u201310.0</td><td>8.1\u20138.7</td><td>9.9\u201311.8</td><td>7.5\u20139.3</td><td>9.4\u201312.8</td><td>10.4\u201314.0</td><td>12.0\u201315.0</td><td>7.8\u201313.0</td><td>11.0\u201315.0</td><td>7.6\u201310.2</td><td>10.0\u201313.2</td></tr></tbody></table>", 
+                                    "<table><thead><tr><th colspan=\"18\">Mandibular</th></tr><tr><th></th><th></th><th colspan=\"2\">I<sub>1</sub></th><th colspan=\"2\">I<sub>2</sub></th><th colspan=\"2\">C</th><th colspan=\"2\">P<sub>3</sub></th><th colspan=\"2\">P<sub>4</sub></th><th colspan=\"2\">M<sub>1</sub></th><th colspan=\"2\">M<sub>2</sub></th><th colspan=\"2\">M<sub>3</sub></th></tr><tr><th></th><th></th><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>LL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th><th>MD</th><th>BL</th></tr></thead><tbody><tr><td rowspan=\"3\"><i>Au. anamensis</i></td><td>n</td><td>2</td><td>1</td><td>4</td><td>3</td><td>7</td><td>7</td><td>8</td><td>8</td><td>8</td><td>8</td><td>9</td><td>10</td><td>7</td><td>7</td><td>8</td><td>8</td></tr><tr><td>mean</td><td>6.9</td><td>7.4</td><td>7.8</td><td>8.3</td><td>10.0</td><td>10.4</td><td>12.4</td><td>9.2</td><td>9.1</td><td>11.3</td><td>12.9</td><td>12.3</td><td>14.0</td><td>13.4</td><td>15.3</td><td>13.4</td></tr><tr><td>range</td><td>6.8\u20136.9</td><td>\u2013</td><td>6.6\u20138.7</td><td>7.9\u20138.6</td><td>6.6\u201313.9</td><td>9.2\u201311.4</td><td>11.3\u201313.4</td><td>8.6\u201310.0</td><td>7.4\u20139.8</td><td>9.6\u201313.2</td><td>11.6\u201313.8</td><td>10.2\u201314.8</td><td>13.0\u201315.9</td><td>12.3\u201314.9</td><td>13.7\u201317.0</td><td>12.1\u201315.2</td></tr><tr><td rowspan=\"3\"><i>Au. afarensis</i></td><td>n</td><td>7</td><td>8</td><td>7</td><td>6</td><td>13</td><td>16</td><td>27</td><td>26</td><td>24</td><td>21</td><td>32</td><td>26</td><td>31</td><td>27</td><td>26</td><td>23</td></tr><tr><td>mean</td><td>6.7</td><td>7.1</td><td>6.7</td><td>8.0</td><td>8.8</td><td>10.4</td><td>9.6</td><td>10.6</td><td>9.8</td><td>11.0</td><td>13.1</td><td>12.6</td><td>14.3</td><td>13.4</td><td>15.3</td><td>13.5</td></tr><tr><td>range</td><td>5.6\u20137.7</td><td>5.6\u20138.0</td><td>5.0\u20138.0</td><td>6.7\u20138.8</td><td>7.5\u201311.7</td><td>8.0\u201312.4</td><td>7.9\u201312.6</td><td>8.9\u201313.8</td><td>7.7\u201311.4</td><td>9.8\u201312.8</td><td>10.1\u201314.8</td><td>11.0\u201314.0</td><td>12.1\u201316.5</td><td>11.1\u201315.2</td><td>13.4\u201318.1</td><td>11.3\u201315.3</td></tr><tr><td rowspan=\"3\"><i>Au. africanus</i></td><td>n</td><td>11</td><td>12</td><td>12</td><td>13</td><td>23</td><td>25</td><td>20</td><td>21</td><td>25</td><td>23</td><td>29</td><td>32</td><td>38</td><td>38</td><td>34</td><td>35</td></tr><tr><td>mean</td><td>6.2</td><td>6.7</td><td>7.2</td><td>7.9</td><td>9.4</td><td>10.1</td><td>9.7</td><td>11.5</td><td>10.4</td><td>11.6</td><td>14.0</td><td>13.0</td><td>15.7</td><td>14.5</td><td>16.3</td><td>14.6</td></tr><tr><td>range</td><td>4.8\u20136.9</td><td>5.7\u20137.9</td><td>5.6\u20138.1</td><td>6.6\u20139.2</td><td>8.5\u201310.7</td><td>8.2\u201312.1</td><td>8.8\u201311.0</td><td>9.9\u201313.9</td><td>8.7\u201312.3</td><td>9.3\u201313.2</td><td>12.4\u201315.8</td><td>11.2\u201315.1</td><td>14.2\u201317.7</td><td>12.8\u201316.8</td><td>13.5\u201318.5</td><td>12.2\u201316.8</td></tr><tr><td rowspan=\"3\"><i>Au. sediba</i></td><td>n</td><td>\u2013</td><td>1</td><td>\u2013</td><td>1</td><td>2</td><td>2</td><td>1</td><td>1</td><td>1</td><td>1</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td><td>2</td></tr><tr><td>mean</td><td>\u2013</td><td>5.9</td><td>\u2013</td><td>6.6</td><td>7.7</td><td>8.0</td><td>8.1</td><td>9.2</td><td>8.8</td><td>9.7</td><td>13.1</td><td>11.4</td><td>14.5</td><td>12.8</td><td>14.9</td><td>13.2</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>7.3\u20138.0</td><td>7.4\u20138.6</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>13.1\u201313.1</td><td>11.3\u201311.5</td><td>14.4\u201314.5</td><td>12.3\u201313.2</td><td>14.9\u201314.9</td><td>12.5\u201313.6</td></tr><tr><td rowspan=\"3\"><i>H. naledi</i></td><td>n</td><td>7</td><td>7</td><td>5</td><td>6</td><td>7</td><td>7</td><td>9</td><td>10</td><td>6</td><td>6</td><td>11</td><td>11</td><td>9</td><td>9</td><td>6</td><td>5</td></tr><tr><td>mean</td><td>6.1</td><td>5.4</td><td>6.9</td><td>5.9</td><td>7.1</td><td>7.1</td><td>9.0</td><td>8.8</td><td>8.7</td><td>9.1</td><td>12.2</td><td>10.7</td><td>13.3</td><td>11.2</td><td>13.4</td><td>12.1</td></tr><tr><td>range</td><td>5.7\u20137.0</td><td>5.3\u20135.9</td><td>6.6\u20137.4</td><td>5.9\u20136.0</td><td>6.4\u20137.5</td><td>6.9\u20137.4</td><td>8.2\u20139.4</td><td>8.2\u20139.7</td><td>8.3\u20139.0</td><td>8.5\u201310.2</td><td>11.3\u201312.7</td><td>10.3\u201311.4</td><td>12.3\u201314.0</td><td>10.7\u201312.2</td><td>12.9\u201313.7</td><td>11.7\u201312.8</td></tr><tr><td rowspan=\"3\"><i>H. habilis</i></td><td>n</td><td>2</td><td>2</td><td>2</td><td>2</td><td>3</td><td>2</td><td>4</td><td>4</td><td>3</td><td>3</td><td>5</td><td>5</td><td>4</td><td>4</td><td>4</td><td>4</td></tr><tr><td>mean</td><td>6.4</td><td>6.8</td><td>7.4</td><td>7.6</td><td>8.7</td><td>9.0</td><td>9.6</td><td>9.6</td><td>9.9</td><td>10.5</td><td>13.7</td><td>11.9</td><td>15.0</td><td>13.5</td><td>15.4</td><td>13.3</td></tr><tr><td>range</td><td>6.4\u20136.5</td><td>6.7\u20137.0</td><td>7.2\u20137.7</td><td>7.6\u20137.6</td><td>7.6\u20139.6</td><td>7.9\u201310.0</td><td>9.0\u201310.6</td><td>8.6\u201311.1</td><td>9.0\u201310.5</td><td>9.9\u201311.0</td><td>13.0\u201314.8</td><td>10.9\u201312.8</td><td>14.2\u201315.7</td><td>12.0\u201315.1</td><td>14.8\u201315.9</td><td>12.4\u201314.4</td></tr><tr><td rowspan=\"3\"><i>H. rudolfensis</i></td><td>n</td><td>\u2013</td><td>1</td><td>\u2013</td><td>1</td><td>\u2013</td><td>1</td><td>3</td><td>3</td><td>6</td><td>6</td><td>5</td><td>5</td><td>6</td><td>5</td><td>3</td><td>3</td></tr><tr><td>mean</td><td>\u2013</td><td>5.4</td><td>\u2013</td><td>6.7</td><td>\u2013</td><td>8.3</td><td>9.9</td><td>11.1</td><td>10.1</td><td>11.4</td><td>14.0</td><td>12.7</td><td>16.0</td><td>13.7</td><td>16.4</td><td>14.1</td></tr><tr><td>range</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>\u2013</td><td>9.0\u201310.7</td><td>9.5\u201312.3</td><td>8.8\u201311.8</td><td>9.8\u201312.2</td><td>12.8\u201315.2</td><td>11.4\u201313.2</td><td>14.0\u201318.3</td><td>12.7\u201314.9</td><td>15.6\u201317.0</td><td>13.1\u201314.6</td></tr><tr><td rowspan=\"3\"><i>H. erectus</i></td><td>n</td><td>11</td><td>12</td><td>14</td><td>16</td><td>14</td><td>16</td><td>30</td><td>30</td><td>25</td><td>26</td><td>43</td><td>43</td><td>41</td><td>40</td><td>26</td><td>27</td></tr><tr><td>mean</td><td>6.2</td><td>6.4</td><td>7</td><td>7.2</td><td>8.7</td><td>9</td><td>9</td><td>10.1</td><td>8.7</td><td>10.1</td><td>12.7</td><td>11.9</td><td>13.3</td><td>12.5</td><td>12.7</td><td>11.7</td></tr><tr><td>range</td><td>4.8\u20137.4</td><td>5.8\u20137.1</td><td>5.3\u20138.1</td><td>6.4\u20138.5</td><td>7.0\u201310.3</td><td>8.0\u201310.4</td><td>7.0\u201312.0</td><td>8.2\u201312.0</td><td>7.2\u201310.3</td><td>8.0\u201312.5</td><td>9.9\u201314.8</td><td>10.1\u201313.3</td><td>11.3\u201315.3</td><td>10.8\u201314.3</td><td>10.0\u201315.2</td><td>10.0\u201314.2</td></tr><tr><td rowspan=\"3\"><i>H. neanderthalensis</i></td><td>n</td><td>9</td><td>16</td><td>23</td><td>31</td><td>36</td><td>41</td><td>20</td><td>21</td><td>23</td><td>25</td><td>38</td><td>40</td><td>26</td><td>27</td><td>18</td><td>20</td></tr><tr><td>mean</td><td>5.6</td><td>7.2</td><td>6.8</td><td>7.8</td><td>7.8</td><td>8.8</td><td>7.9</td><td>9.1</td><td>7.8</td><td>9.4</td><td>11.8</td><td>11.1</td><td>12.1</td><td>11.3</td><td>12.0</td><td>11.0</td></tr><tr><td>range</td><td>4.2\u20136.4</td><td>5.2\u20138.8</td><td>5.9\u20137.5</td><td>6.8\u20139.0</td><td>6.7\u20138.8</td><td>6.8\u201310.3</td><td>6.6\u20139.1</td><td>8.0\u201310.3</td><td>6.5\u20139.4</td><td>8.5\u201310.5</td><td>10.1\u201313.6</td><td>10.2\u201312.9</td><td>9.3\u201314.0</td><td>8.8\u201312.4</td><td>11.2\u201313.9</td><td>9.9\u201312.2</td></tr><tr><td rowspan=\"3\"><i>H. heidelbergensis</i></td><td>n</td><td>21</td><td>22</td><td>19</td><td>20</td><td>23</td><td>24</td><td>22</td><td>22</td><td>26</td><td>26</td><td>29</td><td>29</td><td>29</td><td>29</td><td>32</td><td>32</td></tr><tr><td>mean</td><td>5.6</td><td>6.7</td><td>6.5</td><td>7.3</td><td>7.6</td><td>8.7</td><td>7.9</td><td>8.9</td><td>7.2</td><td>8.7</td><td>11.3</td><td>10.6</td><td>11.2</td><td>10.5</td><td>11.5</td><td>10.0</td></tr><tr><td>range</td><td>4.8\u20136.5</td><td>6.0\u20137.5</td><td>6.0\u20137.2</td><td>6.6\u20138.0</td><td>6.9\u20139.0</td><td>7.3\u201310.0</td><td>7.2\u20139.0</td><td>7.6\u201311.6</td><td>6.6\u20138.8</td><td>7.2\u201311.7</td><td>10.4\u201313.8</td><td>9.6\u201313.0</td><td>9.7\u201314.6</td><td>8.5\u201313.9</td><td>9.7\u201313.2</td><td>8.6\u201312.5</td></tr><tr><td rowspan=\"3\">MP/LP African Homo</td><td>n</td><td>5</td><td>5</td><td>8</td><td>8</td><td>8</td><td>8</td><td>8</td><td>8</td><td>12</td><td>9</td><td>16</td><td>16</td><td>20</td><td>20</td><td>13</td><td>13</td></tr><tr><td>mean</td><td>6.0</td><td>6.8</td><td>6.8</td><td>7.2</td><td>8.8</td><td>9.6</td><td>8.6</td><td>9.8</td><td>8.6</td><td>10.3</td><td>13.1</td><td>11.8</td><td>12.5</td><td>11.7</td><td>12.4</td><td>11.5</td></tr><tr><td>range</td><td>5.7\u20136.4</td><td>6.1\u20137.2</td><td>5.6\u20138.3</td><td>6.4\u20138.0</td><td>7.8\u201310.0</td><td>8.8\u201310.3</td><td>7.7\u20139.0</td><td>8.6\u201311.2</td><td>6.9\u20139.6</td><td>9.3\u201311.4</td><td>10.7\u201314.2</td><td>10.0\u201313.0</td><td>10.8\u201315.0</td><td>9.2\u201313.6</td><td>10.6\u201313.5</td><td>9.9\u201312.7</td></tr></tbody></table>"
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "MP, Middle Pleistocene and LP, Late Pleistocene."
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s2-1", 
+                        "title": "Cranium, mandible, and dentition (DH1, DH2, DH3, DH4, DH5, U.W. 101-377)", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The cranium of <i>H. naledi</i> does not have the well-developed crest patterns that characterize <i>Australopithecus garhi</i> (<a href=\"#bib5\">Asfaw et al., 1999</a>) and species of the genus <i>Paranthropus</i>, nor the derived facial morphology seen in the latter genus. The mandible of <i>H. naledi</i> is notably more gracile than those of <i>Paranthropus</i>. Although maxillary and mandibular incisors and canines of <i>H. naledi</i> overlap in size with those of <i>Paranthropus</i>, the post-canine teeth are notably smaller than those of <i>Paranthropus</i> and <i>Au. garhi</i>, with mandibular molars that are buccolingually narrow."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "<i>H. naledi</i> differs from <i>Australopithecus afarensis</i> and <i>Australopithecus africanus</i> in having a pentagonal-shaped cranial vault in posterior view, sagittal keeling, widely spaced temporal lines, an angular torus, a deep and narrow digastric fossa, an external occipital protuberance, an anteriorly positioned root of the zygomatic process of the maxilla, a broad palate, and a small canine jugum lacking anterior pillars. The anterior and lateral vault of <i>H. naledi</i> differs from <i>Au. afarensis</i> and <i>Au. africanus</i> in exhibiting only slight post-orbital constriction, frontal bossing, a well-developed supraorbital torus with a well-defined supratoral sulcus, temporal lines that are positioned on the posterior rather than the superior aspect of the supraorbital torus, a root of the zygomatic process of the temporal that is angled downwards approximately 30\u00b0 relative to the Frankfort Horizontal (FH) and which begins its lateral expansion above the mandibular fossa rather than the EAM, a mandibular fossa that is positioned medial to the wall of the temporal squame, a small postglenoid process that contacts the tympanic, a coronally oriented petrous, and a small and obliquely oriented EAM. The <i>H. naledi</i> mandible exhibits a more gracile symphysis and corpus, a more vertically inclined symphysis, a slight mandibular incurvation delineating a faint mental trigon, and a steeply inclined posterior face of the mandibular symphysis without a post incisive planum. The incisors of <i>H. naledi</i> overlap in size with some specimens of <i>Au. africanus</i>, though the canines and post-canine dentition are notably smaller, with relatively narrow buccolingual dimensions of the mandibular molars. The maxillary I<sup>1</sup> lacks a median lingual ridge and exhibits a broad and uninflated lingual cervical prominence, the lingual mesial and distal marginal ridges do not merge onto the cervical prominence in the maxillary I<sup>2</sup>, the mandibular canine exhibits only a weak lingual median ridge and a broad and uninflated lingual cervical prominence, and the buccal grooves on the maxillary premolars are only weakly developed. <i>H. naledi</i> exhibits a small and isolated Carabelli's feature in the maxillary molars, unlike the more prominent and extensive Carabelli's feature of <i>Australopithecus</i>. Moreover, the <i>H. naledi</i> mandibular molars possess small, mesiobuccally restricted protostylids that do not intersect the buccal groove, differing from the typically enlarged, centrally positioned protostylids that intersect the buccal groove in <i>Australopithecus</i>."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The cranium of <i>H. naledi</i> differs from <i>Australopithecus sediba</i> (<a href=\"#bib6\">Berger et al., 2010</a>) in exhibiting sagittal keeling, a more pronounced supraorbital torus and supratoral sulcus, a weakly arched supraorbital contour with rounded lateral corners, an angular torus, a well-defined supramastoid crest, a curved superior margin of the temporal squama, a root of the zygomatic process of the temporal that is angled downwards approximately 30\u00b0 relative to FH, a flattened nasoalveolar clivus, weak canine juga, an anteriorly positioned root of the zygomatic process of the maxilla, and a relatively broad palate that is anteriorly shallow. The <i>H. naledi</i> mandible (DH1) has a mental foramen positioned superiorly on the corpus that opens posteriorly, unlike the mid-corpus height, more laterally opening mental foramen of <i>Au. sediba</i>. The maxillary and mandibular teeth of <i>H. naledi</i> are smaller than those of <i>Au. sediba</i>, with mandibular molars that are buccolingually narrow. The lingual mesial and distal marginal ridges do not merge onto the cervical prominence in the maxillary I<sup>2</sup>, the paracone of the maxillary P<sup>3</sup> is equal in size to the protocone, the protoconid and metaconid of the mandibular molars are equally mesially positioned, and the lingual cusps of the molars are positioned at the occlusobuccal margin while the buccal cusps are positioned slightly lingual to the occlusobuccal margin. Also, <i>Au. sediba</i> shares with other australopiths a protostylid that is centrally located and which intersects the buccal groove of the lower molars, unlike the small and mesiobuccally restricted protostylid that does not intersect the buccal groove in <i>H. naledi</i>."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The cranium of <i>H. naledi</i> differs from <i>Homo habilis</i> in exhibiting sagittal keeling, a weakly arched supraorbital contour, temporal lines that are positioned on the posterior rather than the superior aspect of the supraorbital torus, an angular torus, an occipital torus, only slight post-orbital constriction, a curved superior margin of the temporal squama, a suprameatal spine, a weak crista petrosa, a prominent Eustachian process, a small EAM, weak canine juga, and an anteriorly positioned root of the zygomatic process of the maxilla. Mandibles attributed to <i>H. habilis</i> show a weakly inclined, shelf-like post incisive planum with a variably developed superior transverse torus, unlike the steeply inclined posterior face of the mandibular symphysis of <i>H. naledi</i>, which lacks both a post incisive planum or superior transverse torus. The <i>H. naledi</i> mandible (DH1) has a mental foramen positioned superiorly on the corpus that opens posteriorly, while the mental foramen of <i>H. habilis</i> is at mid-corpus height and opens more laterally. The maxillary and mandibular dentitions of DH1 are smaller than typical for <i>H. habilis</i>. The mandibular P<sub>3</sub> of <i>H. naledi</i> is more molarized and lacks the occlusal simplification seen in <i>H. habilis</i>; it has a symmetrical occlusal outline, and multiple roots (two roots: mesiobuccal and distal) not seen in <i>H. habilis</i>. The molars of <i>H. naledi</i> lack crenulation, secondary fissures, and supernumerary cusps that are common to <i>H. habilis</i>. The protoconid and metaconid of the mandibular molars are equally mesially positioned."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The cranium of <i>H. naledi</i> differs from <i>Homo rudolfensis</i> by its smaller cranial capacity, and by exhibiting frontal bossing, a post-bregmatic depression, sagittal keeling, a well-developed supraorbital torus delineated by a distinct supratoral sulcus, temporal lines that are positioned on the posterior rather than the superior aspect of the supraorbital torus, an occipital torus, an external occipital protuberance, only slight post-orbital constriction, a small postglenoid process, a weak crista petrosa, a laterally inflated mastoid process, a canine fossa, incisors that project anteriorly beyond the bi-canine line, and a shallow anterior palate. As in <i>H. habilis</i>, mandibles attributed to <i>H. rudolfensis</i> show a weakly inclined, shelf-like post incisive planum with a variably developed superior transverse torus, unlike the steeply inclined posterior face of the mandibular symphysis of DH1, the latter of which lacks either a post incisive planum or superior transverse torus. The mandibular symphysis and corpus of <i>H. naledi</i> are more gracile than those attributed to <i>H. rudolfensis</i>, and the <i>H. naledi</i> mandible (DH1) has a mental foramen positioned superiorly on the corpus that opens posteriorly, unlike the mid-corpus height, more laterally opening mental foramen of <i>H. rudolfensis</i>. The maxillary and mandibular dentition of <i>H. naledi</i> is smaller than that of most specimens of <i>H. rudolfensis</i>, with only KNM-ER 60000 and KNM-ER 62000 appearing similar in size for some teeth (<a href=\"#bib41\">Leakey et al., 2012</a>). The molars of <i>H. naledi</i> lack crenulation, secondary fissures, or supernumerary cusps common in <i>H. rudolfensis</i>. The buccal grooves of the maxillary premolars are weak in <i>H. naledi</i>, and the protoconid and metaconid of the mandibular molars are equally mesially positioned."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "<i>H. naledi</i> lacks the typically distinctive long and low cranial vault of <i>Homo erectus</i>, as well as the metopic keeling that is typically present in the latter species. <i>H. naledi</i> also differs from <i>H. erectus</i> in having a distinct external occipital protuberance in addition to the tuberculum linearum, a laterally inflated mastoid process, a flat and squared nasoalveolar clivus, and an anteriorly shallow palate. The parasagittal keeling that is present between bregma and lambda in <i>H. naledi</i> (DH1 and DH3) is less marked than often occurs in <i>H. erectus</i>, including in small specimens such as KNM-ER 42700 and the Dmanisi cranial sample. Also unlike most specimens of <i>H. erectus</i>, <i>H. naledi</i> has a small vaginal process, a weak crista petrosa, a marked Eustachian process, and a small EAM. The mandible of <i>H. erectus</i> shows a moderately inclined, shelf-like post incisive planum terminating in a variably developed superior transverse torus, differing from the steeply inclined posterior face of the <i>H. naledi</i> mandibular symphysis, which lacks both a post incisive planum or a superior transverse torus. The mental foramen is positioned superiorly and opens posteriorly in DH1, unlike the mid-corpus height, more laterally opening mental foramen of <i>H. erectus</i>. The maxillary and mandibular incisors and canines of <i>H. naledi</i> are smaller than typical of <i>H. erectus</i>. The mandibular P<sub>3</sub> of <i>H. naledi</i> is more molarized and lacks the occlusal simplification seen in <i>H. erectus</i>, they reveal a symmetrical occlusal outline, and multiple roots (2R: MB+D) not typically seen in <i>H. erectus</i>. Furthermore, the molars of <i>H. naledi</i> lack crenulation, secondary fissures, or supernumerary cusps common in <i>H. erectus</i>."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "<i>H. naledi</i> lacks the reduced cranial height of <i>Homo floresiensis</i>, and displays a marked angular torus and parasagittal keeling between bregma and lambda that is absent in the latter species. <i>H. naledi</i> further has a flat and squared nasoalveolar clivus, unlike the pronounced maxillary canine juga and prominent pillars of <i>H. floresiensis</i>. The mandible of <i>H. floresiensis</i> shows a posteriorly inclined post incisive planum with superior and inferior transverse tori, differing from the steeply inclined posterior face of the <i>H. naledi</i> mandibular symphysis, which lacks both a post incisive planum or a superior transverse torus. Dentally, <i>H. naledi</i> is distinguishable from <i>H. floresiensis</i> by the mesiodistal elongation and extensive talonid of the mandibular P<sub>4</sub>, and the lack of Tomes' root on the mandibular premolars. The molar size gradient of <i>H. naledi</i> follows the M1 &lt; M2 &lt; M3 pattern, unlike the M3 &lt; M2 &lt; M1 pattern in <i>H. floresiensis</i>, and the mandibular molars are relatively mesiodistally long and buccolingually narrow compared to those of <i>H. floresiensis</i>."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "<i>H. naledi</i> differs from Middle Pleistocene (MP) and Late Pleistocene (LP) <i>Homo</i> (here we include specimens sometimes attributed to the putative Early Pleistocene taxon <i>Homo antecessor</i>, and MP <i>Homo heidelbergensis</i>, <i>Homo rhodesiensis</i>, as well as archaic <i>Homo sapiens</i> and Neandertals) in exhibiting a smaller cranial capacity. <i>H. naledi</i> has its maximum cranial width in the supramastoid region, rather than in the parietal region. It has a clearly defined canine fossa (similar to <i>H. antecessor</i>), a shallow anterior palate, and a flat and a squared nasoalveolar clivus. <i>H. naledi</i> lacks the bilaterally arched and vertically thickened supraorbital tori found in MP and LP <i>Homo</i>. <i>H. naledi</i> also differs in exhibiting a root of the zygomatic process of the temporal that is angled downwards approximately 30\u00b0 relative to FH, a projecting entoglenoid process, a weak vaginal process, a weak crista petrosa, a prominent Eustachian process, a laterally inflated mastoid process, and a small EAM. The <i>H. naledi</i> mandible tends to be more gracile than specimens of MP <i>Homo</i>. The mandibular canine retains a distinct accessory distal cuspulid not seen in MP and LP <i>Homo</i>. Molar cuspal proportions for <i>H. naledi</i> do not show the derived reduction of the entoconid and hypoconid that characterizes MP and LP <i>Homo</i>. The mandibular M<sub>3</sub> is not reduced in DH1, thus revealing an increasing molar size gradient that contrasts with reduction of the M<sub>3</sub> in MP and LP <i>Homo</i>."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "<i>H. naledi</i> differs from <i>H. sapiens</i> in exhibiting small cranial capacity, a well-defined supraorbital torus and supratoral sulcus, a root of the zygomatic process of the temporal that is angled downwards approximately 30\u00b0 relative to FH, a large and laterally inflated mastoid with well-developed supramastoid crest, an angular torus, a small vaginal process, a weak crista petrosa, a prominent Eustachian process, a small EAM, a flat and squared nasoalveolar clivus, and a more posteriorly positioned incisive foramen. The <i>H. naledi</i> mandible shows a weaker, less well-defined mentum osseum than <i>H. sapiens</i>, as well as a slight inferior transverse torus that is absent in humans. The mental foramen is positioned superiorly in <i>H. naledi</i>, unlike the mid-corpus height mental foramen of <i>H. sapiens</i>. The mandibular canine possesses a distinct accessory distal cuspulid not seen in <i>H. sapiens</i>. Molar cuspal proportions for <i>H. naledi</i> do not show the derived reduction of the entoconid and hypoconid that characterizes <i>H. sapiens</i>. The mandibular M<sub>3</sub> is not reduced in <i>H. naledi</i>, thus revealing an increasing molar size gradient that contrasts with reduction of the M<sub>3</sub> in <i>H. sapiens</i>."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s2-2", 
+                        "title": "Hand (H1)", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "<i>H. naledi</i> possesses a combination of primitive and derived features not seen in the hand of any other hominin. H1 is differentiated from the estimated intrinsic hand proportions of <i>Au. afarensis</i> in having a relatively long thumb ((Mc1 + PP1)/(Mc3 + PP3 + IP3)) (<a href=\"#bib50\">Rolian and Gordon, 2013</a>; <a href=\"#bib2\">Alm\u00e9cija and Alba, 2014</a>). It is further distinguished from <i>Au. afarensis</i>, <i>Au. africanus,</i> and <i>Au. sediba</i> in having a well-developed crest for both the <i>opponens pollicis</i> and first dorsal <i>interosseous</i> muscles, a trapezium-scaphoid joint that extends onto the scaphoid tubercle, a relatively large and more palmarly-positioned capitate-trapezoid joint, and/or a saddle-shaped Mc5-hamate joint. <i>H. naledi</i> also differs from <i>Au. sediba</i> in that it lacks mediolaterally narrow Mc2-5 shafts (<a href=\"#bib39\">Kivell et al., 2011</a>). Manual morphology of <i>Au. garhi</i> is currently unknown."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "H1 is distinguished from <i>H. habilis</i> in having a deep proximal palmar fossa with a well-developed ridge distally for the insertion of the <i>flexor pollicis longus</i> muscle on the first distal phalanx, and a more proximodistally oriented trapezium-second metacarpal joint. It also differs from both <i>H. habilis</i> and <i>H. floresiensis</i> by having a relatively large trapezium-scaphoid joint that extends onto the scaphoid tubercle, and from <i>H. floresiensis</i> in having a boot-shaped trapezoid with an expanded palmar surface, and a relatively large and more palmarly-positioned capitate-trapezoid joint (<a href=\"#bib65\">Tocheri et al., 2005</a>, <a href=\"#bib64\">2007</a>; <a href=\"#bib47\">Orr et al., 2013</a>)."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "H1 is dissimilar to hand remains attributed to <i>Paranthropus robustus</i>/early <i>Homo</i> from Swartkrans (<a href=\"#bib57\">Susman, 1988</a>; <a href=\"#bib58\">Susman et al., 2001</a>) in having a relatively small Mc1 base and proximal articular facet, a saddle-shaped Mc5-hamate joint, and more curved proximal and intermediate phalanges of ray 2\u20135."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "Manual morphology of <i>H. rudolfensis</i> is currently unknown, and that of <i>H. erectus</i> is largely unknown. Still, H1 differs from a third metacarpal attributed to <i>H. erectus s. l.</i>, as well as from <i>Homo neanderthalensis</i> and <i>H. sapiens</i> by lacking a styloid process (<a href=\"#bib68\">Ward et al., 2013</a>)."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "H1 is further distinguished from <i>H. neanderthalensis</i> and <i>H. sapiens</i> by its relatively small facets for the Mc1 and scaphoid on the trapezium, its low angle between the Mc2 and Mc3 facets on the capitate, and by its long and curved proximal and intermediate phalanges on rays 2\u20135."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "H1 is differentiated from all known hominins in having a Mc1 that combines a mediolaterally narrow proximal end and articular facet with a mediolaterally wide distal shaft and head, a dorsopalmarly flat and strongly asymmetric (with an enlarged palmar-lateral protuberance) Mc1 head, and the combination of an overall later <i>Homo</i>-like carpal morphology combined with proximal and intermediate phalanges that are more curved than most australopiths. H1 also differs from all other known hominins except <i>H. neanderthalensis</i> in having non-pollical distal phalanges with mediolaterally broad apical tufts (relative to length)."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s2-3", 
+                        "title": "Femur (U.W. 101-1391)", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The femur of <i>H. naledi</i> differs from those of all other known hominins in its possession of two well-defined, mediolaterally-running pillars in the femoral neck. The pillars run along the superoanterior and inferoposterior margins of the neck and define a distinct sulcus along its superior aspect."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s2-4", 
+                        "title": "Tibia (U.W. 101-484)", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The tibia of <i>H. naledi</i> differs from those of all other known hominins in its possession of a distinct tubercle for the pes anserinus tendon. The tibia differs from other hominins except <i>H. habilis, H. floresiensis</i>, and (variably) <i>H. sapiens</i> in its possession of a rounded anterior border."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s2-5", 
+                        "title": "Foot (F1)", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The foot of <i>H. naledi</i> differs from the pedal remains of <i>Au. afarensis, Au. africanus,</i> and <i>Au. sediba</i> in having a calcaneus with a weakly developed peroneal trochlea. F1 also differs from <i>Au. afarensis</i> in having a higher orientation of the calcaneal sustentaculum tali. F1 can be further distinguished from pedal remains attributed to <i>Au. africanus</i> in having a higher talar head and neck torsion, a narrower Mt1 base, a dorsally expanded Mt1 head, and greater proximolateral to distomedial orientation of the lateral metatarsals. The <i>H. naledi</i> foot can be further differentiated from the foot of <i>Au. sediba</i> in having a proximodistally flatter talar trochlea, a flat subtalar joint, a diagonally oriented retrotrochlear eminence and a plantar position of the lateral plantar process of the calcaneous, and dorsoplantarly flat articular surface for the cuboid on the Mt4 (<a href=\"#bib72\">Zipfel et al., 2011</a>). Pedal remains of <i>Au. garhi</i> are currently unknown, and those of <i>P. robustus</i> are too poorly known to allow for comparison."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The <i>H. naledi</i> foot can be distinguished from the foot of <i>H. habilis</i> by the presence of a flatter, non-sloping trochlea with equally elevated medial and lateral margins, a narrower Mt1 base, greater proximolateral to distomedial orientation of the lateral metatarsals, and a metatarsal robusticity ratio of 1 &gt; 5 &gt; 4 &gt; 3 &gt; 2. Pedal morphology in <i>H. rudolfensis</i> is currently unknown, and that of <i>H. erectus</i> is too poorly known to allow for comparison. The <i>H. naledi</i> foot can be distinguished from the foot of <i>H. floresiensis</i> by a longer hallux and shorter second through fifth metacarpals relative to hindfoot length, and higher torsion of the talar head and neck."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The foot of <i>H. naledi</i> can be distinguished from the foot of <i>H. sapiens</i> only by its flatter lateral and medial malleolar facets on the talus, its low angle of plantar declination of the talar head, its lower orientation of the calcaneal sustentaculum tali, and its gracile calcaneal tuber."
+                            }
+                        ]
+                    }
+                ]
+            }, 
+            {
+                "type": "section", 
+                "id": "s3", 
+                "title": "Description", 
+                "content": [
+                    {
+                        "type": "paragraph", 
+                        "text": "<i>H. naledi</i> exhibits anatomical features shared with <i>Australopithecus</i>, other features shared with <i>Homo</i>, with several features not otherwise known in any hominin species. This anatomical mosaic is reflected in different regions of the skeleton. The morphology of the cranium, mandible, and dentition is mostly consistent with the genus <i>Homo</i>, but the brain size of <i>H. naledi</i> is within the range of <i>Australopithecus</i>. The lower limb is largely <i>Homo</i>-like, and the foot and ankle are particularly human in their configuration, but the pelvis appears to be flared markedly like that of <i>Au. afarensis</i>. The wrists, fingertips, and proportions of the fingers are shared mainly with <i>Homo</i>, but the proximal and intermediate manual phalanges are markedly curved, even to a greater degree than in any <i>Australopithecus</i>. The shoulders are configured largely like those of australopiths. The vertebrae are most similar to Pleistocene members of the genus <i>Homo</i>, whereas the ribcage is wide distally like <i>Au. afarensis</i>."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "<i>H. naledi</i> has a range of body mass similar to small-bodied modern human populations, and is similar in estimated stature to both small-bodied humans and the largest known australopiths. We estimated body mass from eight femoral specimens for which subtrochanteric diameters can be measured (\u2018Materials and methods\u2019), with results ranging between 39.7 kg and 55.8 kg (<a href=\"#tbl3\">Table 3</a>). No femur specimen is sufficiently complete to measure femur length accurately, but the U.W. 101-484 tibia preserves nearly its complete length, allowing a tibia length estimate of 325 mm (<a href=\"#fig10\">Figure 10</a>). Estimates for the stature of this individual based on African human population samples range between 144.5 and 147.8 mm. Again, this stature estimate is similar to small-bodied modern human populations. It is within the range estimated for Dmanisi postcranial elements (<a href=\"#bib43\">Lordkipanidze et al., 2007</a>), and slightly smaller than estimated for early <i>Homo</i> femoral specimens KNM-ER 1472 and KNM-ER 1481. Some large australopiths also had long tibiae and presumably comparably tall statures, as evidenced by the KSD-VP 1/1 skeleton from Woranso-Mille (<a href=\"#bib27\">Haile-Selassie et al., 2010</a>)."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "table", 
+                                "doi": "10.7554/eLife.09560.014", 
+                                "id": "tbl3", 
+                                "label": "Table 3", 
+                                "title": "Dinaledi body mass estimates from femur specimens preserving subtrochanteric diameters", 
+                                "tables": [
+                                    "<table><thead><tr><th>Specimen ID</th><th>Side</th><th>AP subtrochanteric breadth</th><th>ML subtrochanteric breadth</th><th>Mass (a)</th><th>Mass (b)</th></tr></thead><tbody><tr><td>U.W. 101-002</td><td>R</td><td>18.5</td><td>23.6</td><td>40.0</td><td>44.7</td></tr><tr><td>U.W. 101-003</td><td>R</td><td>21.6</td><td>31.4</td><td>54.5</td><td>55.8</td></tr><tr><td>U.W. 101-018</td><td>R</td><td>18.1</td><td>23.8</td><td>39.7</td><td>44.4</td></tr><tr><td>U.W. 101-226</td><td>L</td><td>19.1</td><td>24.0</td><td>41.3</td><td>45.7</td></tr><tr><td>U.W. 101-1136</td><td>R</td><td>16.9</td><td>25.5</td><td>39.7</td><td>44.4</td></tr><tr><td>U.W. 101-1391</td><td>R</td><td>18.8</td><td>23.9</td><td>40.8</td><td>45.3</td></tr><tr><td>U.W. 101-1475</td><td>L</td><td>18.8</td><td>29.0</td><td>46.5</td><td>49.7</td></tr><tr><td>U.W. 101-1482</td><td>L</td><td>20.7</td><td>28.9</td><td>49.7</td><td>52.1</td></tr></tbody></table>"
+                                ], 
+                                "footnotes": [
+                                    {
+                                        "text": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "Regression equations described in \u2018Materials and methods\u2019. Mass (a) based on forensic statures from European individuals. Mass (b) based on multiple population sample. The two estimates diverge somewhat for smaller femora."
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "doi": "10.7554/eLife.09560.015", 
+                                "id": "fig10", 
+                                "label": "Figure 10", 
+                                "title": "Maximum tibia length in <i>H. naledi</i> and other hominins.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Maximum tibia length for U.W. 101-484, compared to other nearly complete hominin tibia specimens. <i>Australopithecus afarensis</i> represented by A.L. 288-1 and KSD-VP-1/1 (<a href=\"#bib27\">Haile-Selassie et al., 2010</a>); <i>Homo erectus</i> represented by D3901 from Dmanisi and KNM-WT 15000; <i>Homo habilis</i> by OH 35; <i>Homo floresiensis</i> by LB1 and LB8 (<a href=\"#bib10\">Brown et al., 2004</a>; <a href=\"#bib46\">Morwood et al., 2005</a>). Chimpanzee and contemporary European ancestry humans from Cleveland Museum of Natural History (<a href=\"#bib42\">Lee, 2001</a>); Andaman Islanders from <a href=\"#bib56\">Stock (2013)</a>. Vertical lines represent sample ranges; bars represent 1 standard deviation."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig10-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-09560-fig10-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig10-v1.tif", 
+                                    "size": {
+                                        "width": 2750, 
+                                        "height": 2085
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The endocranial volume of all <i>H. naledi</i> specimens is clearly small compared to most known examples of <i>Homo</i>. We combined information from the most complete cranial vault specimens to arrive at an estimate of endocranial volume for both larger (presumably male) and smaller (presumably female) individuals (larger composite depicted in <a href=\"#fig11\">Figure 11</a>). The resulting estimates of approximately 560cc and 465cc, respectively, overlap entirely with the range of endocranial volumes known for australopiths. Within the genus <i>Homo</i>, only the smallest specimens of <i>H. habilis,</i> one single <i>H. erectus</i> specimen, and <i>H. floresiensis</i> overlap with these values."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "doi": "10.7554/eLife.09560.016", 
+                                "id": "fig11", 
+                                "label": "Figure 11", 
+                                "title": "Virtual reconstruction of the endocranium of the larger composite cranium from DH1 and DH2 overlaid with the ectocranial surfaces.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "(<b>A</b>) Lateral view. (<b>B</b>) Superior view. The resulting estimate of endocranial volume is 560cc. Scale bar = 10 cm."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig11-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-09560-fig11-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig11-v1.tif", 
+                                    "size": {
+                                        "width": 2750, 
+                                        "height": 1108
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Despite its small vault size, the cranium of <i>H. naledi</i> is structurally similar to those of early <i>Homo</i>. Frontal bossing is evident, as is a marked degree of parietal bossing. There is no indication of metopic keeling, though there is slight parasagittal keeling between bregma and lambda, and some prelambdoidal flattening. The cranial vault bones are generally thin, becoming somewhat thicker in the occipital region. The supraorbital torus is well developed, though weakly arched, and is bounded posteriorly by a well-developed supratoral sulcus. The lateral corners of the supraorbital torus are rounded and relatively thin. The temporal lines are widely spaced, and there is no indication of a sagittal crest or temporal/nuchal cresting. The temporal crest is positioned on the posterior aspect of the lateral supraorbital torus, rather than on the superior aspect as in australopiths. At the posteroinferior extent of the temporal lines, they curve anteroinferiorly presenting a well-developed angular torus. The crania have a pentagonal outline in posterior view, with the greatest vault breadth located in the supramastoid region. The nuchal region exhibits sexually dimorphic development of nuchal muscle markings and the external occipital protuberance, and there is a clear indication of a tuberculum linearum in addition to the external occipital protuberance. In superior view the vault tapers from posterior to anterior, though post-orbital constriction is slight. The squamosal suture is low and gently curved, and parietal striae are well defined. The lateral margins of the orbits face laterally. A small zygomaticofacial foramen is typically present near the center of the zygomatic bone. The root of the zygomatic process of the maxilla is anteriorly positioned, at the level of the P<sup>3</sup> or the P<sup>4</sup>. There is no indication of a zygomatic prominence, and the zygomatic arches do not flare laterally to any extent. The root of the zygomatic process of the temporal is angled downwards approximately 30\u00b0 relative to FH. The root of the zygomatic process of the temporal begins to laterally expand above the level of the mandibular fossa, rather than above the level of the EAM as in australopiths. The mandibular fossa is somewhat large, and moderately deep. The articular eminence of the mandibular fossa is saddle-shaped, and oriented posteroinferiorly. Almost the entire mandibular fossa is positioned medial to the temporal squama. The entoglenoid process is elongated and faces primarily laterally. The postglenoid process is small and closely appressed to the tympanic, forming part of the posterior wall of the fossa. The petrotympanic is distinctly coronally oriented. The vaginal process is small but distinct. The crista petrosa is weakly developed and not notably sharpened. There is a strong Eustachian process. The external auditory meatus is small, oval-shaped, and obliquely oriented, and a distinct suprameatal spine is present. The mastoid region is slightly laterally inflated. The mastoid process is triangular in cross-section, with a rounded apex and a mastoid crest. The digastric groove is deep and narrow, alongside a marked juxtamastoid eminence. The canine juga are weakly developed and there is no indication that anterior pillars would have been present. A shallow, ill-defined canine fossa is indicated. The nasoalveolar clivus is flat and square-shaped. The parabolic-shaped palate is broad and anteriorly shallow, becoming deeper posteriorly."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The mandibular dentition of <i>H. naledi</i> is arranged in a parabolic arch. The alveolar and basal margins of the corpus diverge slightly. A single, posteriorly opening mental foramen is positioned slightly above the mid-corpus level, between the position of the P<sub>3</sub> and the P<sub>4</sub>. The mandibular corpus is relatively gracile, with a well-developed lateral prominence whose maximum extent is typically at the M<sub>2</sub>. A slight supreme lateral torus (of Dart) weakly delineates the extramolar sulcus from the lateral corpus. The superior lateral torus is moderately developed, running anteriorly to the mental foramen where it turns up to reach the P<sub>3</sub> jugum. The marginal torus is moderately developed, and defines a moderate intertoral sulcus. The posterior and anterior marginal tubercles are indicated only as slight roughenings of bone. The gracile mandibular symphysis is vertically oriented. A well-developed mental protuberance and weak lateral tubercles are delineated by a slight mandibular incisure, thereby presenting a weak mentum osseum. The post-incisive planum is steeply inclined and not-shelf-like. There is no superior transverse torus, while a weak, basally oriented inferior transverse torus is present. The anterior and posterior subalveolar fossae are continuous and deep, overhung by a well-developed alveolar prominence. The extramolar sulcus is moderately wide. The root of the ramus of the mandible originates high on the corpus at the level of the M<sub>2</sub>. Strong ectoangular tuberosities are indicated. A large mandibular foramen is present, with a diffusely defined mylohyoid groove."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Like the skull, the dentition of <i>H. naledi</i> compares most favorably to early <i>Homo</i> samples. Yet compared to samples of <i>H. habilis</i>, <i>H. rudolfensis</i>, and <i>H. erectus</i>, the teeth of <i>H. naledi</i> are comparatively quite small, similar in dimensions to much later samples of <i>Homo</i>. With both small post-canine teeth and a small endocranial volume, <i>H. naledi</i> joins <i>Au. sediba</i> and <i>H. floresiensis</i> in an area distinct from the general hominin relation of smaller post-canine teeth in species with larger brains (<a href=\"#fig12\">Figure 12</a>)."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "doi": "10.7554/eLife.09560.017", 
+                                "id": "fig12", 
+                                "label": "Figure 12", 
+                                "title": "Brain size and tooth size in hominins.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The buccolingual breadth of the first maxillary molar is shown here in comparison to endocranial volume for many hominin species. <i>H. naledi</i> occupies a position with relatively small molar size (comparable to later <i>Homo</i>) and relatively small endocranial volume (comparable to australopiths). The range of variation within the Dinaledi sample is also fairly small, in particular in comparison to the extensive range of variation within the <i>H. erectus sensu lato</i>. Vertical lines represent the range of endocranial volume estimates known for each taxon; each vertical line meets the horizontal line representing M<sup>1</sup> BL diameter at the mean for each taxon. Ranges are illustrated here instead of data points because the ranges of endocranial volume in several species are established by specimens that do not preserve first maxillary molars."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig12-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-09560-fig12-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig12-v1.tif", 
+                                    "size": {
+                                        "width": 2750, 
+                                        "height": 2040
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "In comparison to <i>H. habilis</i>, <i>H. rudolfensis</i>, and <i>H. erectus</i>, the teeth of <i>H. naledi</i> are not only small, but also markedly simple in crown morphology. Maxillary and mandibular molars lack extensive crenulation, secondary fissures and supernumerary cusps. The M<sup>1</sup> has an equal-sized metacone and paracone, and has a slight expression of Carabelli's trait represented by a small cusp or shallow pit. I<sup>1</sup> exhibits slight occlusal curvature with trace marginal ridges and variably small <i>tuberculum dentale</i>. I<sup>2</sup> exhibits greater occlusal curvature and <i>tuberculum dentale</i> expression but neither upper incisor has double shovelling or interruption groove. The mandibular canines of <i>H. naledi</i> have a small occlusal area, and have a distal marginal cuspule as a topographically distinct expression of the cingular margin. The P<sub>3</sub> is double-rooted, fully bicuspid with metaconid and protoconid of approximately equal height and occlusal area separated by a distinct longitudinal groove, has a distally extensive talonid, and an occlusal outline approximately symmetrical with respect to the mesiodistal axis. P<sub>4</sub> likewise has a distally extensive talonid and approximately symmetrical occlusal outline (<a href=\"#fig5\">Figure 5</a>). M<sub>1</sub> and M<sub>2</sub> lack cusp 6 and cusp 7, except for very slight expression in a small fraction of specimens, and have a very faint subvertical depression rather than a distinct or extensive protostylid. Like australopiths and some early <i>Homo</i> specimens, <i>H. naledi</i> has an increasing molar size gradient in the mandibular dentition (M1 &lt; M2 &lt; M3)."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The lower limb of <i>H. naledi</i> is defined not only by a unique combination of primitive and derived traits, but also by the presence of unique features in the femur and tibia. Like all other bipedal hominins, <i>H. naledi</i> possesses a valgus knee and varus ankle. The femoral neck is long, anteverted, and anteroposteriorly compressed. Muscle insertions for the <i>M. gluteus maximus</i> are strong and the femur has a well-marked linea aspera with pilaster variably present. The patella is relatively anteroposteriorly thick. The tibia is mediolaterally compressed with a rounded anterior border, a large proximal attachment for the <i>M. tibialis posterior</i>, and a thin medial malleolus. The fibula is gracile with laterally oriented lateral malleolus, a relatively circular neck and a convex surface for the proximal attachment of the <i>M. peroneus longus</i>. Unique features in the lower limb of <i>H. naledi</i> include a depression in the superior aspect of the femoral neck that results in two mediolaterally oriented pillars inferoposteriorly and superoanteriorly, and a strong distal attachment of the pes anserinus on the tibia."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The foot and ankle of <i>H. naledi</i> are largely humanlike (<a href=\"#fig9\">Figure 9</a>). The tibia stands orthogonally upon the talus, which is moderately wedged, with a mediolaterally flat trochlea having medial and lateral margins at even height, a form distinct from the strong keeling seen in OH 8 (<i>H. habilis</i>) and several tali from Koobi Fora. The talar head and neck exhibit strong, humanlike torsion; the horizontal angle is higher than in most humans, similar to that found in australopiths. The calcaneus is only moderately robust, but possesses the plantar declination of the retrotrochlear eminence and plantarly positioned lateral plantar process found in both modern humans and <i>Au. afarensis</i>. The peroneal trochlea is small, unlike that found in australopiths and similar only to that in <i>H. sapiens</i> and Neanderthals. The talonavicular, subtalar joints and calcaneocuboid joints are humanlike in possessing minimal ranges of motion and evidence for a locking, rigid midfoot. The intermediate and lateral cuneiforms are proximodistally elongated. The hallucal tarsometatarsal joint is flat and proximodistally aligned indicating that <i>H. naledi</i> possessed an adducted, non-grasping hallux. The head of the first metatarsal is mediolaterally expanded dorsally, indicative of a humanlike windlass mechanism. The foot possesses humanlike metatarsal lengths, head proportions, and torsion."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The phalanges are moderately curved, slightly more so than in <i>H. sapiens</i>. The only primitive anatomies found in the foot of <i>H. naledi</i> are the talar head and neck declination and sustentaculum tali angles, suggestive of a lower arched foot with a more plantarly positioned and horizontally inclined medial column than typically found in modern humans (<a href=\"#bib28\">Harcourt-Smith et al., 2015</a>)."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The axial skeleton presents a combination of derived (mainly aspects of the vertebrae) and seemingly primitive (mainly the ribs) traits. The preserved adult T10 and T11 vertebrae are proportioned similarly to Pleistocene <i>Homo</i>, with transverse process morphology most similar to Neandertals. The neural canals of these vertebrae are large in comparison to the diminutive overall size of the vertebrae, proportionally recalling Dmanisi <i>H. erectus</i>, Neandertals, and modern humans. The 11th rib is straight (uncurved), similar to <i>Au. afarensis</i>, and the shape of the upper rib cage appears narrow, as assessed from first and second rib fragments, suggesting that the thorax was pyramidal in shape. The 12th rib presents a robust shaft cross-section most similar to Neandertals. This combination is not found in other hominins and might reflect allometric scaling at a small trunk size."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The Dinaledi iliac blade is flared and shortened anteroposteriorly, resembling <i>Au. afarensis</i> or <i>Au. africanus.</i> The ischium is short with a narrow tuberoacetabular sulcus, and the ischiopubic and iliopubic rami are thick, resembling <i>Au. sediba</i> and <i>H. erectus</i>. This combination of iliac and ischiopubic features has not been found in other fossil hominins (<a href=\"#fig13\">Figure 13</a>)."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "doi": "10.7554/eLife.09560.018", 
+                                "id": "fig13", 
+                                "label": "Figure 13", 
+                                "title": "Selected pelvic specimens of <i>H. naledi</i>.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "U.W. 101-1100 ilium in (<b>A</b>) lateral view showing a weak iliac pillar relatively near the anterior edge of the ilium, with no cristal tubercle development; (<b>B</b>) anterior view, angled to demonstrate the degree of flare, which is clear in comparison to the subarcuate surface. U.W. 101-723 immature sacrum in (<b>C</b>) anterior view; and (<b>D</b>) superior view. U.W. 101-1112 ischium in (<b>E</b>) lateral view; and (<b>F</b>) anterior view, demonstrating relatively short tuberacetabular diameter. Scale bar = 2 cm."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig13-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-09560-fig13-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig13-v1.tif", 
+                                    "size": {
+                                        "width": 1415, 
+                                        "height": 1388
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The shoulder of <i>H. naledi</i> is configured with the scapula situated high and lateral on the thorax, short clavicles, and little or no torsion of the humerus. The humerus is notably slender for its length, with prominent greater and lesser tubercles bounding a deep bicipital groove, with a small, non-projecting humeral deltoid tuberosity and brachioradialis crest. Distally, the humerus has a wide lateral distodorsal pillar and narrow medial distodorsal pillar, and a medially-displaced olecranon fossa with septal aperture. The Dinaledi radius and ulna diaphyses exhibit little curvature. The radius has a globular radial tuberosity, prominent pronator quadratus crest, and reduced styloid process."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The hand shares many derived features of modern humans and Neandertals in the thumb, wrist, and palm, but has relatively long and markedly curved fingers (<a href=\"#bib40\">Kivell et al., 2015</a>). The thumb is long relative to the length of the other digits, and includes a robust metacarpal with well-developed intrinsic (<i>M. opponens pollicis</i> and <i>M. first dorsal interosseous</i>) muscle attachments (<a href=\"#fig6\">Figure 6</a>). The pollical distal phalanx is large and robust with a well-developed ridge along the distal border of a deep proximal palmar fossa for the attachment of <i>flexor pollicis longus</i> tendon. Ungual spines also project proximopalmarly from a radioulnarly expanded apical tuft with a distinct area for the ungual fossa. The wrist includes a boot-shaped trapezoid with an expanded non-articular palmar surface, an enlarged and palmarly-expanded trapezoid-capitate joint, and a trapezium-scaphoid joint that extends further onto the scaphoid tubercle. Overall, carpal shapes and articular configurations are very similar to those of modern humans and Neandertals, and unlike those of great apes and other extinct hominins. However, the <i>H. naledi</i> wrist lacks a third metacarpal styloid process, has a more radioulnarly oriented capitate-Mc2 joint, and has a relatively small trapezium-Mc1 joint compared to humans and Neandertals. Moreover, the phalanges are long (relative to the palm) and more curved than most australopiths."
+                    }
+                ]
+            }, 
+            {
+                "type": "section", 
+                "id": "s4", 
+                "title": "Discussion", 
+                "content": [
+                    {
+                        "type": "paragraph", 
+                        "text": "The overall morphology of <i>H. naledi</i> places it within the genus <i>Homo</i> rather than <i>Australopithecus</i> or other early hominin genera. The shared derived features that connect <i>H. naledi</i> with other members of <i>Homo</i> occupy most regions of the <i>H. naledi</i> skeleton and represent distinct functional systems, including locomotion, manipulation, and mastication. Locomotor traits shared with <i>Homo</i> include the absolutely long lower limb, with well-marked linea aspera, strong <i>M. gluteus maximus</i> insertions, gracile fibula and generally humanlike ankle and foot. These aspects of the lower limb suggest enhanced locomotor performance for a striding gait. The <i>H. naledi</i> hand shares aspects of <i>Homo</i> morphology in the wrist, thumb and palm, pointing to enhanced object manipulation ability relative to australopiths, including <i>Au. sediba</i> (<a href=\"#bib39\">Kivell et al., 2011</a>; <a href=\"#bib40\">Kivell et al., 2015</a>). <i>H. naledi</i> lacks the powerful mastication that typifies <i>Australopithecus</i> and <i>Paranthropus</i>, with generally small teeth across the dentition, gracile mandibular corpus and symphysis, laterally-positioned temporal lines, slight postorbital constriction and non-flaring zygomatic arches. The upper limb, shoulder and ribcage have a more primitive morphological pattern, but do not preclude affiliating <i>H. naledi</i> with <i>Homo</i>, particularly considering that postcranial remains of <i>H. habilis</i> appear to reflect an australopith-like body plan (<a href=\"#bib31\">Johanson et al., 1986</a>). Locomotor, manipulatory, and masticatory systems have both historical and current importance in defining <i>Homo</i> (<a href=\"#bib71\">Wood and Collard, 1999</a>; <a href=\"#bib30\">Holliday, 2012</a>; <a href=\"#bib4\">Ant\u00f3n et al., 2014</a>), and <i>H. naledi</i> fits within our genus in these respects."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The structural configuration of the <i>H. naledi</i> cranium, beyond the functional aspects of mastication, is likewise shared with <i>Homo</i>. As in many specimens of <i>H. erectus</i> and <i>H. habilis</i>, the <i>H. naledi</i> vault includes a well-developed and moderately arched supraorbital torus, marked from the frontal squama by a continuous supratoral sulcus, frontal bossing. Further, as in many <i>H. erectus</i> crania, <i>H. naledi</i> exhibits a marked angular torus and occipital torus. The <i>H. naledi</i> face includes a flat and squared nasoalveolar clivus, comparable to <i>H. rudolfensis</i> (<a href=\"#bib41\">Leakey et al., 2012</a>), and weak canine fossae. While its anatomy places it unambiguously within <i>Homo</i>, the <i>H. naledi</i> cranium and dentition lack many derived features shared by MP and LP <i>Homo</i> and <i>H. sapiens.</i> The australopith-like features of the postcranium, including the ribcage, shoulder, proximal femur, and relatively long, curved fingers, also depart sharply from the morphology present in MP humans and <i>H. sapiens</i>. The similarities of <i>H. naledi</i> to earlier members of <i>Homo</i>, including <i>H. habilis</i>, <i>H. rudolfensis</i>, and <i>H. erectus</i>, suggest that this species may be rooted within the initial origin and diversification of our genus."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The fossil record of early <i>Homo</i> and <i>Homo-</i>like australopiths has rapidly increased during the last 15 years, and this accumulating evidence has changed our perspective on the rise of our genus. Many skeletal and behavioral features observed to separate later <i>Homo</i> from earlier hominins were formerly argued to have arisen as a single adaptive package, including increased brain size, tool manipulation, increased body size, smaller dentition, and greater commitment to terrestrial long-distance walking or running (<a href=\"#bib71\">Wood and Collard, 1999</a>; <a href=\"#bib29\">Hawks et al., 2000</a>). But we now recognize that such features appeared in different combinations in different fossil samples (<a href=\"#bib4\">Ant\u00f3n et al., 2014</a>). The Dmanisi postcranial sample (<a href=\"#bib43\">Lordkipanidze et al., 2007</a>) and additional cranial remains of <i>H. erectus</i> from Dmanisi (<a href=\"#bib22\">Gabunia et al., 2000</a>; <a href=\"#bib66\">Vekua et al., 2002</a>; <a href=\"#bib44\">Lordkipanidze et al., 2013</a>) and East Africa (<a href=\"#bib55\">Spoor et al., 2007</a>; <a href=\"#bib41\">Leakey et al., 2012</a>), demonstrate that larger brain size and body size did not arise synchronously with improved locomotor efficiency and adaptations to long-distance walking or running in <i>H. erectus</i> (<a href=\"#bib30\">Holliday, 2012</a>; <a href=\"#bib4\">Ant\u00f3n et al., 2014</a>). Further, the discovery of <i>Au. sediba</i> showed that a mosaic of <i>Homo</i>-like hand, pelvis and aspects of craniodental morphology can occur within a species with primitive body size, limb proportions, lower limb and foot morphology, thorax shape, vertebral morphology, and brain size (<a href=\"#bib6\">Berger et al., 2010</a>; <a href=\"#bib11\">Carlson et al., 2011</a>; <a href=\"#bib39\">Kivell et al., 2011</a>; <a href=\"#bib12\">Churchill et al., 2013</a>; <a href=\"#bib16\">DeSilva et al., 2013</a>; <a href=\"#bib52\">Schmid et al., 2013</a>). <i>H. naledi</i> presents yet a different combination of traits. This species combines a humanlike body size and stature with an australopith-sized brain; features of the shoulder and hand apparently well-suited for climbing with humanlike hand and wrist adaptations for manipulation; australopith-like hip mechanics with humanlike terrestrial adaptations of the foot and lower limb; small dentition with primitive dental proportions. In light of this evidence from complete skeletal samples, we must abandon the expectation that any small fragment of the anatomy can provide singular insight about the evolutionary relationships of fossil hominins."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "A recent phylogenetic analysis of fossil hominins based on craniodental morphology placed <i>Au. sediba</i> at the base of the genus <i>Homo</i> (<a href=\"#bib15\">Dembo et al., 2015</a>), in agreement with earlier analyses of this species (<a href=\"#bib6\">Berger et al., 2010</a>). The cranial and dental affinities identified between <i>Au. sediba</i> and <i>Homo</i> include many features shared by <i>H. naledi.</i> But <i>H. naledi</i> and <i>Au. sediba</i> share different postcranial features with other species of <i>Homo</i>. Resolving the phylogenetic placement of <i>H. naledi</i> will require both postcranial and craniodental evidence to be integrated together. Such integration poses a challenge because of the poor representation of several key species both within and outside of <i>Homo</i>, most notably <i>H. habilis</i>, for which postcranial evidence is slight, and <i>H. rudolfensis</i> for which no associated postcranial remains are known. We propose the testable hypothesis that the common ancestor of <i>H. naledi</i>, <i>H. erectus</i>, and <i>H. sapiens</i> shared humanlike manipulatory capabilities and terrestrial bipedality, with hands and feet like <i>H. naledi</i>, an australopith-like pelvis and the <i>H. erectus-</i>like aspects of cranial morphology that are found in <i>H. naledi</i>. Enlarged brain size was evidently not a necessary prerequisite for the generally human-like aspects of manipulatory, locomotor, and masticatory morphology of <i>H. naledi</i>."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Although it contains an unprecedented wealth of anatomical information, the Dinaledi deposit remains undated (<a href=\"#bib17\">Dirks et al., 2015</a>). Considering that <i>H. naledi</i> is a morphologically primitive species within our genus, an age may help elucidate the ecological circumstances within which <i>Homo</i> arose and diversified. If the fossils prove to be substantially older than 2 million years, <i>H. naledi</i> would be the earliest example of our genus that is more than a single isolated fragment. The sample would illustrate a model for the relation of adaptive features of the cranium, dentition and postcranium during a critical time interval that is underrepresented by fossil evidence of comparable completeness. A date younger than 1 million years ago would demonstrate the coexistence of multiple <i>Homo</i> morphs in Africa, including this small-brained form, into the later periods of human evolution. The persistence of such a species with clear adaptations for manipulation and grip, alongside MP humans or perhaps even alongside modern humans, would challenge many assumptions about the development of the archaeological record in Africa."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The depth of evidence of <i>H. naledi</i> may provide a perspective on the variation to be expected within fossil hominin taxa (<a href=\"#bib44\">Lordkipanidze et al., 2013</a>; <a href=\"#bib7\">Berm\u00fadez de Castro et al., 2014</a>). The entire Dinaledi collection is remarkably homogeneous. There is very little size variation among adult elements within the collection. Eight body mass estimates from the femur (<a href=\"#tbl2\">Table 2</a>) have a standard deviation of only 4.3 kilograms, for a body mass coefficient of variation (CV) of only 9%. The CV of body mass within most human populations is substantially higher than this, with an average near 15% (<a href=\"#bib45\">McKellar and Hendry, 2009</a>). Likewise, the size variation of cranial and dental elements is minimal. With 11 mandibular first molars, the CV of buccolingual breadth is only 3.2% and for 13 maxillary first molars the CV of buccolingual breadth is only 2.0% (buccolingual breadth is used because it is not subject to variance from interproximal wear). Not only size, but also anatomical shape and form are homogeneous within the sample. Almost every aspect of the morphology of the dentition, including the distinctive form of the lower premolars, the distal accessory cuspule of the mandibular canines, and the expression of nonmetric features that normally vary in human populations, is uniform in every specimen from the collection. The distinctive aspects of cranial morphology are repeated in every specimen, and even the aspects that normally vary among individuals of different body size or between sexes exhibit only slight variation among the Dinaledi remains. One of the most unique aspects of <i>H. naledi</i> is the morphology of the first metacarpal; the derived aspects of this anatomy are present in every one of seven first metacarpal specimens in the collection (<a href=\"#fig14\">Figure 14</a>). Unlike any other fossil hominin site in Africa, the Dinaledi Chamber seems to preserve a large number of individuals from a single population, one with variation equal to or less than that found within local populations of modern humans."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "doi": "10.7554/eLife.09560.004", 
+                                "id": "fig14", 
+                                "label": "Figure 14", 
+                                "title": "First metacarpals of <i>H. naledi</i>.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Seven first metacarpals have been recovered from the Dinaledi Chamber. U.W. 101-1321 is the right first metacarpal of the associated Hand 1 found in articulation. U.W. 101-1282 and U.W. 101-1641 are anatomically similar left and right first metacarpals, which we hypothesize as antimeres, both were recovered from excavation. U.W. 101-007 was collected from the surface of the chamber, and exhibits the same distinctive morphological characteristics as all the first metacarpals in the assemblage. All of these show a marked robusticity of the distal half of the bone, a very narrow, \u2018waisted\u2019 appearance to the proximal shaft and proximal articular surface, prominent crests for attachment of <i>M. opponens pollicis</i> and <i>M. first dorsal interosseous</i>, and a prominent ridge running down the palmar aspect of the bone. The heads of these metacarpals are dorsopalmarly flat and strongly asymmetric, with an enlarged palmar-radial protuberance. These distinctive features are present among all the first metacarpals in the Dinaledi collection, and are absent from any other hominin sample. Their derived nature is evident in comparison to apes and other early hominins, here illustrated with a chimpanzee first metacarpal and the MH2 first metacarpal of <i>Australopithecus sediba</i>."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig14-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-09560-fig14-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig14-v1.tif", 
+                                    "size": {
+                                        "width": 4204, 
+                                        "height": 1289
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "The Dinaledi collection is the richest assemblage of associated fossil hominins ever discovered in Africa, and aside from the Sima de los Huesos collection and later Neanderthal and modern human samples, it has the most comprehensive representation of skeletal elements across the lifespan, and from multiple individuals, in the hominin fossil record. The abundance of evidence from this assemblage supports our emerging understanding that the genus <i>Homo</i> encompassed a variety of evolutionary experiments (<a href=\"#bib4\">Ant\u00f3n et al., 2014</a>), with diversity now evident for fossil <i>Homo</i> in each of the few intensively explored parts of Africa (<a href=\"#bib41\">Leakey et al., 2012</a>). But as much as it advances our knowledge, <i>H. naledi</i> also highlights our ignorance about ancient <i>Homo</i> across the vast geographic span of the African continent. The tree of <i>Homo</i>-like hominins is far from complete: we have missed key transitional forms and lineages that persisted for hundreds of thousands of years. With an increasing pace of discovery from the field and the laboratory, more light will be thrown on the origin of humans."
+                    }
+                ]
+            }, 
+            {
+                "type": "section", 
+                "id": "s5", 
+                "title": "Materials and methods", 
+                "content": [
+                    {
+                        "type": "section", 
+                        "id": "s5-1", 
+                        "title": "Comparative hominin specimens examined in this study", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "In the differential diagnosis of <i>H. naledi</i>, we have compared the holotype DH1, paratypes, and other referred material to fossil evidence from previously-identified hominin taxa. Our goal is to provide a diagnosis for <i>H. naledi</i> that is clear in reference to widely recognized hominin hypodigms. Different specialists continue to disagree about the composition and anatomical breadth represented by these hominin taxa and attribution of particular specimens to them (see e.g., <a href=\"#bib71\">Wood and Collard, 1999</a>; <a href=\"#bib44\">Lordkipanidze et al., 2013</a>; <a href=\"#bib4\">Ant\u00f3n et al., 2014</a> on early <i>Homo</i> taxa). We do not intend to take any position on such disagreements by our selection of comparative samples for <i>H. naledi</i>."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "We have been cautious in our attribution of postcranial specimens to hominin taxa, particularly in the African Plio-Pleistocene, where it has been demonstrated multiple hominin taxa coexisted in time, if not in geographical space. Because the purpose of this study is differential diagnosis in reference to known taxa, unattributed specimens are not germane, although in certain cases there are well-accepted attributions to genus for specimens (e.g., <i>Homo</i> sp<i>.</i> or <i>Australopithecus</i> sp<i>.</i>) as cited below. We have included some specimens in comparisons because they are relatively complete, even if they cannot be attributed to a species, because few hominin taxa are represented by evidence across the entire skeleton. For some anatomical characters, parts are preserved only for MP or later hominin samples, so we have included such comparisons to make clear how <i>H. naledi</i> compares in these elements to the (few) known fossil examples."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "This study relies upon observations and measurements taken from original fossils by the authors, observations taken from casts, and observations taken from the literature. These observations are in large part standard anatomical practice; where features are specially described in previous studies we have referenced those here. For this study, a cast collection was assembled including the Phillip V. Tobias research collection at the University of the Witwatersrand and loans of cast materials from the University of Wisconsin\u2013Madison, University of Michigan, American Museum of Natural History, New York University, University of Colorado\u2013Denver, University of Delaware, Texas A&M University, and the personal collections of Peter Schmid, Milford Wolpoff and Rob Blumenschine. We extend our gratitude to the curators of fossil collections and the generosity of these institutions in facilitating this research, both in South Africa and throughout the world."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "This list of skeletal materials extends the list of craniodental comparative material used in diagnosing <i>Au. sediba</i>, with many of the hypodigms identical to that study (<a href=\"#bib6\">Berger et al., 2010</a>). Where we have had first-hand access to original specimens, we rely upon our own observations; we therefore do not refer readers to other sources for these data."
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-1", 
+                                "title": "<i>Australopithecus afarensis</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The samples attributed to <i>Au. afarensis</i> from Hadar, Laetoli, the Middle Awash, Woranso-Mille and Dikika were utilized. For this taxon we relied upon published reports (<a href=\"#bib32\">Johanson et al., 1982</a>; <a href=\"#bib37\">Kimbel et al., 2004</a>; <a href=\"#bib19\">Drapeau et al., 2005</a>; <a href=\"#bib1\">Alemseged et al., 2006</a>; <a href=\"#bib27\">Haile-Selassie et al., 2010</a>; <a href=\"#bib67\">Ward et al., 2012</a>), in addition to our own observations on original fossils and casts."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-2", 
+                                "title": "<i>Australopithecus africanus</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The samples attributed to <i>Au. africanus</i> from Taung, Sterkfontein and Makapansgat were employed. Original specimens were examined first-hand by the authors."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-3", 
+                                "title": "<i>Australopithecus garhi</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The cranium BOU-VP-12/130 from Bouri was included, with data taken from a published report (<a href=\"#bib5\">Asfaw et al., 1999</a>)."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-4", 
+                                "title": "<i>Australopithecus sediba</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The partial skeletons MH1 and MH2 from Malapa, South Africa were included in this study, based on examination of the original specimens by the authors."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-5", 
+                                "title": "<i>Paranthropus aethiopicus</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The cranium KNM-WT 17000 was examined first-hand for this study."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-6", 
+                                "title": "<i>Paranthropus boisei</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Samples from the Omo Shungura sequence, East Lake Turkana, Olduvai Gorge and Konso were included in this study. Original specimens from Olduvai Gorge and East Lake Turkana were examined first-hand, while casts and published reports (<a href=\"#bib62\">Tobias, 1967</a>; <a href=\"#bib60\">Suwa et al., 1996</a>, <a href=\"#bib59\">1997</a>; <a href=\"#bib18\">Dom\u00ednguez-Rodrigo et al., 2013</a>) were used to study the Omo and Konso materials. Our postcranial considerations of <i>P. boisei</i> are very limited and we did not rely upon the association of KNM-ER 1500 (<a href=\"#bib23\">Grausz et al., 1988</a>) to derive information about the postcranial skeleton of <i>P. boisei</i>."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-7", 
+                                "title": "<i>Paranthropus robustus</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "The samples from Kromdraai, Swartkrans, Sterkfontein, Drimolen, Gondolin, and Coopers were included in this study. First-hand observations of original specimens from all localities were used with the exception of Drimolen fossils, which were compared using published reports (<a href=\"#bib35\">Keyser, 2000</a>; <a href=\"#bib36\">Keyser et al., 2000</a>)."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-8", 
+                                "title": "<i>Homo</i> <i>habilis</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Samples from Olduvai Gorge, East Lake Turkana, the Omo Shungura sequence, Hadar, and Sterkfontein were included in this study. Original Olduvai Gorge and East Lake Turkana fossils were examined first-hand, while for the Omo and Hadar materials we relied on our original observations on casts and originals and published reports (<a href=\"#bib9\">Boaz and Howell, 1977</a>; <a href=\"#bib63\">Tobias, 1991</a>; <a href=\"#bib38\">Kimbel et al., 1997</a>). We include the following fossils in the hypodigm of <i>H</i>. <i>habilis</i>: A.L. 666-1, KNM-ER 1478, KNM-ER 1501, KNM-ER 1502, KNM-ER 1805, KNM-ER 1813, KNM-ER 3735, OH 4, OH 6, OH 7, OH 8, OH 13, OH 15, OH 16, OH 21, OH 24, OH 27, OH 31, OH 35, OH 37, OH 39, OH 42, OH 44, OH 45, OH 62, OMO-L894-1, and Stw 53. We recognize that some authors (including some of the authors of this paper) prefer to classify OH 62, Stw 53 and A.L. 666-1 outside of <i>H. habilis</i>, (e.g., as <i>Homo gautengensis</i> which we do not recognize as valid), or even outside the genus <i>Homo</i>; these specimens expand the morphological and temporal variability encompassed within <i>H. habilis.</i>"
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-9", 
+                                "title": "<i>Homo</i> <i>rudolfensis</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Samples from Olduvai Gorge, East Lake Turkana, and Lake Malawi were included in this study. The East Lake Turkana fossils available prior to 2010 were examined first-hand, while for the Olduvai and Lake Malawi fossils and KNM-ER 60000, 62000, and 62003 we relied on original observations on fossils and casts as well as published reports (<a href=\"#bib53\">Schrenk et al., 1993</a>; <a href=\"#bib8\">Blumenschine et al., 2003</a>; <a href=\"#bib41\">Leakey et al., 2012</a>). We include the following fossils in the hypodigm of <i>H</i>. <i>rudolfensis</i>: KNM-ER 819, KNM-ER 1470, KNM-ER 1482, KNM-ER 1483, KNM-ER 1590, KNM-ER 1801, KNM-ER 1802, KNM-ER 3732, KNM-ER 3891, KNM-ER 60000, KNM-ER 62000, KNM-ER 62003, OH 65, and UR 501. We do recognize that KNM-ER 60000 and KNM-ER 1802 present some conflicting anatomy that some authors have argued precludes them as conspecific specimens (<a href=\"#bib41\">Leakey et al., 2012</a>); by considering both, we aim to be conservative as they encompass more variation within <i>H. rudolfensis</i>."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-10", 
+                                "title": "<i>Homo erectus</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Samples from Buia, Chemeron, Daka, Dmanisi, East and West Lake Turkana, Gona, Hexian, Konso, Mojokerto, Olduvai Gorge, Sangiran, Swartkrans, Trinil, and Zhoukoudian were included in this study. South African material is of special interest in this comparison because of the geographic proximity, and because of the difficulty of clearly identifying <i>Homo</i> specimens within the large fossil sample from Swartkrans. In particular, the following specimens from Swartkrans are considered to represent <i>H. erectus</i>: SK 15, SK 18a, SK 27, SK 43, SK 45, SK 68, SK 847, SK 878, SK 2635, SKW 3114, SKX 257/258, SKX 267/2671, SKX 268, SKX 269, SKX 334, SKX 339, SKX 610, SKX 1756, SKX 2354, SKX 2355, SKX 2356, and SKX 21204. It has been suggested (<a href=\"#bib24\">Grine et al., 1993</a>, <a href=\"#bib26\">1996</a>) that SK 847 and Stw 53 might represent the same taxon, and that this taxon is a currently undiagnosed species of <i>Homo</i> in South Africa. However, we agree with <a href=\"#bib13\">Clarke (1977</a>; <a href=\"#bib14\">2008)</a> that SK 847 can be attributed to <i>H</i>. <i>erectus</i>, and that Stw 53 cannot. Because there is no clear indication that more than one species of <i>Homo</i> is represented in the Swartkrans sample, we consider all this material to belong to <i>H. erectus</i>. We considered \u2018<i>Homo ergaster</i>\u2019 (and also \u2018<i>Homo aff. erectus</i>\u2019 from <a href=\"#bib70\">Wood, 1991</a>) to be synonyms of <i>H. erectus</i> for this study; Turkana Basin specimens that are attributed to <i>H. erectus</i> thus include KNM-ER 730, KNM-ER 820, KNM-ER 992, KNM-ER 1808, KNM-ER 3733, KNM-ER 3883, KNM-ER 42700, KNM-WT 15000. Olduvai specimens include OH 9, OH 12 and OH 28. Original fossil materials from Chemeron, Lake Turkana, Swartkrans, Trinil, and Dmanisi were examined first-hand by the authors, while the remainder were based on casts and published reports (<a href=\"#bib69\">Weidenreich, 1943</a>; <a href=\"#bib70\">Wood, 1991</a>; <a href=\"#bib3\">Ant\u00f3n, 2003</a>; <a href=\"#bib49\">Rightmire et al., 2006</a>; <a href=\"#bib61\">Suwa et al., 2007</a>)."
+                                    }, 
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "A large number of postcranial specimens have been collected from the Turkana Basin and appear consistent with the anatomical range otherwise found in <i>Homo</i>, and inconsistent with known samples of <i>Australopithecus</i> and <i>Paranthropus</i> from elsewhere. These include KNM-ER 1472, KNM-ER 1481, KNM-ER 3228, KNM-ER 737, and others. We may add other fossils from other sites lacking association with craniodental material, such as the partial BOU-VP 12/1 skeleton and even the Gona pelvis. These specimens attributable to <i>Homo</i> but not necessarily to a particular species did inform our understanding of variability within the genus, but for the most part these specimens do not inform our differential diagnosis of <i>H. naledi</i> relative to particular species. For example, the key element of femoral morphology of <i>H. naledi</i> in contrast to other species is the presence of two well-defined mediolaterally running pillars in the femoral neck; the isolated specimens of early <i>Homo</i> do not contradict this apparent autapomorphy. Likewise, no isolated specimens inform us about the humanlike aspects of foot morphology in <i>H. naledi</i>. In these cases, the lack of associations for this evidence actually is less important than the lack of specimens that replicate the distinctive features of the <i>H. naledi</i> morphology."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-11", 
+                                "title": "Middle Pleistocene <i>Homo</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Specimens from the latest Lower Pleistocene and MP of Europe and Africa that cannot be attributed to <i>H. erectus</i> were included in our comparisons. These include fossils that have been attributed to <i>H. heidelbergensis</i>, <i>H. rhodesiensis</i>, \u2018archaic <i>H. sapiens</i>\u2019, or \u2018evolved <i>H. erectus</i>\u2019 by a variety of other authors. Specimens attributed to MP <i>Homo</i> include materials from Eliye Springs, Arago, Atapuerca Sima de los Huesos, Bodo, Broken Hill, Cave of Hearths, Ceprano, Dali, Elandsfontein, Jinniushan, Kapthurin, Mauer, Narmada, Ndutu, Petralona, Reilingen-Schwetzingen, Solo, Steinheim, Swanscombe. This grouping includes the following specimens: KNM-ES 11693, Arago 2, Arago 13, Arago 21, Atapuerca 1, Atapuerca 2, Atapuerca 4, Atapuerca 5, Atapuerca 6, Cave of Hearths, SAM-PQ-EH1, Kabwe, Mauer, Ndutu, Sal\u00e9, Petralona, Reilingen-Schwetzingen, Steinheim."
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "section", 
+                                "id": "s5-1-12", 
+                                "title": "<i>Homo floresiensis</i>", 
+                                "content": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Specimens from Liang Bua, Flores as described by <a href=\"#bib10\">Brown et al., 2004</a>; <a href=\"#bib46\">Morwood et al., 2005</a>, <a href=\"#bib33\">Jungers et al., 2009a</a>, <a href=\"#bib34\">Jungers et al., 2009b</a>, and <a href=\"#bib20\">Falk et al., 2005</a> were included in this study."
+                                    }
+                                ]
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-2", 
+                        "title": "Scanning and virtual reconstruction methods", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The calvariae (DH1-4) were scanned using a NextEngine laser surface scanner (NextEngine, Malibu, CA) at the following settings: Macro, 12 divisions with auto-rotation, HD 17k ppi. Depending on the complexity of the surface relief, either two or three complete scanning cycles were completed per specimen, resulting in multiple 360\u00b0 scans. Each individual scan was trimmed, aligned, and fused (volume merged) in the accompanying ScanStudio HD Pro software. For each specimen, the individual 360\u00b0 scans were then aligned and merged in GeoMagic Studio 14.0 (Raindrop Geomagic, Research Triangle Park, NC), creating a final three-dimensional model of the specimen. Given the fragmented nature of the calvariae specimens, both the ectocranial and endocranial surfaces were captured in the scans."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "DH3 consisted primarily of portions of the right calvaria. However, a small section of the frontal and the parietal crossed the mid\u2013sagittal plane. For this reason, it was possible to mirror image the surface scan to approximate the left calvaria and obtain a more complete visualization of the complete calvaria (<a href=\"#fig15\">Figure 15</a>). The virtual specimen of DH3 was mirrored in GeoMagic Studio, and manually registered (aligned) using common points along the frontal crest and sagittal suture. The registration procedure in GeoMagic Studio is an iterative process that refines the alignment of specimens to minimize spatial differences between corresponding surfaces. In this manner, the program is able to match the position overlapping surfaces, in addition to their angulation and curvature."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.020", 
+                                        "id": "fig15", 
+                                        "label": "Figure 15", 
+                                        "title": "Posterior view of the virtual reconstruction of DH3.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "The resultant mirror image is displayed in blue. The antimeres were aligned by the frontal crest and sagittal suture using the Manual Registration function in GeoMagic Studio 14.0."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig15-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig15-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig15-v1.tif", 
+                                            "size": {
+                                                "width": 707, 
+                                                "height": 631
+                                            }
+                                        }
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The same procedures were used to mirror image and create a virtual reconstruction of DH2 and the occipital portion of DH1 (<a href=\"#fig16\">Figure 16</a>). The occipital and vault portions of DH1 were reconstructed based on the anatomical alignment of the sagittal suture, sagittal sulcus, parietal striae, and the continuation of the temporal lines across both the specimens."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.021", 
+                                        "id": "fig16", 
+                                        "label": "Figure 16", 
+                                        "title": "Virtual reconstruction of (<b>A</b>) DH2 and (<b>B</b>) occipital portion of DH1.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "The actual specimen displays its original coloration and the mirror imaged portion is illustrated in blue."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig16-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig16-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig16-v1.tif", 
+                                            "size": {
+                                                "width": 2750, 
+                                                "height": 981
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-3", 
+                        "title": "Virtual reconstruction of composite crania and estimation of cranial capacity", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "In order to virtually estimate the cranial capacity, composite crania were constructed from the surface scans and mirror imaged scans of the calvariae. Two separate composite crania were created; the relatively smaller-sized calvariae (DH3 and DH4) were combined into one composite, and the larger-sized calvariae (DH1 and DH2) composed the larger composite cranium."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The smaller composite cranium, DH3 was mirrored in GeoMagic Studio 14.0, and merged with the original scan as outlined above. The surface scan of DH4 was uploaded and registered (aligned) to the DH3 model using overlapping temporal features (e.g., the external auditory meatus). No scaling was performed. DH4 was then mirror imaged to complete the occipital contour. The resultant model suggests a general concordance between the specimens in both size and shape with a close alignment of vault surfaces and anatomical features between specimens (<a href=\"#fig17\">Figure 17</a>)."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.022", 
+                                        "id": "fig17", 
+                                        "label": "Figure 17", 
+                                        "title": "Postero-lateral view of the virtual reconstruction of a composite cranium from DH3 and DH4.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "(<b>A</b>) The surface scan of DH3 was mirror imaged and merged as described in Supplementary Note 8. (<b>B</b>) The scan of DH4 was aligned to the DH3 model. (<b>C</b>) DH4 was then mirror imaged to complete the occipital contour (<b>D</b>)."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig17-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig17-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig17-v1.tif", 
+                                            "size": {
+                                                "width": 2989, 
+                                                "height": 662
+                                            }
+                                        }
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "For the larger composite cranium, the surface model of DH2 and its mirror image was then uploaded, registered (aligned), and merged with the mirror-imaged model of DH1. No scaling was performed. The congruency between the specimens in the resultant model suggests that DH1 and DH2 are similar in both size and vault shape (<a href=\"#fig18\">Figure 18</a>)."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.023", 
+                                        "id": "fig18", 
+                                        "label": "Figure 18", 
+                                        "title": "Virtual reconstruction of a composite cranium from DH1 and DH2.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "The surface model of DH2 (blue), consisting of the original scan merged with the mirror image, was then uploaded and aligned with the mirror-imaged DH1 model (pink). Note the similarity in size and shape between DH1 and DH2 observed in the posterior (<b>A</b>) anterior (<b>B</b>) lateral (<b>C</b>) and superior (<b>D</b>) views."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig18-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig18-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig18-v1.tif", 
+                                            "size": {
+                                                "width": 2989, 
+                                                "height": 689
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-4", 
+                        "title": "Virtual reconstruction of cranial capacity", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The composite model of DH3 and DH4 was used to estimate the cranial capacity for the smaller morphotype. In GeoMagic Studio 14.0, the endocranial surface of the composite was carefully selected from the ectocranial surface and copied as a new object. In order to obtain a volume calculation the model has to be a closed surface, meaning that all of the holes in the surface model had to be filled. Small holes in the model were filled using the \u2018Fill by Curvature\u2019 function. Larger holes were filled in by sections. For example, the cranial base was filled in using a number of transverse sections, so that in the absence of the cranial base the contour of the various cranial fossae and the petrous portions of the temporal could be preserved as best as possible. When appropriate (e.g., around angular portions of the petrous bone), small sections were filled using a flat hole filling function. The new surfaces created by the hole-filling mechanism were carefully monitored and repeated until an acceptable model that appeared to best approximate the missing portions was obtained. The result is a closed model approximation of the endocranium, of which a volume can be calculated by GeoMagic Studio (<a href=\"#fig19\">Figure 19</a>, <a href=\"#fig20\">Figure 20</a>). The volume of the smaller composite cranium (DH3 and DH4) indicates a cranial capacity of approximately 465 cm<sup>3</sup>."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.024", 
+                                        "id": "fig19", 
+                                        "label": "Figure 19", 
+                                        "title": "Virtual reconstruction of the endocranium of the composite cranium from DH3 and DH4.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "(<b>A</b>) Lateral view. (<b>B</b>) Superior view. (<b>C</b>) Inferior view. In all views, anterior is to towards the left."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig19-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig19-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig19-v1.tif", 
+                                            "size": {
+                                                "width": 2989, 
+                                                "height": 805
+                                            }
+                                        }
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.025", 
+                                        "id": "fig20", 
+                                        "label": "Figure 20", 
+                                        "title": "Virtual reconstruction of the endocranium of the composite cranium from DH3 and DH4 overlaid with the ectocranial surfaces.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "(<b>A</b>) Lateral view. (<b>B</b>) Superior view."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig20-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig20-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig20-v1.tif", 
+                                            "size": {
+                                                "width": 2750, 
+                                                "height": 991
+                                            }
+                                        }
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "In order to determine whether significant errors were being introduced in the manner that the cranial base was filled in the above procedures, the endocranial volume of DH3/DH4 was also virtually calculated using the cranial base of Sts 19 as a model. A 3D model of Sts 19 was mirrored and aligned to the DH3/DH4 model using the external auditory meatus and common points on the internal surface of the petrous portion as a guide (<a href=\"#fig21\">Figure 21</a>). The Sts 19 model was then scaled by 0.97 to obtain an optimal fit between the two models."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.026", 
+                                        "id": "fig21", 
+                                        "label": "Figure 21", 
+                                        "title": "Virtual reconstruction the DH3/DH4 cranial base using a model of Sts 19.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "(<b>A</b>) Right lateral view. (<b>B</b>) Left lateral view. (<b>C</b>) Posterior view. (<b>D</b>) Inferior view."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig21-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig21-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig21-v1.tif", 
+                                            "size": {
+                                                "width": 3158, 
+                                                "height": 685
+                                            }
+                                        }
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "After the Sts 19 model was merged with the DH3/DH4 model, the endocranial surface was extracted and reconstructed as described above (<a href=\"#fig22\">Figure 22</a>). The resultant endocranial volume using the Sts 19 cranial base was 465.9 cm<sup>3</sup>. This value is in agreement with the first estimate and suggests that using a model cranial base did not significantly alter the results."
+                            }, 
+                            {
+                                "type": "figure", 
+                                "assets": [
+                                    {
+                                        "type": "image", 
+                                        "doi": "10.7554/eLife.09560.027", 
+                                        "id": "fig22", 
+                                        "label": "Figure 22", 
+                                        "title": "Virtual reconstruction the DH3/DH4 endocranial volume using a cranial base model of Sts 19.", 
+                                        "caption": [
+                                            {
+                                                "type": "paragraph", 
+                                                "text": "Right lateral view."
+                                            }
+                                        ], 
+                                        "image": {
+                                            "source": {
+                                                "mediaType": "image/jpeg", 
+                                                "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig22-v1.tif/full/full/0/default.jpg", 
+                                                "filename": "elife-09560-fig22-v1.jpg"
+                                            }, 
+                                            "alt": "", 
+                                            "uri": "https://iiif.elifesciences.org/lax:09560/elife-09560-fig22-v1.tif", 
+                                            "size": {
+                                                "width": 1415, 
+                                                "height": 860
+                                            }
+                                        }
+                                    }
+                                ]
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "The larger composite cranium, consisting of DH1 and DH2, lacks most of the frontal region. In order to create a closed endocranial surface for a volume estimate, the frontal region from the smaller composite cranium was scaled by 5%, and then registered (aligned) and merged to the model of the larger composite cranium. As with the smaller composite cranium, the endocranial surface was then selected and converted to a new object, and the remaining holes filled based on the curvature of the surface. The volume of the closed endocranial model was calculated using GeoMagic Studio. The cranial capacity (endocranial volume) of the larger composite model is approximately 560cc."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-5", 
+                        "title": "Body mass estimation methods", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "Eight femoral fragments from the Dinaledi collection allow a direct measurement of the subtrochanteric anteroposterior and mediolateral diameters (<a href=\"#tbl3\">Table 3</a>). We developed two regression equations to estimate body mass from these diameters based on the masses of modern human samples. MCE measured body masses of a sample of 253 modern European individuals, 128 males and 125 females, collected from the Institute for Forensic Medicine in Zurich, Switzerland. Body masses were taken at time of forensic evaluation. This sample yields the following regression equation relating body mass to subtrochanteric diameter, where FSTpr refers to the product of the femoral subtrochanteric mediolateral and anteroposterior breadths:"
+                            }, 
+                            {
+                                "type": "mathml", 
+                                "id": "equ1", 
+                                "mathml": "<math><mrow><mtext>Body\u2009Mass</mtext><mo>=</mo><mn>0.060</mn><mo>\u00d7</mo><mtext>FSTpr</mtext><mo>+</mo><mn>13</mn><mo>.</mo><mn>856</mn><mo>,</mo><mtext>SEE</mtext><mo>=</mo><mn>6</mn><mo>.</mo><mn>78</mn><mo>,</mo><mtext>r</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>50</mn><mo>,</mo><mtext>p</mtext><mo>=</mo><mo>&lt;</mo><mn>0</mn><mo>.</mo><mn>001</mn><mo>.</mo></mrow></math>"
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "We further examined a broader sample of 276 modern humans taken from a number of populations around the world, with data measured by TWH. The body masses of individuals were estimated from femur head diameter, using the average of results obtained from <a href=\"#bib25\">Grine et al. (1995)</a> and <a href=\"#bib51\">Ruff et al. (1997)</a>. The sample includes 115 females, 155 males, and 6 individuals of indeterminate sex."
+                            }, 
+                            {
+                                "type": "mathml", 
+                                "id": "equ2", 
+                                "mathml": "<math><mrow><mtext>Body\u2009Mass</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>046</mn><mo>\u00d7</mo><mtext>FSTpr</mtext><mo>+</mo><mn>24</mn><mo>.</mo><mn>614</mn><mo>,</mo><mtext>SEE</mtext><mo>=</mo><mn>5</mn><mo>.</mo><mn>82</mn><mo>,</mo><mtext>r</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>82</mn><mo>,</mo><mtext>p</mtext><mo>&lt;</mo><mn>0</mn><mo>.</mo><mn>001</mn><mo>.</mo></mrow></math>"
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-6", 
+                        "title": "Stature estimation methods", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "We collected data from skeletal material representing two African population samples. We use only African populations in this comparison because the ratio of tibia length to femur length, and thereby the proportion of stature constituted by tibia length, varies between human populations both today and prehistorically. Although we do not know this proportion for <i>H. naledi</i>, we adopt the null hypothesis that they likely had tibia/femur proportions similar to other African population samples."
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "95 male and female Kulubnarti individuals from medieval Nubia are curated at the University of Colorado, Boulder. Data were collected by HMG, including estimates of living stature based on the Fully method (<a href=\"#bib21\">Fully, 1956</a>; <a href=\"#bib48\">Raxter et al., 2006</a>), and these were used to develop a regression equation relating tibia length to stature. The resulting equation is:"
+                            }, 
+                            {
+                                "type": "mathml", 
+                                "id": "equ3", 
+                                "mathml": "<math><mrow><mtext>Stature</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>295</mn><mi mathvariant=\"normal\">\u00d7</mi><mtext>TML</mtext><mo>+</mo><mn>48</mn><mo>.</mo><mn>589</mn><mo>,</mo><mtext>SEE</mtext><mo>=</mo><mn>3</mn><mo>.</mo><mn>13</mn><mo>,</mo><mtext>r</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>90</mn><mo>,</mo><mtext>p</mtext><mo>&lt;</mo><mn>0</mn><mo>.</mo><mn>001</mn><mo>.</mo></mrow></math>"
+                            }, 
+                            {
+                                "type": "paragraph", 
+                                "text": "We (HMG and TWH) collected measurements from 38 African males and 38 females curated within the Dart Collection of the University of the Witwatersrand. Specimens were randomly chosen with no preference for specific African ethnic groups. Cadaveric statures are documented for this collection, the regression equation relating tibia length to stature in this sample is:"
+                            }, 
+                            {
+                                "type": "mathml", 
+                                "id": "equ4", 
+                                "mathml": "<math><mrow><mtext>Stature</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>223</mn><mo>\u00d7</mo><mtext>TML</mtext><mo>+</mo><mn>75</mn><mo>.</mo><mn>350</mn><mo>,</mo><mtext>SEE</mtext><mo>=</mo><mn>6</mn><mo>.</mo><mn>50</mn><mo>,</mo><mtext>r</mtext><mo>=</mo><mn>0</mn><mo>.</mo><mn>63</mn><mo>,</mo><mtext>p</mtext><mo>&lt;</mo><mn>0</mn><mo>.</mo><mn>001</mn><mo>.</mo></mrow></math>"
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-7", 
+                        "title": "Nomenclatural acts", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "The electronic edition of this article conforms to the requirements of the amended <a href=\"http://iczn.org/iczn/index.jsp\">International Code of Zoological Nomenclature</a>, and hence, the new name contained herein is available under that Code from the electronic edition of this article. This published work and the nomenclatural acts it contains have been registered in ZooBank, the online registration system for the ICZN. The ZooBank LSIDs (Life Science Identifiers) can be resolved and the associated information viewed through any standard web browser by appending the LSID to the prefix \u2018<a href=\"http://zoobank.org/\">http://zoobank.org/</a>\u2019. The LSID for this publication is: <a href=\"http://zoobank.org/urn:lsid:zoobank.org:pub:00D1E81A-6E08-4A01-BD98-79A2CEAE2411\">urn:lsid:zoobank.org:pub:00D1E81A-6E08-4A01-BD98-79A2CEAE2411</a>. The electronic edition of this work was published in a journal with an ISSN (2050-084X) and has been archived and is available from the following digital repositories: <a href=\"http://www.ncbi.nlm.nih.gov/pmc/issues/247153/\">PubMed Central</a> and <a href=\"http://www.lockss.org/\">LOCKSS</a>."
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "section", 
+                        "id": "s5-8", 
+                        "title": "Access to material", 
+                        "content": [
+                            {
+                                "type": "paragraph", 
+                                "text": "All Dinaledi fossil material is available for study by researchers upon application to the Evolutionary Studies Institute at the University of the Witwatersrand where the material is curated (contact Bernhard Zipfel [<a href=\"mailto:Bernhard.Zipfel@wits.ac.za\">Bernhard.Zipfel@wits.ac.za</a>]). Three-dimensional surface renderings and other digital data are available from the MorphoSource digital repository (<a href=\"http://morphosource.org/\">http://morphosource.org</a>)."
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], 
+        "references": [
+            {
+                "type": "journal", 
+                "id": "bib1", 
+                "date": "2006", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Alemseged", 
+                            "index": "Alemseged, Z"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Spoor", 
+                            "index": "Spoor, F"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kimbel", 
+                            "index": "Kimbel, WH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Bobe", 
+                            "index": "Bobe, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Geraads", 
+                            "index": "Geraads, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Reed", 
+                            "index": "Reed, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JG Wynn", 
+                            "index": "Wynn, JG"
+                        }
+                    }
+                ], 
+                "articleTitle": "A juvenile early hominin skeleton from Dikika, Ethiopia", 
+                "journal": "Nature", 
+                "volume": "443", 
+                "pages": {
+                    "first": "296", 
+                    "last": "301", 
+                    "range": "296\u2013301"
+                }, 
+                "doi": "10.1038/nature05047"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib2", 
+                "date": "2014", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Alm\u00e9cija", 
+                            "index": "Alm\u00e9cija, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Alba", 
+                            "index": "Alba, DM"
+                        }
+                    }
+                ], 
+                "articleTitle": "On manual proportions and pad-to-pad precision grasping in <i>Austalopithecus afarensis</i>", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "73", 
+                "pages": {
+                    "first": "88", 
+                    "last": "92", 
+                    "range": "88\u201392"
+                }, 
+                "doi": "10.1016/j.jhevol.2014.02.006"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib3", 
+                "date": "2003", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Ant\u00f3n", 
+                            "index": "Ant\u00f3n, SC"
+                        }
+                    }
+                ], 
+                "articleTitle": "Natural history of <i>Homo erectus</i>", 
+                "journal": "American Journal of Physical Anthropology", 
+                "pages": {
+                    "first": "126", 
+                    "last": "170", 
+                    "range": "126\u2013170"
+                }, 
+                "doi": "10.1002/ajpa.10399"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib4", 
+                "date": "2014", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Ant\u00f3n", 
+                            "index": "Ant\u00f3n, SC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Potts", 
+                            "index": "Potts, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LC Aiello", 
+                            "index": "Aiello, LC"
+                        }
+                    }
+                ], 
+                "articleTitle": "Human evolution. Evolution of early <i>Homo</i>: an integrated biological perspective", 
+                "journal": "Science", 
+                "volume": "345", 
+                "pages": "1236828", 
+                "doi": "10.1126/science.1236828"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib5", 
+                "date": "1999", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Asfaw", 
+                            "index": "Asfaw, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T White", 
+                            "index": "White, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Lovejoy", 
+                            "index": "Lovejoy, O"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Latimer", 
+                            "index": "Latimer, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Simpson", 
+                            "index": "Simpson, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Suwa", 
+                            "index": "Suwa, G"
+                        }
+                    }
+                ], 
+                "articleTitle": "<i>Australopithecus garhi</i>: a new species of early hominid from Ethiopia", 
+                "journal": "Science", 
+                "volume": "284", 
+                "pages": {
+                    "first": "629", 
+                    "last": "635", 
+                    "range": "629\u2013635"
+                }, 
+                "doi": "10.1126/science.284.5414.629"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib6", 
+                "date": "2010", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Carlson", 
+                            "index": "Carlson, KJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PH Dirks", 
+                            "index": "Dirks, PH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Kibii", 
+                            "index": "Kibii, JM"
+                        }
+                    }
+                ], 
+                "articleTitle": "<i>Australopithecus sediba</i>: a new species of <i>Homo</i>-like australopith from South Africa", 
+                "journal": "Science", 
+                "volume": "328", 
+                "pages": {
+                    "first": "195", 
+                    "last": "204", 
+                    "range": "195\u2013204"
+                }, 
+                "doi": "10.1126/science.1184944"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib7", 
+                "date": "2014", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Berm\u00fadez de Castro", 
+                            "index": "Berm\u00fadez de Castro, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Martin\u00f3n-Torres", 
+                            "index": "Martin\u00f3n-Torres, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Sier", 
+                            "index": "Sier, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Mart\u00edn-Franc\u00e9s", 
+                            "index": "Mart\u00edn-Franc\u00e9s, L"
+                        }
+                    }
+                ], 
+                "articleTitle": "On the variability of the Dmanisi mandibles", 
+                "journal": "PLOS ONE", 
+                "volume": "9", 
+                "pages": "e88212", 
+                "doi": "10.1371/journal.pone.0088212"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib8", 
+                "date": "2003", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Blumenschine", 
+                            "index": "Blumenschine, RJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CR Peters", 
+                            "index": "Peters, CR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FT Masao", 
+                            "index": "Masao, FT"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Clarke", 
+                            "index": "Clarke, RJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Deino", 
+                            "index": "Deino, AL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RL Hay", 
+                            "index": "Hay, RL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CC Swisher", 
+                            "index": "Swisher, CC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "IG Stanistreet", 
+                            "index": "Stanistreet, IG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GM Ashley", 
+                            "index": "Ashley, GM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LJ McHenry", 
+                            "index": "McHenry, LJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NE Sikes", 
+                            "index": "Sikes, NE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Van Der Merwe", 
+                            "index": "Van Der Merwe, NJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JC Tactikos", 
+                            "index": "Tactikos, JC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AE Cushing", 
+                            "index": "Cushing, AE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DM Deocampo", 
+                            "index": "Deocampo, DM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JK Njau", 
+                            "index": "Njau, JK"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JI Ebert", 
+                            "index": "Ebert, JI"
+                        }
+                    }
+                ], 
+                "articleTitle": "Late Pliocene <i>Homo</i> and hominid land use from western Olduvai Gorge, Tanzania", 
+                "journal": "Science", 
+                "volume": "299", 
+                "pages": {
+                    "first": "1217", 
+                    "last": "1221", 
+                    "range": "1217\u20131221"
+                }, 
+                "doi": "10.1126/science.1075374"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib9", 
+                "date": "1977", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NT Boaz", 
+                            "index": "Boaz, NT"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FC Howell", 
+                            "index": "Howell, FC"
+                        }
+                    }
+                ], 
+                "articleTitle": "A gracile hominid cranium from upper member G of the Shungura formation, Ethiopia", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "46", 
+                "pages": {
+                    "first": "93", 
+                    "last": "108", 
+                    "range": "93\u2013108"
+                }, 
+                "doi": "10.1002/ajpa.1330460113"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib10", 
+                "date": "2004", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Brown", 
+                            "index": "Brown, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RP Soejono", 
+                            "index": "Soejono, RP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EW Saptomo", 
+                            "index": "Saptomo, EW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Due", 
+                            "index": "Due, RA"
+                        }
+                    }
+                ], 
+                "articleTitle": "A new small-bodied hominin from the Late Pleistocene of Flores, Indonesia", 
+                "journal": "Nature", 
+                "volume": "431", 
+                "pages": {
+                    "first": "1055", 
+                    "last": "1061", 
+                    "range": "1055\u20131061"
+                }, 
+                "doi": "10.1038/nature02999"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib11", 
+                "date": "2011", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Carlson", 
+                            "index": "Carlson, KJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Stout", 
+                            "index": "Stout, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Jashashvili", 
+                            "index": "Jashashvili, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Tafforeau", 
+                            "index": "Tafforeau, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Carlson", 
+                            "index": "Carlson, K"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "The endocast of MH1, <i>Australopithecus sediba</i>", 
+                "journal": "Science", 
+                "volume": "333", 
+                "pages": {
+                    "first": "1402", 
+                    "last": "1407", 
+                    "range": "1402\u20131407"
+                }, 
+                "doi": "10.1126/science.1203922"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib12", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TW Holliday", 
+                            "index": "Holliday, TW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Carlson", 
+                            "index": "Carlson, KJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Jashashvili", 
+                            "index": "Jashashvili, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ME Macias", 
+                            "index": "Macias, ME"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Mathews", 
+                            "index": "Mathews, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TL Sparling", 
+                            "index": "Sparling, TL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "The upper limb of <i>Australopithecus sediba</i>", 
+                "journal": "Science", 
+                "volume": "340", 
+                "pages": "1233477", 
+                "doi": "10.1126/science.1233477"
+            }, 
+            {
+                "type": "book", 
+                "id": "bib13", 
+                "date": "1977", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Clarke", 
+                            "index": "Clarke, RJ"
+                        }
+                    }
+                ], 
+                "bookTitle": "Unpublished PhD dissertation", 
+                "publisher": {
+                    "name": [
+                        "University of the Witwatersrand"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Johannesburg"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Johannesburg"
+                            ]
+                        }
+                    }
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib14", 
+                "date": "2008", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RJ Clarke", 
+                            "index": "Clarke, RJ"
+                        }
+                    }
+                ], 
+                "articleTitle": "Latest information on Sterkfontein's <i>Australopithecus</i> skeleton and a new look at <i>Australopithecus</i>", 
+                "journal": "South African Journal of Science", 
+                "volume": "104", 
+                "pages": {
+                    "first": "443", 
+                    "last": "449", 
+                    "range": "443\u2013449"
+                }, 
+                "doi": "10.1590/S0038-23532008000600015"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib15", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Dembo", 
+                            "index": "Dembo, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Matzke", 
+                            "index": "Matzke, NJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A\u00d8 Mooers", 
+                            "index": "Mooers, A\u00d8"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Collard", 
+                            "index": "Collard, M"
+                        }
+                    }
+                ], 
+                "articleTitle": "Bayesian analysis of a morphological supermatrix sheds light on controversial fossil hominin relationships", 
+                "journal": "Proceedings of the Royal Society B", 
+                "volume": "282", 
+                "pages": "20150943", 
+                "doi": "10.1098/rspb.2015.0943"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib16", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM DeSilva", 
+                            "index": "DeSilva, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KG Holt", 
+                            "index": "Holt, KG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Carlson", 
+                            "index": "Carlson, KJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Walker", 
+                            "index": "Walker, CS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zipfel", 
+                            "index": "Zipfel, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "The lower limb and mechanics of walking in <i>Australopithecus sediba</i>", 
+                "journal": "Science", 
+                "volume": "340", 
+                "pages": "1232999", 
+                "doi": "10.1126/science.1232999"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib17", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PHGM Dirks", 
+                            "index": "Dirks, PHGM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Roberts", 
+                            "index": "Roberts, EM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JD Kramers", 
+                            "index": "Kramers, JD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hawks", 
+                            "index": "Hawks, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PS Randolph-Quinney", 
+                            "index": "Randolph-Quinney, PS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Elliott", 
+                            "index": "Elliott, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Musiba", 
+                            "index": "Musiba, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Backwell", 
+                            "index": "Backwell, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GA Belyanin", 
+                            "index": "Belyanin, GA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Boshoff", 
+                            "index": "Boshoff, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Hunter", 
+                            "index": "Hunter, KL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Feuerriegel", 
+                            "index": "Feuerriegel, EM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Gurtov", 
+                            "index": "Gurtov, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J du G Harrison ", 
+                            "index": "du G Harrison , J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Hunter", 
+                            "index": "Hunter, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kruger", 
+                            "index": "Kruger, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Morris", 
+                            "index": "Morris, H"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TV Makhubela", 
+                            "index": "Makhubela, TV"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Peixotto", 
+                            "index": "Peixotto, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Tucker", 
+                            "index": "Tucker, S"
+                        }
+                    }
+                ], 
+                "articleTitle": "Geological and taphonomic evidence for deliberate body disposal by the primitive hominin species <i>Homo naledi</i> from the Dinaledi Chamber, South Africa", 
+                "journal": "eLife", 
+                "volume": "4", 
+                "pages": "e09651", 
+                "doi": "10.7554/eLife.09561"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib18", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Dom\u00ednguez-Rodrigo", 
+                            "index": "Dom\u00ednguez-Rodrigo, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Pickering", 
+                            "index": "Pickering, TR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Baquedano", 
+                            "index": "Baquedano, E"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Mabulla", 
+                            "index": "Mabulla, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DF Mark", 
+                            "index": "Mark, DF"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Musiba", 
+                            "index": "Musiba, C"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HT Bunn", 
+                            "index": "Bunn, HT"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Uribelarrea", 
+                            "index": "Uribelarrea, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "V Smith", 
+                            "index": "Smith, V"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Diez-Martin", 
+                            "index": "Diez-Martin, F"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A P\u00e9rez-Gonz\u00e1lez", 
+                            "index": "P\u00e9rez-Gonz\u00e1lez, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P S\u00e1nchez", 
+                            "index": "S\u00e1nchez, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Santonja", 
+                            "index": "Santonja, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Barboni", 
+                            "index": "Barboni, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Gidna", 
+                            "index": "Gidna, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Ashley", 
+                            "index": "Ashley, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Yravedra", 
+                            "index": "Yravedra, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Heaton", 
+                            "index": "Heaton, JL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Arriaza", 
+                            "index": "Arriaza, MC"
+                        }
+                    }
+                ], 
+                "articleTitle": "First partial skeleton of a 1.34-million-year-old <i>Paranthropus boisei</i> from Bed II, Olduvai Gorge, Tanzania", 
+                "journal": "PLOS ONE", 
+                "volume": "8", 
+                "pages": "e80347", 
+                "doi": "10.1371/journal.pone.0080347"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib19", 
+                "date": "2005", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS Drapeau", 
+                            "index": "Drapeau, MS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CV Ward", 
+                            "index": "Ward, CV"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kimbel", 
+                            "index": "Kimbel, WH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC Johanson", 
+                            "index": "Johanson, DC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Rak", 
+                            "index": "Rak, Y"
+                        }
+                    }
+                ], 
+                "articleTitle": "Associated cranial and forelimb remains attributed to <i>Australopithecus afarensis</i> from Hadar, Ethiopia", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "48", 
+                "pages": {
+                    "first": "593", 
+                    "last": "642", 
+                    "range": "593\u2013642"
+                }, 
+                "doi": "10.1016/j.jhevol.2005.02.005"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib20", 
+                "date": "2005", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Falk", 
+                            "index": "Falk, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Hildebolt", 
+                            "index": "Hildebolt, C"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Smith", 
+                            "index": "Smith, K"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Brown", 
+                            "index": "Brown, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Jatmiko", 
+                            "index": "Jatmiko"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EW Saptomo", 
+                            "index": "Saptomo, EW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Brunsden", 
+                            "index": "Brunsden, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Prior", 
+                            "index": "Prior, F"
+                        }
+                    }
+                ], 
+                "articleTitle": "The brain of LB1, <i>Homo floresiensis</i>", 
+                "journal": "Science", 
+                "volume": "308", 
+                "pages": {
+                    "first": "242", 
+                    "last": "245", 
+                    "range": "242\u2013245"
+                }, 
+                "doi": "10.1126/science.1109727"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib21", 
+                "date": "1956", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Fully", 
+                            "index": "Fully, G"
+                        }
+                    }
+                ], 
+                "articleTitle": "Une nouvelle m\u00e9thode de d\u00e9termination de la taille", 
+                "journal": "Annales de M\u00e9decine L\u00e9gale, Criminologie, Police Scientifique et Toxicologie", 
+                "volume": "36", 
+                "pages": {
+                    "first": "266", 
+                    "last": "273", 
+                    "range": "266\u2013273"
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib22", 
+                "date": "2000", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Gabunia", 
+                            "index": "Gabunia, L"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Vekua", 
+                            "index": "Vekua, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lordkipanidze", 
+                            "index": "Lordkipanidze, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CC Swisher III", 
+                            "index": "Swisher, CC, III"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Ferring", 
+                            "index": "Ferring, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Justus", 
+                            "index": "Justus, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Nioradze", 
+                            "index": "Nioradze, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Tvalchrelidze", 
+                            "index": "Tvalchrelidze, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Ant\u00f3n", 
+                            "index": "Ant\u00f3n, SC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Bosinski", 
+                            "index": "Bosinski, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O J\u00f6ris", 
+                            "index": "J\u00f6ris, O"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MA Lumley", 
+                            "index": "Lumley, MA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Majsuradze", 
+                            "index": "Majsuradze, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Mouskhelishvili", 
+                            "index": "Mouskhelishvili, A"
+                        }
+                    }
+                ], 
+                "articleTitle": "Earliest Pleistocene hominid cranial remains from Dmanisi, Republic of Georgia: taxonomy, geological setting and age", 
+                "journal": "Science", 
+                "volume": "288", 
+                "pages": {
+                    "first": "1019", 
+                    "last": "1025", 
+                    "range": "1019\u20131025"
+                }, 
+                "doi": "10.1126/science.288.5468.1019"
+            }, 
+            {
+                "type": "book-chapter", 
+                "id": "bib23", 
+                "date": "1988", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HM Grausz", 
+                            "index": "Grausz, HM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Leakey", 
+                            "index": "Leakey, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Walker", 
+                            "index": "Walker, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Ward", 
+                            "index": "Ward, C"
+                        }
+                    }
+                ], 
+                "editors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FE Grine", 
+                            "index": "Grine, FE"
+                        }
+                    }
+                ], 
+                "bookTitle": "Evolutionary history of the \u2018Robust\u2019 Australopithecines", 
+                "publisher": {
+                    "name": [
+                        "Aldine de Gruyter"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "New York"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "New York"
+                            ]
+                        }
+                    }
+                }, 
+                "chapterTitle": "Associated cranial and postcranial bones of <i>Australopithecus boisei</i>", 
+                "pages": {
+                    "first": "127", 
+                    "last": "132", 
+                    "range": "127\u2013132"
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib24", 
+                "date": "1993", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FE Grine", 
+                            "index": "Grine, FE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Demes", 
+                            "index": "Demes, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TM Cole III", 
+                            "index": "Cole, TM, III"
+                        }
+                    }
+                ], 
+                "articleTitle": "Taxonomic affinity of the early <i>Homo</i> cranium from Swartkrans, South Africa", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "92", 
+                "pages": {
+                    "first": "411", 
+                    "last": "426", 
+                    "range": "411\u2013426"
+                }, 
+                "doi": "10.1002/ajpa.1330920402"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib25", 
+                "date": "1995", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FE Grine", 
+                            "index": "Grine, FE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PV Tobias", 
+                            "index": "Tobias, PV"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "OM Pearson", 
+                            "index": "Pearson, OM"
+                        }
+                    }
+                ], 
+                "articleTitle": "Fossil <i>Homo</i> femur from Berg Aukas, northern Namibia", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "97", 
+                "pages": {
+                    "first": "151", 
+                    "last": "185", 
+                    "range": "151\u2013185"
+                }, 
+                "doi": "10.1002/ajpa.1330970207"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib26", 
+                "date": "1996", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FE Grine", 
+                            "index": "Grine, FE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Schultz", 
+                            "index": "Schultz, J"
+                        }
+                    }
+                ], 
+                "articleTitle": "Phenetic affinities among early <i>Homo crania</i> from East and South Africa", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "30", 
+                "pages": "189", 
+                "doi": "10.1006/jhev.1996.0019"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib27", 
+                "date": "2010", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Haile-Selassie", 
+                            "index": "Haile-Selassie, Y"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BM Latimer", 
+                            "index": "Latimer, BM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Alene", 
+                            "index": "Alene, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AL Deino", 
+                            "index": "Deino, AL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Gibert", 
+                            "index": "Gibert, L"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SM Melillo", 
+                            "index": "Melillo, SM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BZ Saylor", 
+                            "index": "Saylor, BZ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GR Scott", 
+                            "index": "Scott, GR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CO Lovejoy", 
+                            "index": "Lovejoy, CO"
+                        }
+                    }
+                ], 
+                "articleTitle": "An early <i>Australopithecus afarensis</i> postcranium from Woranso-Mille, Ethiopia", 
+                "journal": "Proceedings of the National Academy of Sciences of USA", 
+                "volume": "107", 
+                "pages": {
+                    "first": "12121", 
+                    "last": "12126", 
+                    "range": "12121\u201312126"
+                }, 
+                "doi": "10.1073/pnas.1004527107"
+            }, 
+            {
+                "type": "unknown", 
+                "id": "bib28", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WEH Harcourt-Smith", 
+                            "index": "Harcourt-Smith, WEH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Throckmorton", 
+                            "index": "Throckmorton, Z"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KA Congdon", 
+                            "index": "Congdon, KA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zipfel", 
+                            "index": "Zipfel, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Deane", 
+                            "index": "Deane, AS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MSM  Drapeau", 
+                            "index": " Drapeau, MSM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM DeSilva", 
+                            "index": "DeSilva, JM"
+                        }
+                    }
+                ], 
+                "title": "The foot of <i>Homo naledi</i>", 
+                "details": "8432, Nature Communications, 6, 10.1038/ncomms9432"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib29", 
+                "date": "2000", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hawks", 
+                            "index": "Hawks, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Hunley", 
+                            "index": "Hunley, K"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Lee", 
+                            "index": "Lee, SH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Wolpoff", 
+                            "index": "Wolpoff, M"
+                        }
+                    }
+                ], 
+                "articleTitle": "Population bottlenecks and Pleistocene human evolution", 
+                "journal": "Molecular Biology and Evolution", 
+                "volume": "17", 
+                "pages": {
+                    "first": "2", 
+                    "last": "22", 
+                    "range": "2\u201322"
+                }, 
+                "doi": "10.1093/oxfordjournals.molbev.a026233"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib30", 
+                "date": "2012", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TW Holliday", 
+                            "index": "Holliday, TW"
+                        }
+                    }
+                ], 
+                "articleTitle": "Body size, body shape, and the circumscription of the genus <i>Homo</i>", 
+                "journal": "Current Anthropology", 
+                "volume": "53", 
+                "pages": {
+                    "first": "S330", 
+                    "last": "S345", 
+                    "range": "S330\u2013S345"
+                }, 
+                "doi": "10.1086/667360"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib31", 
+                "date": "1986", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC Johanson", 
+                            "index": "Johanson, DC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FT Masao", 
+                            "index": "Masao, FT"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GG Eck", 
+                            "index": "Eck, GG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD White", 
+                            "index": "White, TD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RC Walter", 
+                            "index": "Walter, RC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kimbel", 
+                            "index": "Kimbel, WH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Asfaw", 
+                            "index": "Asfaw, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Manega", 
+                            "index": "Manega, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Ndessokia", 
+                            "index": "Ndessokia, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Suwa", 
+                            "index": "Suwa, G"
+                        }
+                    }
+                ], 
+                "articleTitle": "New partial skeleton of <i>Homo habilis</i> from Olduvai Gorge, Tanzania", 
+                "journal": "Nature", 
+                "volume": "327", 
+                "pages": {
+                    "first": "205", 
+                    "last": "209", 
+                    "range": "205\u2013209"
+                }, 
+                "doi": "10.1038/327205a0"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib32", 
+                "date": "1982", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC Johanson", 
+                            "index": "Johanson, DC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Taieb", 
+                            "index": "Taieb, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Coppens", 
+                            "index": "Coppens, Y"
+                        }
+                    }
+                ], 
+                "articleTitle": "Pliocene hominids from the Hadar formation, Ethiopia (1973\u20131977): Stratigraphic, chronologic, and paleoenvironmental contexts, with notes on hominid morphology and systematics", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "57", 
+                "pages": {
+                    "first": "373", 
+                    "last": "402", 
+                    "range": "373\u2013402"
+                }, 
+                "doi": "10.1002/ajpa.1330570402"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib33", 
+                "date": "2009", 
+                "discriminator": "a", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WE Harcourt-Smith", 
+                            "index": "Harcourt-Smith, WE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RE Wunderlich", 
+                            "index": "Wunderlich, RE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SG Larson", 
+                            "index": "Larson, SG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Due", 
+                            "index": "Due, RA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }
+                ], 
+                "articleTitle": "The foot of <i>Homo floresiensis</i>", 
+                "journal": "Nature", 
+                "volume": "459", 
+                "pages": {
+                    "first": "81", 
+                    "last": "84", 
+                    "range": "81\u201384"
+                }, 
+                "doi": "10.1038/nature07989"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib34", 
+                "date": "2009", 
+                "discriminator": "b", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SG Larson", 
+                            "index": "Larson, SG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Harcourt-Smith", 
+                            "index": "Harcourt-Smith, W"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RD Awe", 
+                            "index": "Awe, RD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Djubiantono", 
+                            "index": "Djubiantono, T"
+                        }
+                    }
+                ], 
+                "articleTitle": "Descriptions of the lower limb skeleton of <i>Homo floresiensis</i>", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "57", 
+                "pages": {
+                    "first": "538", 
+                    "last": "554", 
+                    "range": "538\u2013554"
+                }, 
+                "doi": "10.1016/j.jhevol.2008.08.014"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib35", 
+                "date": "2000", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AW Keyser", 
+                            "index": "Keyser, AW"
+                        }
+                    }
+                ], 
+                "articleTitle": "The Drimolen skull: the most complete australopithecine cranium and mandible to date", 
+                "journal": "South African Journal of Science", 
+                "volume": "96", 
+                "pages": {
+                    "first": "189", 
+                    "last": "192", 
+                    "range": "189\u2013192"
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib36", 
+                "date": "2000", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AW Keyser", 
+                            "index": "Keyser, AW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CG Menter", 
+                            "index": "Menter, CG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JJ Moggi-Cecchi", 
+                            "index": "Moggi-Cecchi, JJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TR Pickering", 
+                            "index": "Pickering, TR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "Drimolen: a new hominin-bearing site in Gauteng, South Africa", 
+                "journal": "South African Journal of Science", 
+                "volume": "96", 
+                "pages": {
+                    "first": "193", 
+                    "last": "197", 
+                    "range": "193\u2013197"
+                }
+            }, 
+            {
+                "type": "book", 
+                "id": "bib37", 
+                "date": "2004", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kimbel", 
+                            "index": "Kimbel, WH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Rak", 
+                            "index": "Rak, Y"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC Johanson", 
+                            "index": "Johanson, DC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Minugh-Purvis", 
+                            "index": "Minugh-Purvis, N"
+                        }
+                    }
+                ], 
+                "bookTitle": "The skull of Australopithecus afarensis", 
+                "publisher": {
+                    "name": [
+                        "Oxford"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "New York"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "New York"
+                            ]
+                        }
+                    }
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib38", 
+                "date": "1997", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kimbel", 
+                            "index": "Kimbel, WH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC Johanson", 
+                            "index": "Johanson, DC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Rak", 
+                            "index": "Rak, Y"
+                        }
+                    }
+                ], 
+                "articleTitle": "Systematic assessment of a maxilla of Homo from Hadar, Ethiopia", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "103", 
+                "pages": {
+                    "first": "235", 
+                    "last": "262", 
+                    "range": "235\u2013262"
+                }, 
+                "doi": "10.1002/(SICI)1096-8644(199706)103:2<235::AID-AJPA8>3.0.CO;2-S"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib39", 
+                "date": "2011", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TL Kivell", 
+                            "index": "Kivell, TL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Kibii", 
+                            "index": "Kibii, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "<i>Australopithecus sediba</i> hand demonstrates mosaic evolution of locomotor and manipulative abilities", 
+                "journal": "Science", 
+                "volume": "333", 
+                "pages": {
+                    "first": "1411", 
+                    "last": "1417", 
+                    "range": "1411\u20131417"
+                }, 
+                "doi": "10.1126/science.1202625"
+            }, 
+            {
+                "type": "unknown", 
+                "id": "bib40", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TL Kivell", 
+                            "index": "Kivell, TL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Deane", 
+                            "index": "Deane, AS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Orr", 
+                            "index": "Orr, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hawks", 
+                            "index": "Hawks, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }
+                ], 
+                "title": "The hand of <i>Homo naledi</i>", 
+                "details": "8431, Nature Communications, 6, 10.1038/ncomms9431"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib41", 
+                "date": "2012", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MG Leakey", 
+                            "index": "Leakey, MG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Spoor", 
+                            "index": "Spoor, F"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Dean", 
+                            "index": "Dean, MC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Feibel", 
+                            "index": "Feibel, CS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Ant\u00f3n", 
+                            "index": "Ant\u00f3n, SC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Kiarie", 
+                            "index": "Kiarie, C"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LN Leakey", 
+                            "index": "Leakey, LN"
+                        }
+                    }
+                ], 
+                "articleTitle": "New fossils from Koobi Fora in northern Kenya confirm taxonomic diversity in early Homo", 
+                "journal": "Nature", 
+                "volume": "488", 
+                "pages": {
+                    "first": "201", 
+                    "last": "204", 
+                    "range": "201\u2013204"
+                }, 
+                "doi": "10.1038/nature11322"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib42", 
+                "date": "2001", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SH Lee", 
+                            "index": "Lee, SH"
+                        }
+                    }
+                ], 
+                "articleTitle": "Assigned resampling method: a new method to estimate size sexual dimorphism in samples of unknown sex", 
+                "journal": "Przegla\u0328d Antropologiczny Anthropological Review", 
+                "volume": "64", 
+                "pages": {
+                    "first": "21", 
+                    "last": "39", 
+                    "range": "21\u201339"
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib43", 
+                "date": "2007", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lordkipanidze", 
+                            "index": "Lordkipanidze, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Jashashvili", 
+                            "index": "Jashashvili, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Vekua", 
+                            "index": "Vekua, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS Ponce de Le\u00f3n", 
+                            "index": "Ponce de Le\u00f3n, MS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CP Zollikofer", 
+                            "index": "Zollikofer, CP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GP Rightmire", 
+                            "index": "Rightmire, GP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Pontzer", 
+                            "index": "Pontzer, H"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Ferring", 
+                            "index": "Ferring, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "O Oms", 
+                            "index": "Oms, O"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Tappen", 
+                            "index": "Tappen, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Bukhsianidze", 
+                            "index": "Bukhsianidze, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Agusti", 
+                            "index": "Agusti, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Kahlke", 
+                            "index": "Kahlke, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Kiladze", 
+                            "index": "Kiladze, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Martinez-Navarro", 
+                            "index": "Martinez-Navarro, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Mouskhelishvili", 
+                            "index": "Mouskhelishvili, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Nioradze", 
+                            "index": "Nioradze, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Rook", 
+                            "index": "Rook, L"
+                        }
+                    }
+                ], 
+                "articleTitle": "Postcranial evidence from early <i>Homo</i> from Dmanisi, Georgia", 
+                "journal": "Nature", 
+                "volume": "449", 
+                "pages": {
+                    "first": "305", 
+                    "last": "310", 
+                    "range": "305\u2013310"
+                }, 
+                "doi": "10.1038/nature06134"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib44", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lordkipanidze", 
+                            "index": "Lordkipanidze, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS Ponce de Le\u00f3n", 
+                            "index": "Ponce de Le\u00f3n, MS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Margvelashvili", 
+                            "index": "Margvelashvili, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Rak", 
+                            "index": "Rak, Y"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GP Rightmire", 
+                            "index": "Rightmire, GP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Vekua", 
+                            "index": "Vekua, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CP Zollikofer", 
+                            "index": "Zollikofer, CP"
+                        }
+                    }
+                ], 
+                "articleTitle": "A complete skull from Dmanisi, Georgia, and the evolutionary biology of early <i>Homo</i>", 
+                "journal": "Science", 
+                "volume": "342", 
+                "pages": {
+                    "first": "326", 
+                    "last": "331", 
+                    "range": "326\u2013331"
+                }, 
+                "doi": "10.1126/science.1238484"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib45", 
+                "date": "2009", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AE McKellar", 
+                            "index": "McKellar, AE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AP Hendry", 
+                            "index": "Hendry, AP"
+                        }
+                    }
+                ], 
+                "articleTitle": "How humans differ from other animals in their levels of morphological variation", 
+                "journal": "PLOS ONE", 
+                "volume": "4", 
+                "pages": "e6876", 
+                "doi": "10.1371/journal.pone.0006876"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib46", 
+                "date": "2005", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Brown", 
+                            "index": "Brown, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EW Saptomo", 
+                            "index": "Saptomo, EW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KE Westaway", 
+                            "index": "Westaway, KE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Due", 
+                            "index": "Due, RA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RG Roberts", 
+                            "index": "Roberts, RG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Maeda", 
+                            "index": "Maeda, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Wasisto", 
+                            "index": "Wasisto, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Djubiantono", 
+                            "index": "Djubiantono, T"
+                        }
+                    }
+                ], 
+                "articleTitle": "Further evidence for small-bodied hominins from the Late Pleistocene of Flores, Indonesia", 
+                "journal": "Nature", 
+                "volume": "437", 
+                "pages": {
+                    "first": "1012", 
+                    "last": "1017", 
+                    "range": "1012\u20131017"
+                }, 
+                "doi": "10.1038/nature04022"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib47", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Orr", 
+                            "index": "Orr, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Burnett", 
+                            "index": "Burnett, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RD Awe", 
+                            "index": "Awe, RD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EW Saptomo", 
+                            "index": "Saptomo, EW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Jatmiko", 
+                            "index": "Jatmiko"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Wasisto", 
+                            "index": "Wasisto, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }
+                ], 
+                "articleTitle": "New wrist bones for <i>Homo floresiensis</i> from liang bua (Flores, Indonesia)", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "64", 
+                "pages": {
+                    "first": "109", 
+                    "last": "129", 
+                    "range": "109\u2013129"
+                }, 
+                "doi": "10.1016/j.jhevol.2012.10.003"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib48", 
+                "date": "2006", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MH Raxter", 
+                            "index": "Raxter, MH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BM Auerbach", 
+                            "index": "Auerbach, BM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CB Ruff", 
+                            "index": "Ruff, CB"
+                        }
+                    }
+                ], 
+                "articleTitle": "Revision of the fully technique for estimating statures", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "130", 
+                "pages": {
+                    "first": "374", 
+                    "last": "384", 
+                    "range": "374\u2013384"
+                }, 
+                "doi": "10.1002/ajpa.20361"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib49", 
+                "date": "2006", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GP Rightmire", 
+                            "index": "Rightmire, GP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lordkipadnize", 
+                            "index": "Lordkipadnize, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Vekua", 
+                            "index": "Vekua, A"
+                        }
+                    }
+                ], 
+                "articleTitle": "Anatomical descriptions, comparative studies and evolutionary significance of the hominin skulls from Dmanisi, Republic of Georgia", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "50", 
+                "pages": {
+                    "first": "115", 
+                    "last": "141", 
+                    "range": "115\u2013141"
+                }, 
+                "doi": "10.1016/j.jhevol.2005.07.009"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib50", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Rolian", 
+                            "index": "Rolian, C"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AD Gordon", 
+                            "index": "Gordon, AD"
+                        }
+                    }
+                ], 
+                "articleTitle": "Reassessing manual proportions in <i>Australopithecus afarensis</i>", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "152", 
+                "pages": {
+                    "first": "393", 
+                    "last": "406", 
+                    "range": "393\u2013406"
+                }, 
+                "doi": "10.1002/ajpa.22365"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib51", 
+                "date": "1997", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CB Ruff", 
+                            "index": "Ruff, CB"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Trinkaus", 
+                            "index": "Trinkaus, E"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TW Holliday", 
+                            "index": "Holliday, TW"
+                        }
+                    }
+                ], 
+                "articleTitle": "Body mass and encephalization in Pleistocene <i>Homo</i>", 
+                "journal": "Nature", 
+                "volume": "387", 
+                "pages": {
+                    "first": "173", 
+                    "last": "176", 
+                    "range": "173\u2013176"
+                }, 
+                "doi": "10.1038/387173a0"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib52", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nalla", 
+                            "index": "Nalla, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Weissen", 
+                            "index": "Weissen, E"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Carlson", 
+                            "index": "Carlson, KJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "Mosaic morphology in the thorax of <i>Australopithecus sediba</i>", 
+                "journal": "Science", 
+                "volume": "340", 
+                "pages": "1234598", 
+                "doi": "10.1126/science.1234598"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib53", 
+                "date": "1993", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Schrenk", 
+                            "index": "Schrenk, F"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TG Bromage", 
+                            "index": "Bromage, TG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CG Betzler", 
+                            "index": "Betzler, CG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "U Ring", 
+                            "index": "Ring, U"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "YM Juwayeyi", 
+                            "index": "Juwayeyi, YM"
+                        }
+                    }
+                ], 
+                "articleTitle": "Oldest <i>Homo</i> and Pliocene biogeography of the Malawi rift", 
+                "journal": "Nature", 
+                "volume": "365", 
+                "pages": {
+                    "first": "833", 
+                    "last": "836", 
+                    "range": "833\u2013836"
+                }, 
+                "doi": "10.1038/365833a0"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib55", 
+                "date": "2007", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Spoor", 
+                            "index": "Spoor, F"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MG Leakey", 
+                            "index": "Leakey, MG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PN Gathogo", 
+                            "index": "Gathogo, PN"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FH Brown", 
+                            "index": "Brown, FH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Ant\u00f3n", 
+                            "index": "Ant\u00f3n, SC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I McDougall", 
+                            "index": "McDougall, I"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Kiarie", 
+                            "index": "Kiarie, C"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FK Manthi", 
+                            "index": "Manthi, FK"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LN Leakey", 
+                            "index": "Leakey, LN"
+                        }
+                    }
+                ], 
+                "articleTitle": "Implications of new early <i>Homo</i> fossils from Ileret, east of Lake Turkana, Kenya", 
+                "journal": "Nature", 
+                "volume": "448", 
+                "pages": {
+                    "first": "688", 
+                    "last": "691", 
+                    "range": "688\u2013691"
+                }, 
+                "doi": "10.1038/nature05986"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib56", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JT Stock", 
+                            "index": "Stock, JT"
+                        }
+                    }
+                ], 
+                "articleTitle": "The skeletal phenotype of \u2018Negritos\u2019 from the Andaman Islands and Philippines relative to global variation among hunter-gatherers", 
+                "journal": "Human Biology", 
+                "volume": "85", 
+                "pages": {
+                    "first": "67", 
+                    "last": "94", 
+                    "range": "67\u201394"
+                }, 
+                "doi": "10.3378/027.085.0304"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib57", 
+                "date": "1988", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RL Susman", 
+                            "index": "Susman, RL"
+                        }
+                    }
+                ], 
+                "articleTitle": "Hand of <i>Paranthropus robustus</i> from Member 1, Swartkrans: fossil evidence for tool behavior", 
+                "journal": "Science", 
+                "volume": "240", 
+                "pages": {
+                    "first": "781", 
+                    "last": "784", 
+                    "range": "781\u2013784"
+                }, 
+                "doi": "10.1126/science.3129783"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib58", 
+                "date": "2001", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RL Susman", 
+                            "index": "Susman, RL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D de Ruiter", 
+                            "index": "de Ruiter, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CK Brain", 
+                            "index": "Brain, CK"
+                        }
+                    }
+                ], 
+                "articleTitle": "Recently identified postcranial remains of <i>Paranthropus</i> and early <i>Homo</i> from Swartkrans Cave, South Africa", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "41", 
+                "pages": {
+                    "first": "607", 
+                    "last": "629", 
+                    "range": "607\u2013629"
+                }, 
+                "doi": "10.1006/jhev.2001.0510"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib59", 
+                "date": "1997", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Suwa", 
+                            "index": "Suwa, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Asfaw", 
+                            "index": "Asfaw, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Beyene", 
+                            "index": "Beyene, Y"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD White", 
+                            "index": "White, TD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Katoh", 
+                            "index": "Katoh, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nagaoka", 
+                            "index": "Nagaoka, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Nakaya", 
+                            "index": "Nakaya, H"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "K Uzawa", 
+                            "index": "Uzawa, K"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Renne", 
+                            "index": "Renne, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G WoldeGabriel", 
+                            "index": "WoldeGabriel, G"
+                        }
+                    }
+                ], 
+                "articleTitle": "The first skull of <i>Australopithecus boisei</i>", 
+                "journal": "Nature", 
+                "volume": "389", 
+                "pages": {
+                    "first": "489", 
+                    "last": "492", 
+                    "range": "489\u2013492"
+                }, 
+                "doi": "10.1038/39037"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib60", 
+                "date": "1996", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Suwa", 
+                            "index": "Suwa, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TD White", 
+                            "index": "White, TD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FC Howell", 
+                            "index": "Howell, FC"
+                        }
+                    }
+                ], 
+                "articleTitle": "Mandibular postcanine dentition from the Shungura formation, Ethiopia: crown morphology, taxonomic allocations, and Plio-Pleistocene hominid evolution", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "101", 
+                "pages": {
+                    "first": "247", 
+                    "last": "282", 
+                    "range": "247\u2013282"
+                }, 
+                "doi": "10.1002/(SICI)1096-8644(199610)101:2<247::AID-AJPA9>3.0.CO;2-Z"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib61", 
+                "date": "2007", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Suwa", 
+                            "index": "Suwa, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Asfaw", 
+                            "index": "Asfaw, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Haile-Selassie", 
+                            "index": "Haile-Selassie, Y"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T White", 
+                            "index": "White, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Katoh", 
+                            "index": "Katoh, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Woldegabriel", 
+                            "index": "Woldegabriel, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WK Hart", 
+                            "index": "Hart, WK"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Nakaya", 
+                            "index": "Nakaya, H"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Beyene", 
+                            "index": "Beyene, Y"
+                        }
+                    }
+                ], 
+                "articleTitle": "Early pleistocene <i>Homo erectus</i> fossils from konso, southern Ethiopia", 
+                "journal": "Anthropological Science", 
+                "volume": "115", 
+                "pages": {
+                    "first": "133", 
+                    "last": "151", 
+                    "range": "133\u2013151"
+                }, 
+                "doi": "10.1537/ase.061203"
+            }, 
+            {
+                "type": "book", 
+                "id": "bib62", 
+                "date": "1967", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PV Tobias", 
+                            "index": "Tobias, PV"
+                        }
+                    }
+                ], 
+                "bookTitle": "The cranium and maxillary dentition of Australopithecus (Zinjanthropus) boisei", 
+                "publisher": {
+                    "name": [
+                        "Cambridge University Press"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Cambridge"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Cambridge"
+                            ]
+                        }
+                    }
+                }
+            }, 
+            {
+                "type": "book", 
+                "id": "bib63", 
+                "date": "1991", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PV Tobias", 
+                            "index": "Tobias, PV"
+                        }
+                    }
+                ], 
+                "bookTitle": "Olduvai Gorge volume 4: the skulls, endocasts and teeth of Homo habilis", 
+                "publisher": {
+                    "name": [
+                        "Cambridge University Press"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Cambridge"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Cambridge"
+                            ]
+                        }
+                    }
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib64", 
+                "date": "2007", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Orr", 
+                            "index": "Orr, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SG Larson", 
+                            "index": "Larson, SG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Sutikna", 
+                            "index": "Sutikna, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Jatmiko", 
+                            "index": "Jatmiko"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EW Saptomo", 
+                            "index": "Saptomo, EW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RA Due", 
+                            "index": "Due, RA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "T Djubiantono", 
+                            "index": "Djubiantono, T"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MJ Morwood", 
+                            "index": "Morwood, MJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WL Jungers", 
+                            "index": "Jungers, WL"
+                        }
+                    }
+                ], 
+                "articleTitle": "The primitive wrist of <i>Homo floresiensis</i> and its implicatiosn for hominin evolution", 
+                "journal": "Science", 
+                "volume": "317", 
+                "pages": {
+                    "first": "1743", 
+                    "last": "1745", 
+                    "range": "1743\u20131745"
+                }, 
+                "doi": "10.1126/science.1147143"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib65", 
+                "date": "2005", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Razdan", 
+                            "index": "Razdan, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RC Williams", 
+                            "index": "Williams, RC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Marzke", 
+                            "index": "Marzke, MW"
+                        }
+                    }
+                ], 
+                "articleTitle": "A 3D quantitative comparison of trapezium and trapezoid relative articular and nonarticular surface areas in modern humans and great apes", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "49", 
+                "pages": {
+                    "first": "570", 
+                    "last": "586", 
+                    "range": "570\u2013586"
+                }, 
+                "doi": "10.1016/j.jhevol.2005.06.005"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib66", 
+                "date": "2002", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Vekua", 
+                            "index": "Vekua, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lordkipanidze", 
+                            "index": "Lordkipanidze, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GP Rightmire", 
+                            "index": "Rightmire, GP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Agusti", 
+                            "index": "Agusti, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Ferring", 
+                            "index": "Ferring, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Maisuradze", 
+                            "index": "Maisuradze, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Mouskhelishvili", 
+                            "index": "Mouskhelishvili, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Nioradze", 
+                            "index": "Nioradze, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MP De Leon", 
+                            "index": "De Leon, MP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Tappen", 
+                            "index": "Tappen, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Tvalchrelidze", 
+                            "index": "Tvalchrelidze, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Zollikofer", 
+                            "index": "Zollikofer, C"
+                        }
+                    }
+                ], 
+                "articleTitle": "A new skull of early <i>Homo</i> from Dmanisi, Georgia", 
+                "journal": "Science", 
+                "volume": "297", 
+                "pages": {
+                    "first": "85", 
+                    "last": "89", 
+                    "range": "85\u201389"
+                }, 
+                "doi": "10.1126/science.1072953"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib67", 
+                "date": "2012", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CV Ward", 
+                            "index": "Ward, CV"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "WH Kimbel", 
+                            "index": "Kimbel, WH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EH Harmon", 
+                            "index": "Harmon, EH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DC Johanson", 
+                            "index": "Johanson, DC"
+                        }
+                    }
+                ], 
+                "articleTitle": "New postcranial fossils of <i>Australopithecus afarensis</i> from hadar, Ethiopia (1990\u20132007)", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "63", 
+                "pages": {
+                    "first": "1", 
+                    "last": "51", 
+                    "range": "1\u201351"
+                }, 
+                "doi": "10.1016/j.jhevol.2011.11.012"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib68", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CV Ward", 
+                            "index": "Ward, CV"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM Plavcan", 
+                            "index": "Plavcan, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "FH Brown", 
+                            "index": "Brown, FH"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Kyalo Manthi", 
+                            "index": "Kyalo Manthi, F"
+                        }
+                    }
+                ], 
+                "articleTitle": "Early Pleistocene third metacarpal from Kenya and the evolution of modern human-like hand morphology", 
+                "journal": "Proceedings of the National Academy of Sciences of USA", 
+                "volume": "111", 
+                "pages": {
+                    "first": "121", 
+                    "last": "124", 
+                    "range": "121\u2013124"
+                }, 
+                "doi": "10.1073/pnas.1316014110"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib69", 
+                "date": "1943", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "F Weidenreich", 
+                            "index": "Weidenreich, F"
+                        }
+                    }
+                ], 
+                "articleTitle": "The skull of <i>Sinanthropus</i>", 
+                "journal": "Palaeontologia Sinica", 
+                "volume": "10", 
+                "pages": "1"
+            }, 
+            {
+                "type": "book", 
+                "id": "bib70", 
+                "date": "1991", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BA Wood", 
+                            "index": "Wood, BA"
+                        }
+                    }
+                ], 
+                "bookTitle": "Koobi Fora research project IV: hominid cranial remains from Koobi Fora", 
+                "publisher": {
+                    "name": [
+                        "Clarendon"
+                    ], 
+                    "address": {
+                        "formatted": [
+                            "Oxford"
+                        ], 
+                        "components": {
+                            "locality": [
+                                "Oxford"
+                            ]
+                        }
+                    }
+                }
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib71", 
+                "date": "1999", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "BA Wood", 
+                            "index": "Wood, BA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Collard", 
+                            "index": "Collard, M"
+                        }
+                    }
+                ], 
+                "articleTitle": "The human genus", 
+                "journal": "Science", 
+                "volume": "284", 
+                "pages": {
+                    "first": "65", 
+                    "last": "71", 
+                    "range": "65\u201371"
+                }, 
+                "doi": "10.1126/science.284.5411.65"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib72", 
+                "date": "2011", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zipfel", 
+                            "index": "Zipfel, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM DeSilva", 
+                            "index": "DeSilva, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RS Kidd", 
+                            "index": "Kidd, RS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KJ Carlson", 
+                            "index": "Carlson, KJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }
+                ], 
+                "articleTitle": "The foot and ankle of <i>Australopithecus sediba</i>", 
+                "journal": "Science", 
+                "volume": "333", 
+                "pages": {
+                    "first": "1417", 
+                    "last": "1420", 
+                    "range": "1417\u20131420"
+                }, 
+                "doi": "10.1126/science.1202703"
+            }
+        ], 
+        "acknowledgements": [
+            {
+                "type": "paragraph", 
+                "text": "The authors would like to thank the many funding agencies that supported various aspects of this work. In particular the authors would like to thank the National Geographic Society, the South African National Research Foundation and the Gauteng Provincial Government for particularly significant funding of the discovery, recovery and analysis of this material. Other funding agencies include and the Palaeontological Scientific Trust, the Texas A&M College of Liberal Arts Seed Grant Program, the Lyda Hill Foundation and the Wisconsin Alumni Research Foundation. We wish to thank the Jacobs Family for access to the site and the South African Heritage Resource Agency and Cradle of Humankind UNESCO World Heritage Site Management Authority for issuing the various permits required for this work, including the excavation permit (PermitID: 952). We would also like to thank the University of the Witwatersrand and the Evolutionary Studies Institute as well as the South African National Centre of Excellence in PalaeoSciences for curating the material and hosting the authors while studying the material."
+            }
+        ], 
+        "decisionLetter": {
+            "doi": "10.7554/eLife.09560.030", 
+            "description": [
+                {
+                    "type": "paragraph", 
+                    "text": "eLife posts the editorial decision letter and author response on a selection of the published articles (subject to the approval of the authors). An edited version of the letter sent to the authors after peer review is shown, indicating the substantive concerns or comments; minor concerns are not usually shown. Reviewers have the opportunity to discuss the decision before the letter is sent (see <a href=\"http://elifesciences.org/review-process\">review process</a>). Similarly, the author response typically shows only responses to the major concerns raised by the reviewers."
+                }
+            ], 
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "Thank you for submitting your work entitled \u201cA new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa\u201d for peer review at <i>eLife.</i> Your submission has been favorably evaluated by Ian Baldwin (Senior editor), two guest Reviewing editors (Johannes Krause and Nicholas Conard), and two peer reviewers. One of the two peer reviewers, Chris Stringer, has agreed to share his identity, and Johannes Krause has drafted this decision to help you prepare a revised submission."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "The authors describe a large collection of recently discovered hominin fossils from the Dinaledi Chamber in the Rising Star cave system in South Africa. Based on their initial assessment they argue that the fossil remains derive from a single homogenous hominin group and present a new taxon that they call <i>Homo naledi</i>."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "Given the importance and sheer number of hominin remains, the fossils from the Dinaledi cave should be described and published imminently. This will allow direct assess to the material to other researchers where appropriate. Besides a general agreement among the reviewers for publication, they ask for several essential revisions."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "1) The reviewers are surprised to not see an in-depth comparison of <i>H. naledi</i> to <i>H. floresiensis</i>, especially where combinations of small teeth and small brains are concerned. It should be easy, e.g., to add the published <i>H. floresiensis</i> measurements to <a href=\"#fig7\">Figure 7</a>. The authors allude to material attributed to <i>\u2018Homo gautengensis\u2019</i> and perhaps a short discussion or reiteration of their views about the validity of that species is needed."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "2) The reviewers would ask the authors to remove superfluous text and concentrate on the main finding and description. This includes the first and last paragraphs. (\u201cOur view of human evolution ... ancient hominins.\u201d) (\u201cDecades of work remain to expand the window into our origins...\u201d) Both do not add any essential information to the manuscript."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "3) The statement that \u201cAt this time, this evidence does not permit us to resolve the relationships between <i>H. naledi</i> and these other species\u201d is rather confusing. Certainly more remains or a direct date would not change that situation; instead in depth morphometric or cladistics analysis are needed to conclude whether the Dinaledi remains indeed represent a new hominin taxon."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "4) The authors should add a summary table of traits, perhaps adapted from the one they previously used for cladistic assessment."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "In addition, please note that Chris Stringer has provided an annotated PDF with minor comments for your consideration."
+                }
+            ]
+        }, 
+        "authorResponse": {
+            "doi": "10.7554/eLife.09560.031", 
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "<i>1) The reviewers are surprised to not see an in-depth comparison of</i> H. naledi <i>to</i> H. floresiensis<i>, especially where combinations of small teeth and small brains are concerned. It should be easy, e.g., to add the published</i> H. floresiensis <i>measurements to</i> <a href=\"#fig7\"><i>Figure 7</i></a><i>. The authors allude to material attributed to</i> \u2018Homo gautengensis\u2019 <i>and perhaps a short discussion or reiteration of their views about the validity of that species is needed</i>."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "We have added <i>H. floresiensis</i> to the differential diagnosis, including relevant aspects of cranial, dental, hand, lower limb and foot anatomy. We have also added <i>H. floresiensis</i> to both relevant figures (<a href=\"#fig5\">Figure 5</a> and <a href=\"#fig7\">Figure 7</a>). We have also made a short comment on the validity of <i>H. gautengensis</i> in the Materials and methods."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "<i>2) The reviewers would ask the authors to remove superfluous text and concentrate on the main finding and description. This includes the first and last paragraphs. (\u201cOur view of human evolution ... ancient hominins.\u201d) (\u201cDecades of work remain to expand the window into our origins...\u201d) Both do not add any essential information to the manuscript</i>."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "We have removed both initial and final paragraphs in their entirety as suggested, and have slightly altered the remaining (second and penultimate) paragraphs to introduce and conclude the paper."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "<i>3) The statement that \u201cAt this time, this evidence does not permit us to resolve the relationships between</i> H. naledi <i>and these other species\u201d is rather confusing. Certainly more remains or a direct date would not change that situation; instead in depth morphometric or cladistics analysis are needed to conclude whether the Dinaledi remains indeed represent a new hominin taxon</i>."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "We have altered this aspect of the Discussion in order to clarify what we can say about the phylogenetic placement of <i>H. naledi</i>. This includes a timely reference to a new paper on the phylogeny of hominins, which allows us to contextualize the difficulty placing the species considering the mosaic of similarities and differences from known hominins."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "<i>4) The authors should add a summary table of traits, perhaps adapted from the one they previously used for cladistic assessment</i>."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "This summary table is now added as <a href=\"#tbl2\">Table 2</a>; the remaining tables have been renumbered accordingly."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "<i>In addition, please note that Chris Stringer has provided an annotated PDF with minor comments for your consideration</i>."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "We have taken on board all of Chris Stringer\u2019s helpful comments and editorial suggestions, and included these additions and corrections in the manuscript. We did not make changes to the following two suggestions/questions for the following reasons:"
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "\u201c<i>Any comment possible on frontal sinus morphologies</i>?\u201d"
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "None are adequately preserved for us to be confident in making descriptive comments at this time."
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "\u201c<i>Anything to say on middle or inner ear morphology</i>?\u201d"
+                }, 
+                {
+                    "type": "paragraph", 
+                    "text": "We are not in a position to comment on inner ear morphology as this is a more detailed and long-term study for which significant comparative material must be assembled."
+                }
+            ]
+        }, 
+        "stage": "published", 
+        "statusDate": "2099-01-01T00:00:00Z"
+    }
+}

--- a/src/publisher/tests/fixtures/ajson/elife-10627-v1.xml.json
+++ b/src/publisher/tests/fixtures/ajson/elife-10627-v1.xml.json
@@ -1,0 +1,1186 @@
+{
+    "journal": {
+        "id": "eLife", 
+        "title": "eLife", 
+        "issn": "2050-084X"
+    }, 
+    "snippet": {
+        "-meta": {
+            "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/2b1a280ca981a56053d1cd399b529c8e1b30ad4e/articles/elife-10627-v1.xml"
+        }, 
+        "status": "vor", 
+        "id": "10627", 
+        "version": 1, 
+        "type": "insight", 
+        "doi": "10.7554/eLife.10627", 
+        "authorLine": "Chris Stringer", 
+        "title": "The many mysteries of <i>Homo naledi</i>", 
+        "titlePrefix": "Human Evolution", 
+        "published": "2015-09-10T00:00:00Z", 
+        "versionDate": "2015-09-10T00:00:00Z", 
+        "volume": 4, 
+        "elocationId": "e10627", 
+        "pdf": "https://cdn.elifesciences.org/articles/10627/elife-10627-v1.pdf", 
+        "subjects": [
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "abstract": {
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "More than 1500 fossils from the Rising Star cave system in South Africa have been assigned to a new human species, <i>Homo naledi</i>, which displays a unique combination of primitive and derived traits throughout the skeleton."
+                }
+            ]
+        }, 
+        "copyright": {
+            "license": "CC-BY-4.0", 
+            "holder": "Stringer", 
+            "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a>, which permits unrestricted use and redistribution provided that the original author and source are credited."
+        }, 
+        "authors": [
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Chris Stringer", 
+                    "index": "Stringer, Chris"
+                }, 
+                "orcid": "0000-0002-9183-7337", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Earth Sciences", 
+                            "Natural History Museum"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "London", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "London"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "c.stringer@nhm.ac.uk"
+                ], 
+                "competingInterests": "<label>Competing interests:</label>The author declares that no competing interests exist."
+            }
+        ]
+    }, 
+    "article": {
+        "-meta": {
+            "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/2b1a280ca981a56053d1cd399b529c8e1b30ad4e/articles/elife-10627-v1.xml", 
+            "patched": true
+        }, 
+        "status": "vor", 
+        "id": "10627", 
+        "version": 1, 
+        "type": "insight", 
+        "doi": "10.7554/eLife.10627", 
+        "authorLine": "Chris Stringer", 
+        "title": "The many mysteries of <i>Homo naledi</i>", 
+        "titlePrefix": "Human Evolution", 
+        "published": "2015-09-10T00:00:00Z", 
+        "versionDate": "2015-09-10T00:00:00Z", 
+        "volume": 4, 
+        "elocationId": "e10627", 
+        "pdf": "https://cdn.elifesciences.org/articles/10627/elife-10627-v1.pdf", 
+        "subjects": [
+            {
+                "id": "genomics-evolutionary-biology", 
+                "name": "Genomics and Evolutionary Biology"
+            }
+        ], 
+        "abstract": {
+            "content": [
+                {
+                    "type": "paragraph", 
+                    "text": "More than 1500 fossils from the Rising Star cave system in South Africa have been assigned to a new human species, <i>Homo naledi</i>, which displays a unique combination of primitive and derived traits throughout the skeleton."
+                }
+            ]
+        }, 
+        "copyright": {
+            "license": "CC-BY-4.0", 
+            "holder": "Stringer", 
+            "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a>, which permits unrestricted use and redistribution provided that the original author and source are credited."
+        }, 
+        "authors": [
+            {
+                "type": "person", 
+                "name": {
+                    "preferred": "Chris Stringer", 
+                    "index": "Stringer, Chris"
+                }, 
+                "orcid": "0000-0002-9183-7337", 
+                "affiliations": [
+                    {
+                        "name": [
+                            "Department of Earth Sciences", 
+                            "Natural History Museum"
+                        ], 
+                        "address": {
+                            "formatted": [
+                                "London", 
+                                "United Kingdom"
+                            ], 
+                            "components": {
+                                "locality": [
+                                    "London"
+                                ], 
+                                "country": "United Kingdom"
+                            }
+                        }
+                    }
+                ], 
+                "emailAddresses": [
+                    "c.stringer@nhm.ac.uk"
+                ], 
+                "competingInterests": "<label>Competing interests:</label>The author declares that no competing interests exist."
+            }
+        ], 
+        "keywords": [
+            "<i>Homo naledi</i>", 
+            "hominin", 
+            "Dinaledi Chamber", 
+            "paleoanthropology", 
+            "taphonomy"
+        ], 
+        "-related-articles-internal": [
+            "09561", 
+            "09560"
+        ], 
+        "-related-articles-external": [], 
+        "body": [
+            {
+                "type": "section", 
+                "id": "s0", 
+                "title": "Main text", 
+                "content": [
+                    {
+                        "type": "paragraph", 
+                        "text": "When the recovery of fossil hominin remains from the Rising Star cave system near Johannesburg in South Africa was widely publicised in 2013 and 2014, I'm sure I wasn't the only one who thought that the coverage had more hype than substance. But now, in two papers in <i>eLife</i>, we can see what the fuss was all about as Lee Berger of the University of the Witwatersrand, Paul Dirks of James Cook University and an international team of colleagues report the discovery of more than 1500 fossils that represent at least 15 individuals (<a href=\"#bib2\">Berger et al., 2015</a>; <a href=\"#bib5\">Dirks et al., 2015</a>). These remains have now been assigned to a new human species, which has been named <i>Homo naledi</i>. However, despite the wealth of information about the physical characteristics of <i>H. naledi</i> that this collection provides, many mysteries remain. How old are the fossils? Where does <i>H. naledi</i> fit in the scheme of human evolution? And how did the remains arrive deep within the cave system?"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "In the first paper, Berger et al. describe how the collection displays a unique combination of primitive and derived characteristics (<a href=\"#bib2\">Berger et al., 2015</a>). For example, the small brain size, curved fingers and form of the shoulder, trunk and hip joint resemble the prehuman australopithecines and the early human species <i>Homo habilis</i>. Yet the wrist, hands, legs and feet look most like those of Neanderthals and modern humans. The teeth have some primitive features (such as increasing in size towards the back of the tooth row), but they are relatively small and simple, and set in lightly built jawbones (<a href=\"#fig1\">Figure 1</a>). Overall, to my eye, the material looks most similar to the small-bodied examples of <i>Homo erectus</i> from Dmanisi in Georgia, which have been dated at \u223c1.8 million years old (<a href=\"#bib8\">Lordkipanidze et al., 2013</a>). However, the rich <i>H. naledi</i> sample includes bones that are poorly known in other early humans species such as <i>Homo rudolfensis,</i> <i>H. habilis</i> and <i>H. erectus</i>, so it is difficult at the moment to assess how similar these species were throughout the skeleton."
+                    }, 
+                    {
+                        "type": "figure", 
+                        "assets": [
+                            {
+                                "type": "image", 
+                                "id": "fig1", 
+                                "label": "Figure 1", 
+                                "title": "Comparison of skull features of <i>Homo naledi</i> and other early human species.", 
+                                "caption": [
+                                    {
+                                        "type": "paragraph", 
+                                        "text": "Replica crania of (left to right) <i>Homo habilis</i> (KNM-ER 1813, Koobi Fora, Kenya \u223c1.8 million years old), an early <i>Homo erectus</i> (D2700, Dmanisi, Georgia \u223c1.8 million years old) and <i>Homo floresiensis</i> (Liang Bua 1, Indonesia \u223c20,000 years old) are compared with actual fragments of cranial material of <i>H. naledi</i> that have been overlaid on a virtual reconstruction (far right; note some of the images of <i>H. naledi</i> material have been reversed). In each case, the crania are labelled with the typical features of each species. For example, while the adult brain volume of modern humans (<i>Homo sapiens</i>) is typically between 1000 and 1500 cubic centimetres (cc), <i>H. habilis</i> ranged from about 510 to &gt;700 cc, <i>H. erectus</i> from about 550 to &gt;1100 cc, <i>H. floresiensis</i> about 426 cc, and <i>H. naledi</i> between 466 and 560 cc. Furthermore, in modern humans, the occipital bone (at the back of the skull) is typically evenly rounded in profile, whereas in some early humans such as <i>H. erectus</i>, the upper and lower portions of the occipital are sharply angled to each other (i.e., \u2018flexed\u2019), and there is a strong ridge of bone running across the angulated region (called a transverse torus)."
+                                    }
+                                ], 
+                                "image": {
+                                    "source": {
+                                        "mediaType": "image/jpeg", 
+                                        "uri": "https://iiif.elifesciences.org/lax:10627/elife-10627-fig1-v1.tif/full/full/0/default.jpg", 
+                                        "filename": "elife-10627-fig1-v1.jpg"
+                                    }, 
+                                    "alt": "", 
+                                    "uri": "https://iiif.elifesciences.org/lax:10627/elife-10627-fig1-v1.tif", 
+                                    "size": {
+                                        "width": 4473, 
+                                        "height": 2241
+                                    }
+                                }
+                            }
+                        ]
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "If <i>H. naledi</i> is more than 2 million years old, which Berger et al. suggest could be possible, the species might lie close to the very origin of the genus <i>Homo</i>. However, if the <i>H. naledi</i> fossils are less than 100,000 years old, it would mean that it survived until relatively recently, just like <i>Homo floresiensis</i> far away in Indonesia (another species which combines a small brain with small teeth; <a href=\"#bib12\">Stringer, 2014</a>). Because <i>H. naledi</i> is currently only known from one site, it is unclear whether or not it was restricted to southern Africa. If it turns out that <i>H. naledi</i> was more widespread, its moderate body size may lead scientists to re-examine other diminutive fossils from across Africa, which have usually been attributed to a small form of <i>H. erectus</i> (<a href=\"#bib1\">Ant\u00f3n, 2004</a>; <a href=\"#bib10\">Potts et al., 2004</a>; <a href=\"#bib11\">Simpson et al., 2008</a>)."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "In the second paper, Dirks, Berger and colleagues describe the setting of the fossils: the Dinaledi Chamber (<a href=\"#bib5\">Dirks et al., 2015</a>). This cave chamber lies some 80 metres into the Rising Star system, and must have always been in constant darkness. This closely parallels the circumstances of a famous accumulation of \u223c6500 human fossils in the Sima de los Huesos (\u2018Pit of the Bones\u2019) in the Sierra de Atapuerca in Spain. In both cases, there is no associated evidence of human occupation. However, unlike the Dinaledi Chamber, the Sima did contain material from other large mammals. Moreover, the Atapuerca team also recovered numerous bones of the hands, feet and spine that could be articulated (or connected back together as they were in life). This led them to propose that the remains of at least 28 early Neanderthals had been intentionally thrown down into the pit, where the bodies decayed (<a href=\"#bib3\">Carbonell and Mosquera, 2006</a>). After considering the alternative explanations, ranging from whether <i>H. naledi</i> occupied the caves to whether the bodies were left there by predators, Dirks et al. favour a similar scenario to that proposed for the Sima. However, they also recognise that the intentional disposal of the dead bodies is a surprisingly complex behaviour for a creature with a brain no bigger than that of <i>H. habilis</i> or a gorilla"
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Frustratingly, the rich and informative <i>H. naledi</i> material remains undated. Given that this hominin material could conceivably even date within the last 100,000 years, I am puzzled by the apparent lack of attempts to estimate its age. This could have been achieved directly via radiocarbon dating (even if only to test whether the material lies beyond the effective range of that method) or indirectly based on ancient DNA samples. For example, after ancient DNA was successfully recovered from the Sima de los Huesos fossils, it was used to date them to about 400,000 years old (<a href=\"#bib9\">Meyer et al., 2014</a>). Moreover, tests on even small fragments of bone and tooth enamel could have narrowed down the possible age range and at least ruled out either a very ancient or very young age (<a href=\"#bib6\">Gr\u00fcn, 2006</a>)."
+                    }, 
+                    {
+                        "type": "paragraph", 
+                        "text": "Even without date information, the mosaic nature of the <i>H. naledi</i> skeletons provides yet another indication that the genus <i>Homo</i> had complex origins. The individual mix of primitive and derived characteristics in different fossils perhaps even indicates that the genus <i>Homo</i> might be \u2018polyphyletic\u2019: in other words, some members of the genus might have originated independently in different regions of Africa. If this is the case, it would mean that the species currently placed within the genus <i>Homo</i> would need to be reassessed (<a href=\"#bib4\">Dembo et al., 2015</a>; <a href=\"#bib7\">Hublin, 2015</a>). While many have concentrated on East Africa as the key and perhaps sole region for the origins of the genus <i>Homo</i>, the continuing surprises emerging from further south remind us that Africa is a huge continent that even now is largely unexplored for its early human fossils."
+                    }
+                ]
+            }
+        ], 
+        "references": [
+            {
+                "type": "journal", 
+                "id": "bib1", 
+                "date": "2004", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SC Ant\u00f3n", 
+                            "index": "Ant\u00f3n, SC"
+                        }
+                    }
+                ], 
+                "articleTitle": "The face of Olduvai hominid 12", 
+                "journal": "Journal of Human Evolution", 
+                "volume": "46", 
+                "pages": {
+                    "first": "335", 
+                    "last": "345", 
+                    "range": "335\u2013345"
+                }, 
+                "doi": "10.1016/j.jhevol.2003.12.005"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib2", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Berger", 
+                            "index": "Berger, L"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hawks", 
+                            "index": "Hawks, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LK Delezene", 
+                            "index": "Delezene, LK"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TL Kivell", 
+                            "index": "Kivell, TL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "HM Garvin", 
+                            "index": "Garvin, HM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SA Williams", 
+                            "index": "Williams, SA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM DeSilva", 
+                            "index": "DeSilva, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MM Skinner", 
+                            "index": "Skinner, MM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Musiba", 
+                            "index": "Musiba, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "N Cameron", 
+                            "index": "Cameron, N"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TW Holliday", 
+                            "index": "Holliday, TW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "W Harcourt-Smith", 
+                            "index": "Harcourt-Smith, W"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "RR Ackermann", 
+                            "index": "Ackermann, RR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Bastir", 
+                            "index": "Bastir, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Bogin", 
+                            "index": "Bogin, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Bolter", 
+                            "index": "Bolter, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Brophy", 
+                            "index": "Brophy, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "ZD Cofran", 
+                            "index": "Cofran, ZD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KA Congdon", 
+                            "index": "Congdon, KA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AS Deane", 
+                            "index": "Deane, AS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Dembo", 
+                            "index": "Dembo, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Drapeau", 
+                            "index": "Drapeau, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MC Elliott", 
+                            "index": "Elliott, MC"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Feuerriegel", 
+                            "index": "Feuerriegel, EM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Garcia-Martinez", 
+                            "index": "Garcia-Martinez, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ Green", 
+                            "index": "Green, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Gurtov", 
+                            "index": "Gurtov, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JD Irish", 
+                            "index": "Irish, JD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kruger", 
+                            "index": "Kruger, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MF Laird", 
+                            "index": "Laird, MF"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Marchi", 
+                            "index": "Marchi, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MR Meyer", 
+                            "index": "Meyer, MR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Nalla", 
+                            "index": "Nalla, S"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EW Negash", 
+                            "index": "Negash, EW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Orr", 
+                            "index": "Orr, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Radovcic", 
+                            "index": "Radovcic, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "L Schroeder", 
+                            "index": "Schroeder, L"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JE Scott", 
+                            "index": "Scott, JE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Z Throckmorton", 
+                            "index": "Throckmorton, Z"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MW Tocheri", 
+                            "index": "Tocheri, MW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C VanSickle", 
+                            "index": "VanSickle, C"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CS Walker", 
+                            "index": "Walker, CS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Wei", 
+                            "index": "Wei, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Zipfel", 
+                            "index": "Zipfel, B"
+                        }
+                    }
+                ], 
+                "articleTitle": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa", 
+                "journal": "eLife", 
+                "volume": "4", 
+                "pages": "e09560", 
+                "doi": "10.7554/eLife.09560"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib3", 
+                "date": "2006", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Carbonell", 
+                            "index": "Carbonell, E"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Mosquera", 
+                            "index": "Mosquera, M"
+                        }
+                    }
+                ], 
+                "articleTitle": "The emergence of a symbolic behaviour: the sepulchral pit of Sima de los Huesos, Sierra de Atapuerca, Burgos, Spain", 
+                "journal": "Comptes Rendus Pal\u00e9vol", 
+                "volume": "5", 
+                "pages": {
+                    "first": "155", 
+                    "last": "160", 
+                    "range": "155\u2013160"
+                }, 
+                "doi": "10.1016/j.crpv.2005.11.010"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib4", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Dembo", 
+                            "index": "Dembo, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NJ Matzke", 
+                            "index": "Matzke, NJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A\u00d8 Mooers", 
+                            "index": "Mooers, A\u00d8"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Collard", 
+                            "index": "Collard, M"
+                        }
+                    }
+                ], 
+                "articleTitle": "Bayesian analysis of a morphological supermatrix sheds light on controversial fossil hominin relationships", 
+                "journal": "Proceedings of the Royal Society B", 
+                "volume": "282", 
+                "pages": "20150943", 
+                "doi": "10.1098/rspb.2015.0943"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib5", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PHGM Dirks", 
+                            "index": "Dirks, PHGM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Berger", 
+                            "index": "Berger, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Roberts", 
+                            "index": "Roberts, EM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JD Kramers", 
+                            "index": "Kramers, JD"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Hawks", 
+                            "index": "Hawks, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "PS Randolph-Quinney", 
+                            "index": "Randolph-Quinney, PS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Elliott", 
+                            "index": "Elliott, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CM Musiba", 
+                            "index": "Musiba, CM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SE Churchill", 
+                            "index": "Churchill, SE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "DJ de Ruiter", 
+                            "index": "de Ruiter, DJ"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Schmid", 
+                            "index": "Schmid, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "LR Backwell", 
+                            "index": "Backwell, LR"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GA Belyanin", 
+                            "index": "Belyanin, GA"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Boshoff", 
+                            "index": "Boshoff, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "KL Hunter", 
+                            "index": "Hunter, KL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "EM Feuerriegel", 
+                            "index": "Feuerriegel, EM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Gurtov", 
+                            "index": "Gurtov, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JG Harrison", 
+                            "index": "Harrison, JG"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Hunter", 
+                            "index": "Hunter, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Kruger", 
+                            "index": "Kruger, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "H Morris", 
+                            "index": "Morris, H"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "TV Makhubela", 
+                            "index": "Makhubela, TV"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Peixotto", 
+                            "index": "Peixotto, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Tucker", 
+                            "index": "Tucker, S"
+                        }
+                    }
+                ], 
+                "articleTitle": "Geological and taphonomic context for the new hominin species <i>Homo naled</i>i from the Dinaledi Chamber, South Africa", 
+                "journal": "eLife", 
+                "volume": "4", 
+                "pages": "e09561", 
+                "doi": "10.7554/eLife.09561"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib6", 
+                "date": "2006", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Gr\u00fcn", 
+                            "index": "Gr\u00fcn, R"
+                        }
+                    }
+                ], 
+                "articleTitle": "Direct dating of human fossils", 
+                "journal": "American Journal of Physical Anthropology", 
+                "volume": "131", 
+                "pages": {
+                    "first": "2", 
+                    "last": "48", 
+                    "range": "2\u201348"
+                }, 
+                "doi": "10.1002/ajpa.20516"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib7", 
+                "date": "2015", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JJ Hublin", 
+                            "index": "Hublin, JJ"
+                        }
+                    }
+                ], 
+                "articleTitle": "Paleoanthropology: How old is the oldest human?", 
+                "journal": "Current Biology", 
+                "volume": "25", 
+                "pages": {
+                    "first": "R453", 
+                    "last": "R455", 
+                    "range": "R453\u2013R455"
+                }, 
+                "doi": "10.1016/j.cub.2015.04.009"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib8", 
+                "date": "2013", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "D Lordkipanidze", 
+                            "index": "Lordkipanidze, D"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "MS de Le\u00f3n", 
+                            "index": "de Le\u00f3n, MS"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Margvelashvili", 
+                            "index": "Margvelashvili, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Y Rak", 
+                            "index": "Rak, Y"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "GP Rightmire", 
+                            "index": "Rightmire, GP"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Vekua", 
+                            "index": "Vekua, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "CP Zollikofer", 
+                            "index": "Zollikofer, CP"
+                        }
+                    }
+                ], 
+                "articleTitle": "A complete skull from Dmanisi, Georgia, and the evolutionary biology of early <i>Homo</i>", 
+                "journal": "Science", 
+                "volume": "342", 
+                "pages": {
+                    "first": "326", 
+                    "last": "331", 
+                    "range": "326\u2013331"
+                }, 
+                "doi": "10.1126/science.1238484"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib9", 
+                "date": "2014", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Meyer", 
+                            "index": "Meyer, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "Q Fu", 
+                            "index": "Fu, Q"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Aximu-Petri", 
+                            "index": "Aximu-Petri, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Glocke", 
+                            "index": "Glocke, I"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "B Nickel", 
+                            "index": "Nickel, B"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JL Arsuaga", 
+                            "index": "Arsuaga, JL"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "I Mart\u00ednez", 
+                            "index": "Mart\u00ednez, I"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Gracia", 
+                            "index": "Gracia, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "JM de Castro", 
+                            "index": "de Castro, JM"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "E Carbonell", 
+                            "index": "Carbonell, E"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S P\u00e4\u00e4bo", 
+                            "index": "P\u00e4\u00e4bo, S"
+                        }
+                    }
+                ], 
+                "articleTitle": "A mitochondrial genome sequence of a hominin from Sima de los Huesos", 
+                "journal": "Nature", 
+                "volume": "505", 
+                "pages": {
+                    "first": "403", 
+                    "last": "406", 
+                    "range": "403\u2013406"
+                }, 
+                "doi": "10.1038/nature12788"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib10", 
+                "date": "2004", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Potts", 
+                            "index": "Potts, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "AK Behrensmeyer", 
+                            "index": "Behrensmeyer, AK"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "A Deino", 
+                            "index": "Deino, A"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "P Ditchfield", 
+                            "index": "Ditchfield, P"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Clark", 
+                            "index": "Clark, J"
+                        }
+                    }
+                ], 
+                "articleTitle": "Small mid-Pleistocene hominin associated with East African Acheulean technology", 
+                "journal": "Science", 
+                "volume": "305", 
+                "pages": {
+                    "first": "75", 
+                    "last": "78", 
+                    "range": "75\u201378"
+                }, 
+                "doi": "10.1126/science.1097661"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib11", 
+                "date": "2008", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "SW Simpson", 
+                            "index": "Simpson, SW"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "J Quade", 
+                            "index": "Quade, J"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "NE Levin", 
+                            "index": "Levin, NE"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "R Butler", 
+                            "index": "Butler, R"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "G Dupont-Nivet", 
+                            "index": "Dupont-Nivet, G"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "M Everett", 
+                            "index": "Everett, M"
+                        }
+                    }, 
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "S Semaw", 
+                            "index": "Semaw, S"
+                        }
+                    }
+                ], 
+                "articleTitle": "A female <i>Homo erectus</i> pelvis from Gona, Ethiopia", 
+                "journal": "Science", 
+                "volume": "322", 
+                "pages": {
+                    "first": "1089", 
+                    "last": "1092", 
+                    "range": "1089\u20131092"
+                }, 
+                "doi": "10.1126/science.1163592"
+            }, 
+            {
+                "type": "journal", 
+                "id": "bib12", 
+                "date": "2014", 
+                "authors": [
+                    {
+                        "type": "person", 
+                        "name": {
+                            "preferred": "C Stringer", 
+                            "index": "Stringer, C"
+                        }
+                    }
+                ], 
+                "articleTitle": "Human evolution: Small remains still pose big problems", 
+                "journal": "Nature", 
+                "volume": "514", 
+                "pages": {
+                    "first": "427", 
+                    "last": "429", 
+                    "range": "427\u2013429"
+                }, 
+                "doi": "10.1038/514427a"
+            }
+        ], 
+        "stage": "published", 
+        "statusDate": "2099-01-01T00:00:00Z"
+    }
+}

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -12,6 +12,7 @@ from jsonschema.exceptions import ValidationError
 from publisher import logic
 from django.test import Client, override_settings
 from django.core.urlresolvers import reverse
+from unittest.mock import patch, MagicMock
 
 class Ingest(BaseCase):
     def setUp(self):
@@ -24,6 +25,8 @@ class Ingest(BaseCase):
         f3 = join(self.fixture_dir, 'ajson', 'elife-01968-v1.xml.json')
         self.invalid_ajson = self.load_ajson(f3)
         self.invalid_ajson['article']['title'] = '' # ha! my invalid json is now valid. make it explicitly invalid.
+
+        self.commits = 0
 
     def tearDown(self):
         pass
@@ -237,6 +240,41 @@ class Ingest(BaseCase):
         av = self.freshen(av)
         self.assertEqual(av.article_json_v1, None)
         self.assertEqual(av.article_json_v1_snippet, None)
+
+    @patch('publisher.ajson_ingestor.transaction')
+    @patch('publisher.ajson_ingestor.aws_events')
+    def test_events(self, aws_events, transaction):
+        aws_events.notify = MagicMock()
+        transaction.on_commit = MagicMock()
+
+        # has 2 related
+        self.with_related_explicit = self.load_ajson(join(self.fixture_dir, 'ajson', 'elife-10627-v1.xml.json'), strip_relations=False)
+        ajson_ingestor.ingest(self.with_related_explicit)
+        self._apply(transaction)
+        self.assertEqual(len(aws_events.notify.mock_calls), 3)
+        self.assertEqual(self._event(aws_events, 0), 10627)
+        self.assertEqual(self._event(aws_events, 1), 9561) # linked by 10627
+        self.assertEqual(self._event(aws_events, 2), 9560) # linked by 10627
+
+        # has 1 related, but it's also pointed at by 10627
+        self.with_related_pointing_at_it = self.load_ajson(join(self.fixture_dir, 'ajson', 'elife-09560-v1.xml.json'), strip_relations=False)
+        ajson_ingestor.ingest(self.with_related_pointing_at_it)
+        self._apply(transaction)
+        self.assertEqual(len(aws_events.notify.mock_calls), 3 + 3)
+        self.assertEqual(self._event(aws_events, 3), 9560)
+        self.assertEqual(self._event(aws_events, 4), 10627) # links to 9560
+        self.assertEqual(self._event(aws_events, 5), 9561) # linked by 9560
+
+    def _apply(self, transaction):
+        self.assertEqual(len(transaction.on_commit.mock_calls), self.commits + 1)
+        (on_commit, ) = transaction.on_commit.mock_calls[self.commits][1]
+        on_commit()
+        self.commits = self.commits + 1
+
+    def _event(self, aws_events, index):
+        args = 1
+        first_arg = 0
+        return aws_events.notify.mock_calls[index][args][first_arg].manuscript_id
 
 
 class Publish(BaseCase):

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -25,8 +25,6 @@ class Ingest(BaseCase):
         self.invalid_ajson = self.load_ajson(f3)
         self.invalid_ajson['article']['title'] = '' # ha! my invalid json is now valid. make it explicitly invalid.
 
-        self.commits = 0
-
     def tearDown(self):
         pass
 

--- a/src/publisher/tests/test_events.py
+++ b/src/publisher/tests/test_events.py
@@ -1,7 +1,7 @@
 from . import base
 from os.path import join
 from publisher import models, ajson_ingestor
-from unittest.mock import patch  # , MagicMock
+from unittest.mock import patch
 
 class One(base.BaseCase):
     def setUp(self):

--- a/src/publisher/tests/test_events.py
+++ b/src/publisher/tests/test_events.py
@@ -1,8 +1,9 @@
-from .base import BaseCase
+from . import base
 from os.path import join
 from publisher import models, ajson_ingestor
+from unittest.mock import patch  # , MagicMock
 
-class One(BaseCase):
+class One(base.BaseCase):
     def setUp(self):
         f1 = join(self.fixture_dir, 'ajson', 'elife-01968-v1.xml.json')
         self.without_history = self.load_ajson(f1)
@@ -53,3 +54,56 @@ class One(BaseCase):
         ajson_ingestor.ingest(self.without_history)
         ael = models.ArticleEvent.objects.all()
         self.assertEqual(ael.count(), len(expected_events))
+
+
+class Two(base.TransactionBaseCase):
+    def setUp(self):
+        self.f1 = join(self.fixture_dir, 'ajson', 'elife-10627-v1.xml.json')
+        self.ajson1 = self.load_ajson(self.f1, strip_relations=False)
+
+        self.f2 = join(self.fixture_dir, 'ajson', 'elife-09560-v1.xml.json')
+        self.ajson2 = self.load_ajson(self.f2, strip_relations=False)
+
+        self.commits = 0
+
+    def tearDown(self):
+        pass
+
+    @patch('publisher.ajson_ingestor.aws_events.notify')
+    def test_related_events(self, notify_mock):
+        "aws_events.notify is called once for the article being ingested and once each for related articles"
+
+        ajson_ingestor.ingest(self.ajson1) # has 2 related
+
+        def event_msid(index):
+            args, first_arg = 1, 0
+            return notify_mock.mock_calls[index][args][first_arg].manuscript_id
+
+        # 10627 has two relations, 9561 and 9560
+        # ensure `notify` called once for each article
+        self.assertEqual(len(notify_mock.mock_calls), 3)
+
+        # ensure the events have the right manuscript id
+        self.assertEqual(event_msid(1), 9561)
+        self.assertEqual(event_msid(2), 9560)
+
+    def test_related_events2(self):
+        """aws_events.notify is called once for the article being ingested and once
+        each for related articles, including reverse relations"""
+
+        ajson_ingestor.ingest(self.ajson1) # has 2 related, 9561 and 9560
+
+        with patch('publisher.ajson_ingestor.aws_events.notify') as notify_mock:
+
+            def event_msid(index):
+                args, first_arg = 1, 0
+                return notify_mock.mock_calls[index][args][first_arg].manuscript_id
+
+            ajson_ingestor.ingest(self.ajson2) # has 2 related, 10627, 9561
+
+            self.assertEqual(len(notify_mock.mock_calls), 3)
+
+            # ensure the events have the right manuscript id
+            self.assertEqual(event_msid(0), 9560)
+            self.assertEqual(event_msid(1), 10627) # links to 9560
+            self.assertEqual(event_msid(2), 9561) # linked by 9560


### PR DESCRIPTION
Relations are explicitly passed in, while in these tests they are normally removed. We add events for the related articles to be sent together with the main one being ingested/published, even if the related articles are stubs.

Two new fixtures are introduce, related Homo Naledi articles.