### PR TITLE
bumps django to 1.11.20 after 1.11.19 release went missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astroid==1.6.5
 autopep8==1.4
 boto3==1.9.18
 coverage==4.5.1
-Django==1.11.19
+Django==1.11.20
 django-admin-view-permission==1.8
 django-annoying==0.10.4
 django-autoslug==1.9.3


### PR DESCRIPTION
related to https://github.com/elifesciences/lax/pull/425

this is a bit of a weird one, a package on pypi has been removed

cc @giorgiosironi