### PR TITLE
Feature: forced INGEST requests on v1 articles now sets pubdate

### DIFF
--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -162,10 +162,17 @@ class Ingest(BaseCase):
         self.assertTrue(av.published())
 
         # attempt another ingest
-        expected_title = 'foo'
-        self.ajson['article']['title'] = expected_title
+        attrs = {
+            'title': 'foo',
+            'published': datetime(year=2012, month=2, day=2),
+        }
+        self.ajson['article'].update(attrs)
         av = ajson_ingestor.ingest(self.ajson, force=True)
-        self.assertEqual(av.title, expected_title)
+
+        utils.renkey(attrs, 'published', 'datetime_published')
+
+        for key, expected_val in attrs.items():
+            self.assertEqual(getattr(av, key), expected_val)
 
     @skip("we don't scrape journal data any more. we may in future")
     def test_article_ingest_bad_journal(self):
@@ -625,6 +632,3 @@ class ValidationFailureError(BaseCase):
 
             # the `trace` also contains the full dump of all sub-errors ('possibilities')
             self.assertTrue("(error 3, possibility 7)" in err.trace)
-
-            # print(err.trace)
-            # print(err.message)


### PR DESCRIPTION
This turned out to be less of a bug and more of a deliberate, thoroughly tested design decision. 

The intent was that if you wanted to change the publication date for an already-published article, you would send a forced PUBLISH event for that article. 

Unfortunately this behaviour was forgotten about, including by me, as a forced INGEST ('silent correction') is assumed to update the article data without exception. In the design, this is true, but with the pubdate being the only exception ;)

So for better or worse, this introduces a feature/fixes a bug where silent corrections can alter the publication date.

Caveat: To change the original pubdate of an article the silent correction must be issued for the v1 article.  If the bad date is also present in subsequent versions of the xml, they need silent corrections as well for consistency but are generally not used (but *are* available as the raw unprocessed fragment data sent to lax).