### PR TITLE
Fix: bumps psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ mock==2.0.0
 netaddr==0.7.19
 ordered-set==3.0.2
 prospector==1.1.3
-psycopg2==2.7.5
+psycopg2==2.8.3
 pyflakes==2.0.0
 pylint==1.9.3
 pylint-django==0.11.1


### PR DESCRIPTION
it's mysteriously segfaulting on new instances:
https://github.com/elifesciences/lax-formula/pull/36

possibly caused by an upgrade to libpq ...?

fyi @giorgiosironi 