### PR TITLE
Run lax-related subset of end2end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,8 @@ elifePipeline {
                     stackname: 'lax--end2end',
                     revision: commit,
                     folder: '/srv/lax'
-                ]
+                ],
+                marker: 'lax'
             )
         }
 


### PR DESCRIPTION
See also https://github.com/elifesciences/elife-spectrum/commit/cba82676fa22924ffe31b331f9769af65768edaf

Should be speed up a bit the end2end stage as there are tests that don't touch Lax itself, and can be excluded.