### PR TITLE
test scripts shifted to use .test-green.sh over .test.sh

### DIFF
--- a/.cc-check.sh
+++ b/.cc-check.sh
@@ -17,7 +17,7 @@ xenon src/ \
 	--max-absolute B \
 	--max-modules A \
 	--max-average A \
-	--exclude '*eif_ingestor.py,*ajson_ingestor.py,*ingest.py' || {
+	--exclude '*ajson_ingestor.py,*ingest.py' || {
 
     echo "use 'radon cc path/to/file.py' for more detail" > /dev/stderr
     exit 1

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
-omit = 
+omit =
+    */tests/*
+    */migrations/*
     src/core/wsgi.py
     src/publisher/admin.py

--- a/.green
+++ b/.green
@@ -1,0 +1,4 @@
+verbose = 3
+processes = 2
+#run-coverage = True # prints coverage report at end
+quiet-coverage = True

--- a/.test-green.sh
+++ b/.test-green.sh
@@ -8,13 +8,37 @@ pyflakes src/
 
 args="$@"
 module="src"
+print_coverage=1
+coverage_threshold=80
+
 if [ ! -z "$args" ]; then
+    # we're running a subset of tests
     module="src.$args"
+    # suppress coverage report
+    print_coverage=0
 fi
+
+# remove any old compiled python files
+find src/ -name '*.pyc' -delete
 
 GREEN_CONFIG=.green LAX_MULTIPROCESSING=1 ./src/manage.py test "$module" \
     --testrunner=green.djangorunner.DjangoRunner \
     --no-input \
     -v 3
+echo "* passed tests"
+
+# run coverage test
+# only report coverage if we're running a complete set of tests
+if [ $print_coverage -eq 1 ]; then
+    coverage report
+    # is only run if tests pass
+    covered=$(coverage report | grep TOTAL | awk '{print $4}' | sed 's/%//')
+    if [ $covered -lt $coverage_threshold ]; then
+        echo
+        echo "FAILED this project requires at least $coverage_threshold% coverage, got $covered%"
+        echo
+        exit 1
+    fi
+fi
 
 echo "[✓] .test-green.sh"

--- a/.test.sh
+++ b/.test.sh
@@ -21,7 +21,7 @@ find src/ -name '*.pyc' -delete
 rm -f build/junit.xml
 
 # testing management commands that require a queue shared between processes
-LAX_MULTIPROCESSING=1 coverage run --source='src/' --omit='*/tests/*,*/migrations/*' src/manage.py test "$module" --no-input
+LAX_MULTIPROCESSING=1 coverage run --source='src/' src/manage.py test "$module" --no-input
 echo "* passed tests"
 
 # run coverage test

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -4,5 +4,5 @@ set -e
 source venv/bin/activate
 
 . .lint.sh
-. .test.sh
+. .test-green.sh
 . .cc-check.sh

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@
 set -e
 . install.sh
 . .lint.sh
-. .test.sh
+. .test-green.sh
 # encoding errors in python3 version of xenon/radon
 . .cc-check.sh


### PR DESCRIPTION
looks like green is counting fewer files than the coverage test runner and is reporting a 75% pass rather than coverage's own 88%