### PR TITLE
validation failures are logged as warnings when caught by  ingest 

### DIFF
--- a/src/publisher/management/commands/ingest.py
+++ b/src/publisher/management/commands/ingest.py
@@ -51,7 +51,8 @@ def error(print_queue, errtype, code, message, force, dry_run, log_context, **mo
     ])
     struct.update(moar)
     log_context['status'] = errtype
-    LOG.error(message, extra=log_context)
+    logfn = LOG.warn if code == codes.INVALID else LOG.error
+    logfn(message, extra=log_context)
     write(print_queue, struct)
     clean_up(print_queue)
     sys.exit(1)

--- a/src/publisher/tests/fixtures/ajson/elife-01968-v1-bad.xml.json
+++ b/src/publisher/tests/fixtures/ajson/elife-01968-v1-bad.xml.json
@@ -7,7 +7,7 @@
     "article": {
         "id": "15507", 
         "version": 1, 
-
+        "status": "poa",
 
         "type": "INVALID ARTICLE TYPES SHALT NOT PASS", 
 


### PR DESCRIPTION
another instance in lax where validation failures are being reported as errors rather than as a warning that Loggly will then send to us.

validation failures are an ordinary part of the production workflow