### PR TITLE
api, article-version-history date fixes

### DIFF
--- a/src/publisher/logic.py
+++ b/src/publisher/logic.py
@@ -20,8 +20,8 @@ def qdebug(f):
         result = f(*args, **kwargs)
         qt = [(float(query["time"]) * 1000) for query in connection.queries]
 
-        [print(q['sql']) for q  in connection.queries]
-        
+        [print(q["sql"]) for q in connection.queries]
+
         print("%s queries" % len(qt))
         print("%s ms" % sum(qt))
         print()
@@ -39,7 +39,8 @@ def dictfetchall(cursor):
     columns = [col[0] for col in cursor.description]
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
-@qdebug
+
+# @qdebug
 def execute_sql(filename, params):
     with connection.cursor() as cursor:
         cursor.execute(settings.SQL_MAP[filename], params)
@@ -375,12 +376,12 @@ def article_version_history__v1(msid, only_published=True):
     if article.type in EXCLUDE_RECEIVED_ACCEPTED_DATES:
         struct = exsubdict(struct, ["received", "accepted"])
     else:
-        if not struct['received']:
-            del struct['received']
+        if not struct["received"]:
+            del struct["received"]
 
-        if not struct['accepted']
-            del struct['accepted']
-        
+        if not struct["accepted"]:
+            del struct["accepted"]
+
     return struct
 
 
@@ -430,11 +431,11 @@ def article_version_history__v2(msid, only_published=True):
     if article.type in EXCLUDE_RECEIVED_ACCEPTED_DATES:
         struct = exsubdict(struct, ["received", "accepted"])
     else:
-        if not struct['received']:
-            del struct['received']
+        if not struct["received"]:
+            del struct["received"]
 
-        if not struct['accepted']
-            del struct['accepted']
+        if not struct["accepted"]:
+            del struct["accepted"]
 
     sent_for_peer_review_event = [
         ae for ae in article_event_list if ae.event == models.DATE_SENT_FOR_PEER_REVIEW


### PR DESCRIPTION
api, article-version-history, fixes case where 'received' and 'accept…ed' dates may be None,
which serialise to 'null' in json. These should be omitted.