### PR TITLE
multiprocessing.Manager instance available only with LAX_MULTIPROCESSING

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -126,7 +126,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'core.wsgi.application'
 
-MP_MANAGER = multiprocessing.Manager()
+# a process-wide manager is only available if lax is called with LAX_MULTIPROCESSING=1
+# this manager is not available from uwsgi-started process or a fork
+MP_MANAGER = multiprocessing.Manager() if os.environ.get('LAX_MULTIPROCESSING') else None
 
 # Testing
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'


### PR DESCRIPTION
https://elifesciences.atlassian.net/browse/ELPP-3295

I don't really know how uwsgi is doing it's process forking and it's interaction with the creation of a multiprocessing.Manager instance and how these relates to the two different errors we're seeing (cannot join thread, cannot join child process), but there is no reason for a Manager instance to be created when the lax process is started by uwsgi. it's used so the command line ingest and aws event sending can converse.