### PR TITLE
Ignoring ip address in authentication

### DIFF
--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from netaddr import IPAddress, IPNetwork
 import logging
 from django.utils.deprecation import MiddlewareMixin
 
@@ -36,15 +35,6 @@ class KongAuthentication(MiddlewareMixin):
                 strip_auth_headers(request)
                 return
             headers[header] = str(request.META[header])
-
-        # if request not originating from within vpn, strip auth
-        client_ip = IPAddress(request.META['REMOTE_ADDR'])
-        internal_networks = [IPNetwork(n) for n in settings.INTERNAL_NETWORKS]
-        in_internal_networks = len([n for n in internal_networks if client_ip in n]) > 0
-        if not in_internal_networks:
-            strip_auth_headers(request)
-            LOG.debug("IP doesn't originate within internal network, refusing auth: %s" % request.META['REMOTE_ADDR'])
-            return
 
         # if request has expected headers, but their values are invalid, strip auth
         if headers[CGROUPS] not in ['user', 'admin']:

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -23,13 +23,6 @@ class KongAuthMiddleware(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'True')
 
-    def test_bad_authentication_request1(self):
-        "client is trying to authenticate but IP doesn't originate within subnet"
-        self.extra['REMOTE_ADDR'] = '192.168.0.1' # internal, but not *our* internal
-        resp = self.c.get('/', **self.extra)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'False')
-
     def test_bad_authentication_request2(self):
         "client is trying to authenticate but the user group doesn't have any special permissions"
         self.extra[mware.CGROUPS] = 'user'


### PR DESCRIPTION
Moves authentication to nginx, depends on https://github.com/elifesciences/lax-formula/pull/12