### PR TITLE
Keep fewer pre-deploy backups

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -6,7 +6,7 @@ elifePipeline {
     }
 
     stage 'Backup', {
-        builderCmdNode 'lax--prod', 1, "./backup_prune.sh 3", "/srv/lax"
+        builderCmdNode 'lax--prod', 1, "./backup_prune.sh 2", "/srv/lax"
         builderCmdNode 'lax--prod', 1, "./backup.sh ${env.BUILD_TAG}", "/srv/lax"
     }
 


### PR DESCRIPTION
We currently backup the full database before every deploy. We have many nightly backups so we don't need to keep as many copies on disk.