### PR TITLE
donotmerge - fixes a test that is calling aws

### DIFF
--- a/src/publisher/aws_events.py
+++ b/src/publisher/aws_events.py
@@ -21,7 +21,7 @@ def sns_topic_arn():
     return arn
 
 def event_bus_conn():
-    sns = boto3.resource('sns')
+    sns = boto3.resource('sns', region=settings.EVENT_BUS['region'])
     return sns.Topic(sns_topic_arn())
 
 #

--- a/src/publisher/tests/test_aws_events.py
+++ b/src/publisher/tests/test_aws_events.py
@@ -164,7 +164,9 @@ class Two(base.TransactionBaseCase):
         """aws_events.notify is called once for the article being ingested and once
         each for related articles, including reverse relations"""
 
-        ajson_ingestor.ingest(self.ajson1) # has 2 related, 9561 and 9560
+        with patch('publisher.ajson_ingestor.aws_events.notify'):
+            # ensure this ingest doesn't call out to aws
+            ajson_ingestor.ingest(self.ajson1) # has 2 related, 9561 and 9560
 
         with patch('publisher.ajson_ingestor.aws_events.notify') as notify_mock:
 


### PR DESCRIPTION
locally it's calling our --prod subscriptions because of config defaults

update: there are actually more tests contacting aws while testing. looking for a way to patch boto so it never connects