### PR TITLE
Fix: disabled black on all but python3.6 installations

### DIFF
--- a/.scrub.sh
+++ b/.scrub.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 # scrub.sh uses the autopep8 tool to clean up whitespace and other small bits
 
-black src/ --target-version py34
+if [ -e venv/bin/python3.6 ]; then
+    black src/ --target-version py34
+else
+    # seeing this on new 16.04 lax instances
+    echo "black requires Python 3.6+"
+fi


### PR DESCRIPTION
cc @giorgiosironi 

it's interfering with testing lax formula on 16.04