### PR TITLE
removes swagger, the api gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ the [Django web framework](https://www.djangoproject.com/) and a
 
 Documentation can be found here:
 
+* [API GUI](https://api.elifesciences.org/documentation/#articles)
 * [code](https://github.com/elifesciences/lax/blob/master/src/publisher/api.py)
-* [Swagger](https://lax.elifesciences.org/api/docs/) (or your [local version](/api/docs/))
 
 For example, the [Homo Naledi](http://elifesciences.org/content/4/e09560) article:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ django-autoslug==1.9.6
 django-db-logger==0.1.8rc1
 django-filter==2.2.0
 django-markdown2==0.3.1
-django-rest-swagger==2.2.0
 django-sql-explorer==1.1.3
 django-tqdm==1.0.0
 djangorestframework==3.11.0

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -78,7 +78,6 @@ INSTALLED_APPS = (
     "explorer",  # sql creation
     # 'django_db_logger', # logs certain entries to the database
     "rest_framework",
-    "rest_framework_swagger",  # gui for api
     "reports",  # necessary for management commands
     "publisher",
 )
@@ -214,12 +213,6 @@ REST_FRAMEWORK = {
     # )
 }
 
-SWAGGER_SETTINGS = {
-    "api_version": "1",
-    "exclude_namespaces": [
-        "proxied"
-    ],  # swagger docs are broken, but this gives them the right namespace
-}
 
 #
 # sql explorer

--- a/src/publisher/urls.py
+++ b/src/publisher/urls.py
@@ -1,9 +1,7 @@
 from django.conf.urls import include, url
 from . import views, rss
-from rest_framework_swagger.views import get_swagger_view
 
 urlpatterns = [
-    url(r"^api/docs/", get_swagger_view(title="Article Store API")),
     url(r"^api/v2/", include("publisher.api_v2_urls", namespace="v2")),
     url(r"^rss/articles/", include(rss.urlpatterns)),
     url(r"^$", views.landing, name="pub-landing"),


### PR DESCRIPTION
Got a 500 error today from someone accessing https://prod--lax.elifesciences.org/api/docs

It used to work, but as different requirements got upgraded and others got left behind, it must have stopped working at some point.

It's inclusion is unnecessary and the 'proper' api docs are available at https://api.elifesciences.org/documentation

fyi @NuclearRedeye 