### PR TITLE
Transforms defer() into a CallBatch class

### DIFF
--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -199,7 +199,7 @@ def add_fragment_update_article(art, key, fragment):
         ensure(created or updated, "fragment was not created/updated")
 
         # notify event bus that article change has occurred
-        transaction.on_commit(partial(aws_events.notify, art))
+        transaction.on_commit(partial(aws_events.BATCH.notify, art))
 
         return set_all_article_json(art, quiet=False)
 
@@ -210,7 +210,7 @@ def delete_fragment_update_article(art, key):
         models.ArticleFragment.objects.get(article=art, type=key, version=None).delete()
 
         # notify event bus that article change has occurred
-        transaction.on_commit(partial(aws_events.notify, art))
+        transaction.on_commit(partial(aws_events.BATCH.notify, art))
 
         return set_all_article_json(art, quiet=False)
 

--- a/src/publisher/tests/test_events.py
+++ b/src/publisher/tests/test_events.py
@@ -67,7 +67,7 @@ class Two(base.TransactionBaseCase):
     def tearDown(self):
         pass
 
-    @patch('publisher.ajson_ingestor.aws_events.notify')
+    @patch('publisher.ajson_ingestor.aws_events.BATCH.notify')
     def test_related_events(self, notify_mock):
         "aws_events.notify is called once for the article being ingested and once each for related articles"
 
@@ -92,7 +92,7 @@ class Two(base.TransactionBaseCase):
 
         ajson_ingestor.ingest(self.ajson1) # has 2 related, 9561 and 9560
 
-        with patch('publisher.ajson_ingestor.aws_events.notify') as notify_mock:
+        with patch('publisher.ajson_ingestor.aws_events.BATCH.notify') as notify_mock:
 
             def event_msid(index):
                 args, first_arg = 1, 0


### PR DESCRIPTION
From global state to object state (although the object is still in a global variable due to the difficulty of injecting it only where it is used).