### PR TITLE
Feature: validation failure error improvements

### DIFF
--- a/src/publisher/ajson_ingestor.py
+++ b/src/publisher/ajson_ingestor.py
@@ -181,7 +181,7 @@ def _ingest(data, force=False) -> models.ArticleVersion:
         raise
 
     except ValidationError as err:
-        raise StateError(codes.INVALID, "validation error: %s" % err.message, err)
+        raise StateError(codes.INVALID, err.message, err)
 
     except Exception:
         LOG.exception("unhandled exception attempting to ingest article-json", extra=log_context)
@@ -256,7 +256,7 @@ def _publish(msid, version, force=False) -> models.ArticleVersion:
 
     except ValidationError as err:
         # the problem isn't that the ajson is invalid, it's that we've allowed invalid ajson into the system
-        raise StateError(codes.INVALID, "refusing to publish an article '%sv%s' with invalid article-json: %s" % (msid, version, err), err)
+        raise StateError(codes.INVALID, "refusing to publish an article '%sv%s' with invalid article-json" % (msid, version), err)
 
     except models.ArticleFragment.DoesNotExist:
         raise StateError(codes.NO_RECORD, "no 'xml->json' fragment found. being strict and failing this publish. please INGEST!")

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -590,8 +590,9 @@ class ValidationFailureError(BaseCase):
         invalid_fixture = copy.deepcopy(self.valid_fixture)
 
         # two errors:
-        # jsonschema.exceptions.ValidationError: volume = -1 is less than the minimum of 1(
-        invalid_fixture['article']['volume'] = -1
+        # jsonschema.exceptions.ValidationError: volume = 0 is less than the minimum of 1
+        # *and* it bypasses the PositiveSmallIntegerField integrity check in sqlite+psql
+        invalid_fixture['article']['volume'] = 0
         # jsonschema.exceptions.ValidationError: doi = 'asdf' does not match '^10[.][0-9]{4,}[^\\s"/<>]*/[^\\s"]+$'
         invalid_fixture['article']['doi'] = 'asdf'
 

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -578,8 +578,7 @@ class UnicodePreserved(BaseCase):
         self.assertEqual(expected, given)
 
 from django.conf import settings
-import jsonschema
-from jsonschema.exceptions import best_match
+from jsonschema.exceptions import ErrorTree
 
 class X(BaseCase):
     def setUp(self):
@@ -607,18 +606,22 @@ class X(BaseCase):
             # when ingesting we wrap the validationerror in a stateerror
             
             errinst = err.args[2]
+            
+            error_list = errinst.more['error-list']
+            schema_file = errinst.more['schema-path']
 
-            #print('moar:',errinst.more)
-            for error in errinst.more:
-                print('-'*80)
-                print("(err)",error.message)
+            for error in error_list:
+                msg, detail = utils.format_validation_error(error, schema_file)
+                print(msg)
+                if detail:
+                    #print("(more detail available)")
+                    print("** (sub) **")
+                    for det in detail:
+                        print(det)
 
-                suberror_list = sorted(error.context, key=lambda e: e.schema_path)
-                for suberror in suberror_list:
-                    print("(sub)",list(suberror.schema_path), suberror.message, sep=", ")
-
-                if suberror_list:
-                    print("(best)",best_match(suberror_list).message)
+                print()
+                print('-' * 80)
+                print()
 
         self.fail()
 

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -11,6 +11,8 @@ from unittest import skip
 from publisher import logic
 from django.test import Client, override_settings
 from django.core.urlresolvers import reverse
+from django.conf import settings
+from jsonschema.exceptions import ValidationError
 
 class IngestIdentical(BaseCase):
     def setUp(self):
@@ -576,10 +578,7 @@ class UnicodePreserved(BaseCase):
         given = av.article_json_v1['authors'][1]['name']['preferred']
         self.assertEqual(expected, given)
 
-from django.conf import settings
-from jsonschema.exceptions import ValidationError
-
-class X(BaseCase):
+class ValidationFailureError(BaseCase):
     def setUp(self):
         self.valid_fixture = self.load_ajson(join(self.fixture_dir, "ajson", "elife-20125-v1.xml.json"))
         self.poa_schema = settings.SCHEMA_IDX['poa']

--- a/src/publisher/tests/test_utils.py
+++ b/src/publisher/tests/test_utils.py
@@ -42,16 +42,25 @@ class Errors(base.BaseCase):
             self.assertEqual(err.message, 'msg')
             self.assertEqual(err.code, 1)
 
+            # test update 2018-06-13:
+            # trace is now the complete list of errors, which can be very long for very invalid data
+            # ordering may still be non-deterministic as two errors can have the same 'weight'
+            # the error messages have changed
+            # I can't find any mention of `expected2`, it's possible the schema or the fixture has changed
+            # during the life of this test. The `or` would have hidden it.
+            
+            #expected1 = """'status' is a required property"""
+            #expected2 = """None is not of type 'string'
+            #Failed validating 'type' in schema['allOf'][0]['allOf'][0]['properties']['statusDate']:"""
+            #trace = err.trace.lstrip()
             # non-deterministic ordering of errors! hooray
+            #self.assertTrue(trace.startswith(expected1) or trace.startswith(expected2))
 
-            expected1 = """'status' is a required property"""
+            expected1 = "'status' is a required property"
+            self.assertTrue(expected1 in err.trace)
 
-            expected2 = """None is not of type 'string'
-
-Failed validating 'type' in schema['allOf'][0]['allOf'][0]['properties']['statusDate']:"""
-
-            trace = err.trace.lstrip()
-            self.assertTrue(trace.startswith(expected1) or trace.startswith(expected2))
+            # we still have access to the original error message if we need it
+            self.assertTrue(expected1 in verr.message)
 
     def test_state_error4(self):
         """Will fail validation due to:

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from functools import reduce
-from jsonschema import validate as validator
+import jsonschema
 from jsonschema import ValidationError
 import os, copy, json, glob
 import pytz
@@ -291,10 +291,11 @@ def boolkey(*args):
 #
 #
 
-
+# TODO: remove
 def format_error_path(path):
     return '.'.join([str(item) for item in path])
 
+# TODO: remove
 def generate_error_string(message, path):
     if len(path):
         equals_str = ' = '
@@ -317,20 +318,25 @@ def validate(struct, schema_path):
 
     try:
         schema = load_schema(schema_path)
-        validator(struct, schema)
+        jsonschema.validate(struct, schema)
         return struct
 
     except ValueError as err:
-        # your json schema is broken
+        # json schema is broken
         #raise ValidationError("validation error: '%s' for: %s" % (err.message, struct))
         raise
 
     except ValidationError as err:
-        # your json is incorrect
+        # json is incorrect
         #LOG.error("struct failed to validate against schema: %s" % err.message)
 
-        output = generate_error_string(message=err.message, path=err.path)
-        raise ValidationError(output)
+        #output = generate_error_string(message=err.message, path=err.path)
+        #raise ValidationError(output)
+
+        v = jsonschema.Draft4Validator(schema)
+        err.more = list(v.iter_errors(struct))
+        
+        raise err
 
 # modified from:
 # http://stackoverflow.com/questions/9323749/python-check-if-one-dictionary-is-a-subset-of-another-larger-dictionary

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -53,7 +53,7 @@ class StateError(RuntimeError):
 
         # if exception object has a 'trace' attribute, use that,
         # else just stringify the thing
-        return getattr(traceobj, 'trace') or str(traceobj)
+        return getattr(traceobj, 'trace', None) or str(traceobj)
 
 class LaxAssertionError(AssertionError):
     @property


### PR DESCRIPTION
ticket: https://elifesciences.atlassian.net/browse/ELPP-3681

Big changes to validation errors:
* formatting of error message changed to be clearer
* failures against multiple schemas get a summary instead
* default error message returned contains all top-level errors
* the error trace (also returned) contains all top-level errors and any sub-errors for heavy debugging
* change to the order of sub-errors so the smallest + most relevant ones come first

[error.txt](https://github.com/elifesciences/lax/files/2093052/error.txt)
[trace.txt](https://github.com/elifesciences/lax/files/2093053/trace.txt)

