### PR TITLE
Do not use message key in log_context

### DIFF
--- a/src/publisher/management/commands/ingest.py
+++ b/src/publisher/management/commands/ingest.py
@@ -82,6 +82,9 @@ def success(print_queue, action, av, force, dry_run, log_context):
         ('message', None),
     ])
     log_context.update(struct)
+    # if a 'message' key is present, we need to remove it to avoid
+    #     KeyError: "Attempt to overwrite 'message' in LogRecord"
+    log_context.pop('message')
     LOG.info("successfully %s article %s", status, log_context['msid'], extra=log_context)
     write(print_queue, struct)
     clean_up(print_queue)


### PR DESCRIPTION
Attempts to solve https://ci--alfred.elifesciences.org/job/test-lax/442/consoleFull
```
ERROR - unhandled exception!
Traceback (most recent call last):
  File "/srv/lax/src/publisher/management/commands/ingest.py", line 136, in handle_single
    success(print_queue, action, av, force, dry_run, log_context)
  File "/srv/lax/src/publisher/management/commands/ingest.py", line 85, in success
    LOG.info("successfully %s article %s", status, log_context['msid'], extra=log_context)
  File "/usr/lib/python3.5/logging/__init__.py", line 1279, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.5/logging/__init__.py", line 1414, in _log
    exc_info, func, extra, sinfo)
  File "/usr/lib/python3.5/logging/__init__.py", line 1388, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'message' in LogRecord"
```