### PR TITLE
fix: capped error messages

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -258,6 +258,10 @@ ALL_SCHEMA_IDX = {
 SCHEMA_IDX = {tpe: rows[0][1] for tpe, rows in ALL_SCHEMA_IDX.items()}
 API_PATH = join(SCHEMA_PATH, 'api.raml')
 
+# a schema failure may have multiple independent failures and each failure
+# may have multiple possibilities.
+NUM_SCHEMA_ERRORS = NUM_SCHEMA_ERROR_SUBS = 10
+
 def _load_api_raml(path):
     # load the api.raml file, ignoring any "!include" commands
     yaml.add_multi_constructor('', lambda *args: '[disabled]')

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -586,6 +586,13 @@ class ValidationFailureError(BaseCase):
         # before any test uses this fixture, prove it actually is valid ...
         utils.validate(self.valid_fixture['article'], self.poa_schema)
 
+    def test_heaps_of_failures_detected(self):
+        invalid_fixture = {'party': 'pants'}
+        try:
+            utils.validate(invalid_fixture, settings.SCHEMA_IDX['poa'])
+        except ValidationError as err:
+            self.assertTrue("(error 10 of 10, 19 total)" in err.message)
+
     def test_n_failures_detected(self):
         invalid_fixture = copy.deepcopy(self.valid_fixture)
 

--- a/src/publisher/utils.py
+++ b/src/publisher/utils.py
@@ -13,6 +13,7 @@ from django.db.models.fields.related import ManyToManyField
 from kids.cache import cache
 from rfc3339 import rfc3339
 from django.db import transaction, IntegrityError
+from django.conf import settings
 import traceback
 
 LOG = logging.getLogger(__name__)
@@ -412,14 +413,20 @@ def format_validation_error_list(error_list, schema_file):
     trace_list = []
     sep = "\n%s\n" % ("-" * 40,)
 
-    for i, error in enumerate(error_list):
-        msg, sub_msg_list = format_validation_error(error, schema_file)
-        # (error 1 of 2) ...
-        msg = "(error %s of %s)\n\n%s\n" % (i + 1, len(error_list), msg)
+    total_errors = len(error_list) # realises lazy list
+    many_errors = total_errors > settings.NUM_SCHEMA_ERRORS
+    for i, error in enumerate(error_list[:settings.NUM_SCHEMA_ERRORS]):
+        _msg, sub_msg_list = format_validation_error(error, schema_file)
+
+        # (error 1/2) ...
+        msg = "(error %s of %s)\n\n%s\n" % (i + 1, total_errors, _msg)
+        if many_errors:
+            # (error 1/10, 190 total)
+            msg = "(error %s of %s, %s total)\n\n%s\n" % (i + 1, settings.NUM_SCHEMA_ERRORS, total_errors, _msg)
 
         # note: sub_msg will be an empty string if no sub-errors exist
         _subs = []
-        for j, sub_msg in enumerate(sub_msg_list):
+        for j, sub_msg in enumerate(sub_msg_list[:settings.NUM_SCHEMA_ERROR_SUBS]):
             # (error 1, possibility 2) ... This: foo ... is not valid because: ...
             _subs.append("(error %s, possibility %s)\n\n%s\n" % (i + 1, j + 1, sub_msg))
         sub_msg = sep.join(_subs)


### PR DESCRIPTION
validation failures with more than N (10) errors are given a slightly different error messages and the output is capped at 10.

same for iterating through individual error possibilities but we don't tweak those messages