### PR TITLE
New green version (2.11.0) breaking install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ if [ ! -e app.cfg ]; then
     ln -s elife.cfg app.cfg
 fi
 
-pip install -r requirements.txt
+pip install -r requirements.txt --no-cache-dir
 NEW_RELIC_EXTENSIONS=false pip install --no-binary :all: newrelic==2.82.0.62
 
 python src/manage.py migrate --no-input

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-rest-swagger==2.1.2
 django-sql-explorer==1.1.1
 djangorestframework==3.6.3
 et3==1.5
-green==2.11.0
+green==2.9.0
 joblib==0.11
 jsonschema==2.6.0
 kids.cache==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ django-rest-swagger==2.1.2
 django-sql-explorer==1.1.1
 djangorestframework==3.6.3
 et3==1.5
+# versions of green > 2.9.0 conflict with kids.cache
+# both are doing command line parsing during installation
 green==2.9.0
 joblib==0.11
 jsonschema==2.6.0


### PR DESCRIPTION
When trying to provision a new lax Vagrant VM locally I was getting failures during the requirements.txt dependancy installs. When running the install.sh directly you can see the following error:

```
Running setup.py install for green ... done
Running setup.py install for et3 ... done
Running setup.py install for kids.cache ... error
Complete output from command /srv/lax/venv/bin/python3.5 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-02oi32lj/kids.cache/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-6uaul3gn-record/install-record.txt --single-version-externally-managed --compile --install-headers /srv/lax/venv/include/site/python3.5/kids.cache:
usage: green [options] [target [target2 ...]]
green: error: unrecognized arguments: --record /tmp/pip-6uaul3gn-record/install-record.txt --single-version-externally-managed --compile --install-headers /srv/lax/venv/include/site/python3.5/kids.cache
error in setup command: Error parsing /tmp/pip-build-02oi32lj/kids.cache/setup.cfg: SystemExit: 2
```
After some investigation we found that rolling back the 'green' version back to 2.9.0 fixes this issue and allows the installation of the dependancies.

This is related to https://github.com/elifesciences/lax/commit/7891e78b664ad3e5e23129714b0e205cde2fb564