### PR TITLE
ELPP-3341 Support for multiple, granular ACL groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ build/
 .repop*
 htmlcov/
 app.cfg
-uwsgi.ini
+/newrelic.ini
+/uwsgi.ini
 ingestion-lax.log.json
 /src/core/prod_settings.py
 aws-perms.sh

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -20,7 +20,6 @@ class KongAuthentication(MiddlewareMixin):
         headers = {}
 
         # if request doesn't have all expected headers, strip auth
-        header = CGROUPS
         if CGROUPS not in request.META:
             # no auth or invalid auth request, return immediately
             LOG.debug('header %r not found, refusing auth', CGROUPS)

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -36,8 +36,10 @@ class KongAuthentication(MiddlewareMixin):
                 return
             headers[header] = str(request.META[header])
 
+        groups = [h.strip() for h in headers[CGROUPS].split(',')]
+
         # if request has expected headers, but their values are invalid, strip auth
-        if headers[CGROUPS] not in ['user', 'admin', 'view-unpublished-content']:
+        if not 'admin' in groups and not 'view-unpublished-content' in groups:
             strip_auth_headers(request)
             LOG.debug("unknown user group, refusing auth")
             return

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -38,20 +38,13 @@ class KongAuthentication(MiddlewareMixin):
 
         groups = [h.strip() for h in headers[CGROUPS].split(',')]
 
-        # if request has expected headers, but their values are invalid, strip auth
-        if not 'admin' in groups and not 'view-unpublished-content' in groups:
+        LOG.debug('user groups: %s', groups)
+        if 'admin' in groups or 'view-unpublished-content' in groups:
+            LOG.debug('user groups: %s', groups)
+            strip_auth_headers(request, authenticated=True)
+        else:
+            LOG.debug('setting request as not authenticated')
             strip_auth_headers(request)
-            LOG.debug("unknown user group, refusing auth")
-            return
-
-        # if user is 'just' a user
-        if headers[CGROUPS] == 'user':
-            strip_auth_headers(request)
-            LOG.debug("'user' group receives has no special permissions")
-            return
-
-        strip_auth_headers(request, authenticated=True)
-        LOG.debug("authenticated!")
 
 #
 #

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -37,7 +37,7 @@ class KongAuthentication(MiddlewareMixin):
             headers[header] = str(request.META[header])
 
         # if request has expected headers, but their values are invalid, strip auth
-        if headers[CGROUPS] not in ['user', 'admin']:
+        if headers[CGROUPS] not in ['user', 'admin', 'view-unpublished-content']:
             strip_auth_headers(request)
             LOG.debug("unknown user group, refusing auth")
             return

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -23,6 +23,13 @@ class KongAuthMiddleware(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'True')
 
+    def test_authenticated_request_multiple_groups(self):
+        "ensure an authenticated request is marked as such"
+        self.extra[mware.CGROUPS] = 'user, view-unpublished-content'
+        resp = self.c.get('/', **self.extra)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'True')
+
     def test_bad_authentication_request2(self):
         "client is trying to authenticate but the user group doesn't have any special permissions"
         self.extra[mware.CGROUPS] = 'user'
@@ -37,7 +44,7 @@ class KongAuthMiddleware(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'False')
 
-class DownstreamCachine(TestCase):
+class DownstreamCaching(TestCase):
     def setUp(self):
         self.c = Client()
         self.url = '/' # we could hit more urls but it's applied application-wide

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -8,7 +8,7 @@ class KongAuthMiddleware(TestCase):
         self.c = Client()
         self.extra = {
             'REMOTE_ADDR': '10.0.2.6',
-            mware.CGROUPS: 'admin',
+            mware.CGROUPS: 'view-unpublished-content',
         }
 
     def test_unauthenticated_request(self):

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -6,10 +6,6 @@ from core import middleware as mware
 class KongAuthMiddleware(TestCase):
     def setUp(self):
         self.c = Client()
-        self.extra = {
-            'REMOTE_ADDR': '10.0.2.6',
-            mware.CGROUPS: 'view-unpublished-content',
-        }
 
     def test_unauthenticated_request(self):
         "ensure an unauthenticated request is marked as such"
@@ -19,28 +15,25 @@ class KongAuthMiddleware(TestCase):
 
     def test_authenticated_request(self):
         "ensure an authenticated request is marked as such"
-        resp = self.c.get('/', **self.extra)
+        resp = self.c.get('/', **{mware.CGROUPS: 'view-unpublished-content'})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'True')
 
     def test_authenticated_request_multiple_groups(self):
         "ensure an authenticated request is marked as such"
-        self.extra[mware.CGROUPS] = 'user, view-unpublished-content'
-        resp = self.c.get('/', **self.extra)
+        resp = self.c.get('/', **{mware.CGROUPS: 'user, view-unpublished-content'})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'True')
 
     def test_bad_authentication_request2(self):
         "client is trying to authenticate but the user group doesn't have any special permissions"
-        self.extra[mware.CGROUPS] = 'user'
-        resp = self.c.get('/', **self.extra)
+        resp = self.c.get('/', **{mware.CGROUPS: 'user'})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'False')
 
     def test_bad_authentication_request3(self):
         "client is trying to authenticate but the user is unknown"
-        self.extra[mware.CGROUPS] = 'party'
-        resp = self.c.get('/', **self.extra)
+        resp = self.c.get('/', **{mware.CGROUPS: 'party'})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp[settings.KONG_AUTH_HEADER], 'False')
 

--- a/src/publisher/tests/test_api_v2_views.py
+++ b/src/publisher/tests/test_api_v2_views.py
@@ -18,7 +18,7 @@ class Fragments(base.BaseCase):
         self.c = Client()
         # authenticated
         self.ac = Client(**{
-            mware.CGROUPS: 'admin',
+            mware.CGROUPS: 'view-unpublished-content',
         })
 
         self.msid = 16695
@@ -181,7 +181,7 @@ class V2Content(base.BaseCase):
         self.c = Client()
         # an authenticated client
         self.ac = Client(**{
-            mware.CGROUPS: 'admin',
+            mware.CGROUPS: 'view-unpublished-content',
         })
 
     def test_ping(self):
@@ -490,7 +490,7 @@ class V2PostContent(base.BaseCase):
 
         self.c = Client()
         self.ac = Client(**{
-            mware.CGROUPS: 'admin',
+            mware.CGROUPS: 'view-unpublished-content',
         })
 
     def test_add_fragment(self):
@@ -616,7 +616,7 @@ class FragmentEvents(base.TransactionBaseCase):
 
         self.c = Client()
         self.ac = Client(**{
-            mware.CGROUPS: 'admin',
+            mware.CGROUPS: 'view-unpublished-content',
         })
 
     def tearDown(self):
@@ -687,7 +687,7 @@ class RequestArgs(base.BaseCase):
 
         self.c = Client()
         self.ac = Client(**{
-            mware.CGROUPS: 'admin',
+            mware.CGROUPS: 'view-unpublished-content',
         })
     #
     # Pagination


### PR DESCRIPTION
Mostly supporting comma-separated values in `X-Consumer-Groups`, since we will use those to define fine-grained permissions rather than the `admin` level.

But also:
- Removing unused `X-Consumer-*` headers knowledge
- Removing `REMOTE_ADDR` knowledge
- Simplifying logic since it depends on one header only now