### PR TITLE
Revert "multiprocessing.Manager instance available only with LAX_MULTIPROCESSING"

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -126,9 +126,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'core.wsgi.application'
 
-# a process-wide manager is only available if lax is called with LAX_MULTIPROCESSING=1
-# this manager is not available from uwsgi-started process or a fork
-MP_MANAGER = multiprocessing.Manager() if os.environ.get('LAX_MULTIPROCESSING') else None
+MP_MANAGER = multiprocessing.Manager()
 
 # Testing
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'


### PR DESCRIPTION
All end2end tests failed, so we need a more incremental solution to adopt this variable (such as logging when it's not available).

This reverts commit 1cf862edc0910dbd428076e265b134ac666c27f6.