### PR TITLE
Customize TTL of responses

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -3,6 +3,7 @@ debug: True
 env: dev
 secret-key: these-are-dev-settings.DO.NOT.USE.IN.PROD.EVER
 allowed-hosts: localhost
+cache-headers-ttl: 300
 reporting-bucket: 
 
 [journal]

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -51,8 +51,8 @@ class DownstreamCaching(object):
     def __call__(self, request):
         public_headers = {
             'public': True,
-            'max-age': 60 * 5, # 5 minutes, 300 seconds
-            'stale-while-revalidate': 60 * 5, # 5 minutes, 300 seconds
+            'max-age': settings.CACHE_HEADERS_TTL,
+            'stale-while-revalidate': settings.CACHE_HEADERS_TTL,
             'stale-if-error': (60 * 60) * 24, # 1 day, 86400 seconds
         }
         private_headers = {

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -390,3 +390,5 @@ logger = {
     'propagate': False, # don't propagate up to root logger
 }
 LOGGING['loggers'].update(dict(list(zip(module_loggers, [logger] * len(module_loggers)))))
+
+CACHE_HEADERS_TTL = cfg('general.cache-headers-ttl', 60 * 5) # 5 minutes, 300 seconds by default

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -1,8 +1,7 @@
 from django.conf import settings
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
 #from django.core.urlresolvers import reverse
 from core import middleware as mware
-from mock import patch
 
 class KongAuthMiddleware(TestCase):
     def setUp(self):
@@ -66,9 +65,8 @@ class DownstreamCaching(TestCase):
         for header in cases:
             self.assertFalse(resp.has_header(header), "header %r present in response" % header)
 
-    @patch('core.middleware.settings')
-    def test_custom_ttl_in_configuration(self, stub_settings):
-        stub_settings.CACHE_HEADERS_TTL = 30
+    @override_settings(CACHE_HEADERS_TTL=30)
+    def test_custom_ttl_in_configuration(self):
         resp = self.c.get(self.url)
         cache_control = self._parse_cache_control(resp)
         self.assertIn('max-age=30', cache_control)


### PR DESCRIPTION
This is useful in testing environments as we don't have to wait 5 minutes before a silent correction is propagated to Journal after cache expiration.
e.g. https://github.com/elifesciences/elife-spectrum/pull/108