### PR TITLE
Try ping in smoke tests before articles endpoint.

### DIFF
--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 set -ex
 
-for path in / /api/v2/ping /api/v2/articles; do
-    [ $(curl --write-out %{http_code} --silent --output /dev/null https://$(hostname)$path) == 200 ]
+num_attempts=3
+retry_delay=5 # seconds
+
+for path in / /api/v2/articles; do
+    [ $(curl --retry $num_attempts --retry-delay $retry_delay --write-out %{http_code} --silent --output /dev/null https://$(hostname)$path) == 200 ]
 done
 
 for path in /admin /explorer; do
-    [ $(curl --write-out %{http_code} --silent --output /dev/null https://$(hostname)$path) == 301 ]
+    [ $(curl --retry $num_attempts --retry-delay $retry_delay --write-out %{http_code} --silent --output /dev/null https://$(hostname)$path) == 301 ]
 done
+
 
 # api-raml version must be identical for lax and bot-lax-adaptor
 diff /opt/bot-lax-adaptor/api-raml.sha1 api-raml.sha1

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-for path in / /api/v2/articles; do
+for path in / /api/v2/ping /api/v2/articles; do
     [ $(curl --write-out %{http_code} --silent --output /dev/null https://$(hostname)$path) == 200 ]
 done
 


### PR DESCRIPTION
A theory if we try the ping endpoint in smoke tests prior to trying to get the article list it may be easier to determine when a `502` Bad Gateway response is returned in a test pipeline after the entire stack has been restarted.