### PR TITLE
Generate friendly error path string

### DIFF
--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -435,7 +435,8 @@ class Publish(BaseCase):
             ajson_ingestor.ingest_publish(self.ajson)
         except StateError as err:
             self.assertEqual(err.code, codes.INVALID)
-            self.assertEqual(err.trace.strip()[:15], "'' is too short")
+            # self.assertEqual(err.trace.strip()[:15], "'' is too short")
+            self.assertEqual(err.trace.strip()[:23], "title = '' is too short")
 
 class IngestPublish(BaseCase):
     def setUp(self):

--- a/src/publisher/tests/test_utils.py
+++ b/src/publisher/tests/test_utils.py
@@ -44,9 +44,7 @@ class Errors(base.BaseCase):
 
             # non-deterministic ordering of errors! hooray
 
-            expected1 = """'status' is a required property
-
-Failed validating 'required' in schema['allOf'][0]['allOf'][0]:"""
+            expected1 = """'status' is a required property"""
 
             expected2 = """None is not of type 'string'
 
@@ -54,6 +52,22 @@ Failed validating 'type' in schema['allOf'][0]['allOf'][0]['properties']['status
 
             trace = err.trace.lstrip()
             self.assertTrue(trace.startswith(expected1) or trace.startswith(expected2))
+
+    def test_state_error4(self):
+        """Will fail validation due to:
+
+        funding.awards.1.source.funderId = '0000'
+
+        which does not match the required '^10[.][0-9]{4,}[^\\s"/<>]*/[^\\s"]+$' format.
+        """
+        try:
+            ajson = json.load(open(join(self.fixture_dir, 'ajson', 'elife-16695-v1.xml.json'), 'r'))
+            utils.validate(ajson['article'], settings.SCHEMA_IDX['poa'])
+        except ValidationError as verr:
+            expected1 = """funding.awards.1.source.funderId = '0000' does not match '^10[.][0-9]{4,}[^\\s"/<>]*/[^\\s"]+$'"""
+
+            self.assertTrue(verr.startswith(expected1))
+
 
 class TestUtils(base.BaseCase):
     def setUp(self):

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -291,6 +291,13 @@ def boolkey(*args):
 #
 #
 
+
+def format_error_path(path):
+    return ' >> '.join([str(item) for item in path])
+
+def generate_error_string(message, instance, path):
+    return '{0} \n\n* path to field *: {1} = {2}'.format(message, format_error_path(path), instance)
+
 @cache
 def load_schema(schema_path):
     return json.load(open(schema_path, 'r', encoding='utf-8'))
@@ -316,7 +323,11 @@ def validate(struct, schema_path):
     except ValidationError as err:
         # your json is incorrect
         #LOG.error("struct failed to validate against schema: %s" % err.message)
-        raise
+
+        output = generate_error_string(message=err.message,
+                                       instance=err.instance,
+                                       path=err.path)
+        raise ValidationError(output)
 
 # modified from:
 # http://stackoverflow.com/questions/9323749/python-check-if-one-dictionary-is-a-subset-of-another-larger-dictionary

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -293,10 +293,15 @@ def boolkey(*args):
 
 
 def format_error_path(path):
-    return ' >> '.join([str(item) for item in path])
+    return '.'.join([str(item) for item in path])
 
-def generate_error_string(message, instance, path):
-    return '{0} \n\n* path to field *: {1} = {2}'.format(message, format_error_path(path), instance)
+def generate_error_string(message, path):
+    if len(path):
+        equals_str = ' = '
+    else:
+        equals_str = ''
+
+    return '{0}{1}{2}'.format(format_error_path(path), equals_str, message)
 
 @cache
 def load_schema(schema_path):
@@ -324,9 +329,7 @@ def validate(struct, schema_path):
         # your json is incorrect
         #LOG.error("struct failed to validate against schema: %s" % err.message)
 
-        output = generate_error_string(message=err.message,
-                                       instance=err.instance,
-                                       path=err.path)
+        output = generate_error_string(message=err.message, path=err.path)
         raise ValidationError(output)
 
 # modified from:


### PR DESCRIPTION
When an error is not in a `oneOf` check (you can get the full error path):

`Issue: an invalid funderId`

**Current message:** 
```validation error: '0000' does not match '^10[.][0-9]{4,}[^\\s"/<>]*/[^\\s"]+$'```


**With changes:**
```
validation error: '0000' does not match '^10[.][0-9]{4,}[^\\s"/<>]*/[^\\s"]+$' 

*path to field *: funding >> awards >> 2 >> source >> funderId = 0000
```

When an error is in a `oneOf` check (you can only get so far):

`Issue: an invalid author orcid`

**Current message:**

```validation error: {'type': 'person', 'name': {……...rest of the data... is not valid under any of the given schemas``` 


**With changes:**

```
validation error: {'type': 'person', 'name': {……...rest of the data... is not valid under any of the given schemas 

*path to field *: authors >> 4 = {'type': 'person', 'name': { ……...rest of the data...
```

I tried playing with `best_match(Draft4Validator(schema).iter_errors(struct))`.

You can use it (in a limited way) if you just wanted it to traverse into oneOfs for you by calling best_match([e]), but it turned out to not always give the required error message, as you know you don’t know which `oneOf` you were targeting in the first place, it failing on one might be perfectly fine because that was not the expected structure. It could have some legs but would get quite involved.

You can obviously get access to the full trace but the target is a short summary/pointer towards problem data without having to do too much digging.