### PR TITLE
uses native python3 virtualenv to create virtualenv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,30 +4,26 @@ echo "[-] install.sh"
 
 . download-api-raml.sh
 
-# use the latest version of python3 we can find. 
-# on Ubuntu14.04 the stable version is 3.3, the max we can install is 3.6
-
-# ll: /usr/bin/python3.6
-#maxpy=$(which /usr/bin/python3* | grep -E '[0-9]$' | sort -r | head -n 1)
-maxpy=/usr/bin/python3.5
-
-# ll: python3.6
-# http://stackoverflow.com/questions/2664740/extract-file-basename-without-path-and-extension-in-bash
-py=${maxpy##*/} # magic
+python=/usr/bin/python3.5
+py=${python##*/} # ll: python3.5
 
 # check for exact version of python3
 if [ ! -e "venv/bin/$py" ]; then
     echo "could not find venv/bin/$py, recreating venv"
     rm -rf venv
-    virtualenv --python="$maxpy" venv
+    $python -m venv venv
 fi
+
 source venv/bin/activate
+
 if [ ! -e app.cfg ]; then
     echo "* no app.cfg found! using the example settings (elife.cfg) by default."
     ln -s elife.cfg app.cfg
 fi
+
 pip install -r requirements.txt
 NEW_RELIC_EXTENSIONS=false pip install --no-binary :all: newrelic==2.82.0.62
+
 python src/manage.py migrate --no-input
 
 echo "[✓] install.sh"


### PR DESCRIPTION
all python3 apps should use the native virtualenv to create a virtualenv.

`virtualenv` will still be available for any python2 apps in 16.04 but should be considered deprecated. python2 is approaching EOL too. 