### PR TITLE
removed v1 content upgrade for v2 requests

### DIFF
--- a/src/publisher/middleware.py
+++ b/src/publisher/middleware.py
@@ -57,6 +57,7 @@ def downgrade(content):
         return item
     return visit_target(content, transformer)
 
+'''
 def upgrade(content):
     "returns v2-compliant content"
     def transformer(item):
@@ -65,11 +66,12 @@ def upgrade(content):
             del item['title']
         return item
     return visit_target(content, transformer)
+'''
 
 TRANSFORMS = {
     '1': downgrade,
-    '2': upgrade,
-    '*': upgrade, # accept ll: */*
+    #'2': upgrade,
+    #'*': upgrade, # accept ll: */*
 }
 
 # adapted from https://djangosnippets.org/snippets/1042/

--- a/src/publisher/tests/test_api_v12_temp.py
+++ b/src/publisher/tests/test_api_v12_temp.py
@@ -41,13 +41,13 @@ class One(base.BaseCase):
 
         cases = [
             # content, request, response
-            (v1, v1, v1),
-            (v1, v2, v2),
+            #(v1, v1, v1),
+            #(v1, v2, v2),
 
             (v2, v1, v1),
             (v2, v2, v2),
 
-            (v1, v12, v2),
+            #(v1, v12, v2),
             (v2, v12, v2),
         ]
 


### PR DESCRIPTION
all content has been upgraded to v2.

some context for @seanwiseman : we had a major version upgrade of our article content type from v1 to v2. it was our first major content type upgrade and it required dealing with the transition period (which we're still in) where some content would be v2, some would be v1, some client requests would be v1, some v2, some unspecified, etc.

Luckily, the change could be made to the content without explicitly knowing whether it was a v1 or v2, so I implemented the change as a piece of middleware that modified the response depending on what the user 'asked' for in their `Accept` header.

Now that all article content is v2 we no longer have to upgrade responses and this PR disables them. Once all the clients have been upgraded to make v2 requests, I'll remove the middleware and tests entirely.

The upgrade from article v2 to v3 (if/when it eventually happens) may not be as clean.