### PR TITLE
Feature: improve identity checks for regular usage of lax

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -1,6 +1,5 @@
 [general]
 debug: True
-env: dev
 secret-key: these-are-dev-settings.DO.NOT.USE.IN.PROD.EVER
 allowed-hosts: localhost
 cache-headers-ttl: 300
@@ -12,7 +11,7 @@ inception: 2012-11-13
 
 [bus]
 name: bus-articles
-env: prod
+env: ci
 region: us-east-1
 subscriber: 1234567890
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -50,13 +50,6 @@ SECRET_KEY = cfg('general.secret-key')
 DEBUG = cfg('general.debug')
 assert isinstance(DEBUG, bool), "'debug' must be either True or False as a boolean, not %r" % (DEBUG, )
 
-DEV, VAGRANT, TEST, PROD = 'dev', 'vagrant', 'test', 'prod'
-ENV = cfg('general.env', DEV)
-
-# temporary until the 'vagrant' env is more formalised
-if os.path.exists('/vagrant'):
-    ENV = VAGRANT
-
 ALLOWED_HOSTS = cfg('general.allowed-hosts', '').split(',')
 
 # Application definition
@@ -318,7 +311,7 @@ LOG_NAME = '%s.log' % PROJECT_NAME # ll: lax.log
 
 INGESTION_LOG_NAME = 'ingestion-%s.log' % PROJECT_NAME
 
-LOG_DIR = PROJECT_DIR if ENV == DEV else '/var/log/'
+LOG_DIR = PROJECT_DIR if DEBUG else '/var/log/'
 LOG_FILE = join(LOG_DIR, LOG_NAME) # ll: /var/log/lax.log
 INGESTION_LOG_FILE = join(LOG_DIR, INGESTION_LOG_NAME) # ll: /var/log/lax.log
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -296,9 +296,11 @@ ENABLE_RELATIONS = True
 # when ingesting an article, if an article says it's related to an article that doesn't exist, should an Article stub be created? default, True.
 RELATED_ARTICLE_STUBS = cfg('general.related-article-stubs', True)
 
+# DEPRECATED: failure to validate article-json should always fail an ingest/publish
 # when ingesting and publishing article-json with the force=True parameter,
 # should validation failures cause the ingest/publish action to fail?
-VALIDATE_FAILS_FORCE = cfg('general.validate-fails-force', True)
+#VALIDATE_FAILS_FORCE = cfg('general.validate-fails-force', True)
+VALIDATE_FAILS_FORCE = True
 
 #
 API_V12_TRANSFORMS = True

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -11,6 +11,6 @@ urlpatterns = [
     url(r'^', include('publisher.urls')),
 ]
 
-if settings.ENV == settings.DEV:
+if settings.DEBUG:
     from django.conf.urls.static import static
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -127,6 +127,9 @@ def extract_snippet(merged_result):
 
 def pre_process(av, result):
     "supplements the merged fragments with more article data required for validating"
+    # we need to inspect this value later in `hashcheck` before it gets nullified
+    result['-published'] = result['published'] # bit of a hack. this value is used later to determine identity
+
     # 'published' is when the v1 article was published
     # if unpublished, this value will be None
     if av.version == 1:
@@ -196,21 +199,59 @@ class Identical(RuntimeError):
         self.av = av
         self.hashval = hashval
 
-# TODO: rename `quiet` to `valid_check` or similar.
-def set_article_json(av, quiet, hash_check=True):
+# TODO: 'quiet' (validation-check), 'hash_check' and 'update_fragment' are all symptoms of spaghetti logic and need to be removed.
+def set_article_json(av, data=None, quiet=True, hash_check=True, update_fragment=True):
     """updates the article with the result of the merge operation.
     if the result of the merge was valid, the merged result will be saved.
-    if invalid, the ArticleVersion instance's article-json will be unset.
-    if invalid and quiet=False, a ValidationError will be raised"""
-    log_context = {'article-version': av, 'quiet': quiet, 'hash_check': hash_check}
-    result = merge_if_valid(av, quiet=quiet)
+    if invalid, a ValidationError will be raised"""
+    log_context = {'article-version': av, 'hash_check': hash_check}
+
+    # todo: only necessary if hashcheck is being done
+    try:
+        # merge -> *merges current fragment set*
+        # adding new fragment data must wait until we have what we need from the old
+        raw_original = merge(av)
+    except StateError:
+        # NO RECORD: nothing has been ingested yet, no previous article data to compare to
+        raw_original = {}
+
+    if data:
+        add(av, models.XML2JSON, data['article'], pos=0, update=update_fragment)
+
+    # merge_if_valid -> merge -> preprocess - *merges current fragment set*
+    # TODO: inline the above and remove those intermediate functions, it's too obfuscated here
+    result = merge_if_valid(av, quiet=quiet) # raises ValidationError
     newhash, oldhash = hash_ajson(result), av.article_json_hash
-    if hash_check and oldhash == newhash:
-        raise Identical("article data is identical to the article data already stored", av, newhash)
+
+    if hash_check:
+        # if old is identical to new, then skip commit and roll the transaction back
+        # backfills (thousands of forced ingest) require skipping when identical
+        # day-to-day INGEST and PUBLISH events require this too. happens on multiple deliveries
+        # silent corrections (forced ingest) where only pubdate has changed now requires this
+
+        if oldhash == newhash:
+            # article data is identical
+            # compare pubdates
+            # `preprocess` will alter the publication date value if it hasn't been published yet
+            oldpubdate = raw_original.get('published')
+            newpubdate = result.get('-published')
+
+            if oldpubdate == newpubdate:
+                raise Identical("article data is identical to the article data already stored", av, newhash)
+
+    # postprocess
+    # result is None when VALIDATE_FAILS_FORCE = False and validation fails
+    # this is some old logic that will be removed in a later PR
+    if result:
+        del result['-published'] # set in preprocess
+
+    # save
     av.article_json_v1 = result
     av.article_json_v1_snippet = extract_snippet(result)
     av.article_json_hash = newhash
     av.save()
+
+    # todo: more bad old logic that silently fails on validation errors. remove.
     if not result:
         msg = "this article failed to merge it's fragments into a valid result. Any article-json previously set for this version of the article has been removed. This article cannot be published in it's current state."
         LOG.critical(msg, extra=log_context)

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -128,7 +128,7 @@ def extract_snippet(merged_result):
 def pre_process(av, result):
     "supplements the merged fragments with more article data required for validating"
     # we need to inspect this value later in `hashcheck` before it gets nullified
-    result['-published'] = result['published'] # bit of a hack. this value is used later to determine identity
+    result['-published'] = result['published']
 
     # 'published' is when the v1 article was published
     # if unpublished, this value will be None

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -196,6 +196,7 @@ def hash_ajson(merge_result):
 class Identical(RuntimeError):
     def __init__(self, msg, av, hashval):
         super(Identical, self).__init__(msg)
+        LOG.info(msg, extra={'hash': hashval, 'msid': av.article.manuscript_id, 'version': av.version})
         self.av = av
         self.hashval = hashval
 

--- a/src/publisher/tests/test_ajson_ingest.py
+++ b/src/publisher/tests/test_ajson_ingest.py
@@ -35,7 +35,7 @@ class IngestIdentical(BaseCase):
         self.assertRaises(fragment_logic.Identical, ajson_ingestor.ingest, self.ajson, force=True)
         self.assertEqual(1, models.ArticleVersion.objects.count())
 
-    @override_settings(DEBUG=False) #
+    @override_settings(DEBUG=False)
     def test_ingest_identical_doesnt_send_event(self):
         "an ingest event that fails because of identical data does not send an aws event"
         with patch('publisher.aws_events.notify') as mock:
@@ -51,9 +51,9 @@ class IngestIdentical(BaseCase):
 
         self.ajson['article']['published'] = '2019-01-01'
 
-        ajson_ingestor.ingest(self.ajson)
+        ajson_ingestor.ingest_publish(self.ajson)
         av = models.ArticleVersion.objects.get(article__manuscript_id=20105)
-        print(av)
+        self.assertEqual(utils.todt('2019-01-01'), av.datetime_published)
 
     # handy test but may not belong in this test suite
 

--- a/src/publisher/tests/test_related_logic.py
+++ b/src/publisher/tests/test_related_logic.py
@@ -259,7 +259,7 @@ class RelationList(base.BaseCase):
             (self.msid3, [self.msid1, self.msid2]), # 3 => [1, 2]
         ]
 
-        relation_logic._print_relations()
+        #relation_logic._print_relations()
 
         for msid, expected_relations in expected_relationships:
             av = models.Article.objects.get(manuscript_id=msid).latest_version


### PR DESCRIPTION
* removes the mess of unused 'ENV'ironments
* shifts the saving of the new fragment data into `set_article_json` so it has access to the current data (if any) so the identity check can take into account pubdates
* deprecates use of `VALIDATE_FAILS_FORCE`, which, if `False` (default True) will save an empty string as an article's ajson
