### PR TITLE
added the 'privileged' database to settings.

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -20,5 +20,7 @@ name: lax.sqlite3
 engine: django.db.backends.sqlite3
 user: 
 password:
+root-user: 
+root-password: 
 host: 
-port: 
+port:

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,6 @@ fi
 pip install -r requirements.txt --no-cache-dir
 NEW_RELIC_EXTENSIONS=false pip install --no-binary :all: newrelic==2.82.0.62
 
-python src/manage.py migrate --no-input
+python src/manage.py migrate --no-input --database=privileged
 
 echo "[✓] install.sh"

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -151,8 +151,17 @@ DATABASES = {
         'PASSWORD': cfg('database.password'),
         'HOST': cfg('database.host'),
         'PORT': cfg('database.port')
-    }
+    },
 }
+
+# exactly the same during development,
+# used to run migrations outside of development.
+DATABASES['privileged'] = copy.deepcopy(DATABASES['default'])
+if not DEBUG:
+    DATABASES['privileged'].update({
+        'USER': cfg('database.root-user'),
+        'PASSWORD': cfg('database.root-password'),
+    })
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -5,7 +5,7 @@ example settings can be found in /path/to/lax/elife.cfg
 
 ./install.sh will create a symlink from dev.cfg -> lax.cfg if lax.cfg not found."""
 
-import os
+import os, copy
 import multiprocessing
 from os.path import join
 from datetime import datetime


### PR DESCRIPTION
this uses the root db credentials in the app.cfg file to run migrations outside of development.

not sure if this is the best route or if granting the app user db modification privileges is, but I was getting frustrated figuring out what specific set of additional GRANTs the app user needed in postgresql. 
this way at least it need not be a root user just simply another user but with elevated privileges

depends on https://github.com/elifesciences/lax-formula/pull/23