### PR TITLE
foreign fragment merging

### DIFF
--- a/elife.cfg
+++ b/elife.cfg
@@ -4,7 +4,7 @@ secret-key: these-are-dev-settings.DO.NOT.USE.IN.PROD.EVER
 allowed-hosts: localhost
 cache-headers-ttl: 300
 reporting-bucket: 
-merge-foreign-fragments: true
+merge-foreign-fragments: True
 
 [journal]
 name: eLife

--- a/elife.cfg
+++ b/elife.cfg
@@ -4,6 +4,7 @@ secret-key: these-are-dev-settings.DO.NOT.USE.IN.PROD.EVER
 allowed-hosts: localhost
 cache-headers-ttl: 300
 reporting-bucket: 
+merge-foreign-fragments: true
 
 [journal]
 name: eLife

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -293,8 +293,7 @@ RELATED_ARTICLE_STUBS = cfg("general.related-article-stubs", True)
 VALIDATE_FAILS_FORCE = True
 
 # allow fragments pushed in from other sources?
-# todo: read from app.cfg
-MERGE_FOREIGN_FRAGMENTS = True
+MERGE_FOREIGN_FRAGMENTS = cfg("general.merge-foreign-fragments", True)
 
 #
 # logging

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -292,6 +292,10 @@ RELATED_ARTICLE_STUBS = cfg("general.related-article-stubs", True)
 # VALIDATE_FAILS_FORCE = cfg('general.validate-fails-force', True)
 VALIDATE_FAILS_FORCE = True
 
+# allow fragments pushed in from other sources?
+# todo: read from app.cfg
+MERGE_FOREIGN_FRAGMENTS = True
+
 #
 # logging
 #

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -372,8 +372,19 @@ def delete_fragment_update_article(art, key):
         # notify event bus that article change has occurred
         transaction.on_commit(partial(aws_events.notify, art.manuscript_id))
 
-        # hash check disabled. if removing fragment doesn't alter final article, then fragment should still be removed
+        # `hash_check=False`: if removing fragment doesn't alter final article, then fragment should still be removed
         return set_all_article_json(art, quiet=False, hash_check=False)
+
+def reset_merged_fragments(art):
+    """re-merges and re-sets article-json for given `art` object.
+    Added 2021-01-21 to fix valid article-json that yielded invalid article-json snippets."""
+    with transaction.atomic():
+        # notify event bus that article change has occurred
+        transaction.on_commit(partial(aws_events.notify, art.manuscript_id))
+
+        # `hash_check=False`: if removing fragment doesn't alter final article, then fragment should still be removed
+        return set_all_article_json(art, quiet=False, hash_check=False)
+
 
 #
 #

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -383,7 +383,7 @@ def reset_merged_fragments(art):
         # notify event bus that article change has occurred
         transaction.on_commit(partial(aws_events.notify, art.manuscript_id))
 
-        # `hash_check=False`: if removing fragment doesn't alter final article, then fragment should still be removed
+        # `hash_check=False`: reset merged fragments regardless of whether final article-json is changed
         return set_all_article_json(art, quiet=False, hash_check=False)
 
 

--- a/src/publisher/fragment_logic.py
+++ b/src/publisher/fragment_logic.py
@@ -375,6 +375,7 @@ def delete_fragment_update_article(art, key):
         # `hash_check=False`: if removing fragment doesn't alter final article, then fragment should still be removed
         return set_all_article_json(art, quiet=False, hash_check=False)
 
+
 def reset_merged_fragments(art):
     """re-merges and re-sets article-json for given `art` object.
     Added 2021-01-21 to fix valid article-json that yielded invalid article-json snippets."""

--- a/src/publisher/tests/test_fragment_logic.py
+++ b/src/publisher/tests/test_fragment_logic.py
@@ -264,20 +264,23 @@ class FragmentMerge(base.BaseCase):
         logic.add(self.msid, "frag3", {"foot": "baz"})
 
         result = logic.merge(self.av)
-        self.assertEqual("foo", result['title'])
-        self.assertEqual("bar", result['body'])
-        self.assertEqual("baz", result['foot'])
+        self.assertEqual("foo", result["title"])
+        self.assertEqual("bar", result["body"])
+        self.assertEqual("baz", result["foot"])
 
         # just to ensure we're dealing with a whole article fixture
-        self.assertEqual("published", result['stage'])
+        self.assertEqual("published", result["stage"])
 
-        with patch('publisher.fragment_logic.settings.MERGE_FOREIGN_FRAGMENTS', False):
+        with patch("publisher.fragment_logic.settings.MERGE_FOREIGN_FRAGMENTS", False):
             logic.reset_merged_fragments(self.av.article)
             result = logic.merge(self.av)
-            self.assertEqual("A Cryptochrome 2 Mutation Yields Advanced Sleep Phase in Human", result['title'])
+            self.assertEqual(
+                "A Cryptochrome 2 Mutation Yields Advanced Sleep Phase in Human",
+                result["title"],
+            )
             self.assertFalse("bar" in result)
             self.assertFalse("baz" in result)
-            self.assertEqual("published", result['stage'])
+            self.assertEqual("published", result["stage"])
 
 
 """

--- a/src/publisher/tests/test_fragment_logic.py
+++ b/src/publisher/tests/test_fragment_logic.py
@@ -259,6 +259,7 @@ class FragmentMerge(base.BaseCase):
         self.assertEqual(expected, logic.merge(self.av))
 
     def test_reset_merged_fragments(self):
+        "article-json can be reset, ignoring any foreign (unknown) fragment types."
         logic.add(self.msid, "frag1", {"title": "foo"})
         logic.add(self.msid, "frag2", {"body": "bar"})
         logic.add(self.msid, "frag3", {"foot": "baz"})


### PR DESCRIPTION
* adds ability to disable 'foreign' fragment merging

- [x] non-lax fragment merging can be turned off
- [x] configurable from app.cfg, default to allow merging (existing behaviour)
- [x] function to re-set an article's json and snippet